### PR TITLE
Basic command/function completion

### DIFF
--- a/cmd/dlv/main.go
+++ b/cmd/dlv/main.go
@@ -13,15 +13,11 @@ import (
 	"syscall"
 
 	"github.com/derekparker/delve/command"
-	"github.com/derekparker/delve/goreadline"
 	"github.com/derekparker/delve/proctl"
+	"golang.org/x/crypto/ssh/terminal"
 )
 
 const version string = "0.1.3.beta"
-
-type term struct {
-	stdin *bufio.Reader
-}
 
 const historyFile string = ".dbg_history"
 
@@ -37,7 +33,6 @@ func main() {
 		printv  bool
 		err     error
 		dbgproc *proctl.DebuggedProcess
-		t       = newTerm()
 		cmds    = command.DebugCommands()
 	)
 
@@ -82,7 +77,13 @@ func main() {
 		}
 	}
 
-	goreadline.LoadHistoryFromFile(historyFile)
+	t := newTerm()
+	if t.term != nil {
+		completer := &autoCompletion{proc: dbgproc, cmds: command.DebugCommands()}
+		t.term.AutoCompleteCallback = completer.complete
+	}
+	defer t.Restore()
+
 	fmt.Println("Type 'help' for list of commands.")
 
 	for {
@@ -108,13 +109,11 @@ func main() {
 	}
 }
 func handleExit(t *term, dbp *proctl.DebuggedProcess, status int) {
-	errno := goreadline.WriteHistoryToFile(historyFile)
-	fmt.Println("readline:", errno)
-
-	fmt.Println("Would you like to kill the process? [y/n]")
+	t.Restore()
+	fmt.Println("\nWould you like to kill the process? [y/n]")
 	answer, err := t.stdin.ReadString('\n')
 	if err != nil {
-		die(2, err.Error())
+		die(2, err)
 	}
 
 	for pc := range dbp.BreakPoints {
@@ -147,10 +146,26 @@ func die(status int, args ...interface{}) {
 	os.Exit(status)
 }
 
+type term struct {
+	stdin    *bufio.Reader
+	term     *terminal.Terminal
+	oldState *terminal.State
+}
+
 func newTerm() *term {
-	return &term{
-		stdin: bufio.NewReader(os.Stdin),
+	t := term{stdin: bufio.NewReader(os.Stdin)}
+	fd := int(os.Stdin.Fd())
+	if terminal.IsTerminal(fd) {
+		if state, err := terminal.MakeRaw(fd); err != nil {
+			fmt.Fprintf(os.Stderr, "Error initializing terminal: %s\n", err)
+		} else {
+			t.term = terminal.NewTerminal(os.Stdin, "dlv> ")
+			t.oldState = state
+		}
+	} else {
+		fmt.Fprintln(os.Stderr, "Warning stdin is not a terminal")
 	}
+	return &t
 }
 
 func parseCommand(cmdstr string) (string, []string) {
@@ -159,15 +174,84 @@ func parseCommand(cmdstr string) (string, []string) {
 }
 
 func (t *term) promptForInput() (string, error) {
-	prompt := "dlv> "
-	linep := goreadline.ReadLine(&prompt)
-	if linep == nil {
-		return "", io.EOF
+	if t.term == nil {
+		fmt.Print("dlv> ")
+		line, err := t.stdin.ReadString('\n')
+		if err != nil {
+			return "", err
+		}
+		return strings.TrimSuffix(line, "\n"), nil
+	} else {
+		return t.term.ReadLine()
 	}
-	line := strings.TrimSuffix(*linep, "\n")
-	if line != "" {
-		goreadline.AddHistory(line)
+}
+
+func (t *term) Restore() {
+	if t.term != nil {
+		terminal.Restore(int(os.Stdin.Fd()), t.oldState)
+	}
+}
+
+type autoCompletion struct {
+	proc       *proctl.DebuggedProcess
+	cmds       *command.Commands
+	lastKey    rune
+	candidates []string
+	index      int
+}
+
+func (a *autoCompletion) complete(line string, pos int, key rune) (newLine string, newPos int, ok bool) {
+
+	if key != '\t' {
+		a.lastKey = key
+		return "", -1, false
 	}
 
-	return line, nil
+	prefix := line[:pos]
+	if a.lastKey != '\t' {
+		// first completion with this prefix
+		a.index = 0
+
+		space := strings.Index(prefix, " ")
+		if space == -1 {
+			// complete command names
+			a.candidates = a.cmds.FindPrefix(prefix)
+		} else {
+			var candidates []string
+			cmd := prefix[:space]
+
+			for space < len(prefix) && prefix[space] == ' ' {
+				space += 1
+			}
+			arg := prefix[space:]
+
+			switch cmd {
+			case "clear":
+				for _, bp := range a.proc.BreakPoints {
+					if strings.HasPrefix(bp.FunctionName, arg) {
+						candidates = append(candidates, cmd+" "+bp.FunctionName)
+					}
+				}
+			case "break":
+				for _, fn := range a.proc.GoSymTable.Funcs {
+					if strings.Contains(fn.Sym.Name, arg) {
+						candidates = append(candidates, cmd+" "+fn.Sym.Name)
+					}
+				}
+			}
+
+			a.candidates = candidates
+		}
+	} else {
+		// cycle through candidates with old prefix
+		a.index += 1
+	}
+	a.lastKey = key
+
+	if len(a.candidates) == 0 {
+		return "", -1, false
+	}
+
+	comp := a.candidates[a.index%len(a.candidates)]
+	return comp + line[pos:], len(comp), true
 }

--- a/command/command.go
+++ b/command/command.go
@@ -92,6 +92,16 @@ func (c *Commands) Find(cmdstr string) cmdfunc {
 
 	return noCmdAvailable
 }
+// FindPrefix returns a slice of command names with the given prefix.
+func (c *Commands) FindPrefix(prefix string) []string {
+	var matches  []string
+	for _, cmd := range c.cmds {
+		if strings.HasPrefix(cmd.aliases[0], prefix) {
+			matches = append(matches, cmd.aliases[0])
+		}
+	}
+	return matches
+}
 
 func CommandFunc(fn func() error) cmdfunc {
 	return func(p *proctl.DebuggedProcess, args ...string) error {


### PR DESCRIPTION
This is more of a RFC/experiment and probably a bit rough around the edges. It
switches from the goreadline binding to golang.org/x/crypto/ssh/terminal for
terminal handling and implements basic command and function name completion
(for `clear` and `break`).
