### PR TITLE
Breakpoints now have ids. Consolidated location lookup logic

### DIFF
--- a/command/command.go
+++ b/command/command.go
@@ -4,14 +4,11 @@ package command
 
 import (
 	"bufio"
-	"debug/gosym"
 	"fmt"
 	"io"
 	"os"
-	"path/filepath"
 	"regexp"
 	"sort"
-	"strconv"
 	"strings"
 
 	"github.com/derekparker/delve/proctl"
@@ -158,44 +155,12 @@ func clear(p *proctl.DebuggedProcess, args ...string) error {
 		return fmt.Errorf("not enough arguments")
 	}
 
-	var (
-		fn    *gosym.Func
-		pc    uint64
-		fname = args[0]
-	)
-
-	if strings.ContainsRune(fname, ':') {
-		fl := strings.Split(fname, ":")
-
-		f, err := filepath.Abs(fl[0])
-		if err != nil {
-			return err
-		}
-
-		l, err := strconv.Atoi(fl[1])
-		if err != nil {
-			return err
-		}
-
-		pc, fn, err = p.GoSymTable.LineToPC(f, l)
-		if err != nil {
-			return err
-		}
-	} else {
-		fn = p.GoSymTable.LookupFunc(fname)
-		if fn == nil {
-			return fmt.Errorf("No function named %s", fname)
-		}
-
-		pc = fn.Entry
-	}
-
-	bp, err := p.Clear(pc)
+	bp, err := p.ClearByLocation(args[0])
 	if err != nil {
 		return err
 	}
 
-	fmt.Printf("Breakpoint cleared at %#v for %s %s:%d\n", bp.Addr, bp.FunctionName, bp.File, bp.Line)
+	fmt.Printf("Breakpoint %d cleared at %#v for %s %s:%d\n", bp.ID, bp.Addr, bp.FunctionName, bp.File, bp.Line)
 
 	return nil
 }
@@ -205,44 +170,12 @@ func breakpoint(p *proctl.DebuggedProcess, args ...string) error {
 		return fmt.Errorf("not enough arguments")
 	}
 
-	var (
-		fn    *gosym.Func
-		pc    uint64
-		fname = args[0]
-	)
-
-	if strings.ContainsRune(fname, ':') {
-		fl := strings.Split(fname, ":")
-
-		f, err := filepath.Abs(fl[0])
-		if err != nil {
-			return err
-		}
-
-		l, err := strconv.Atoi(fl[1])
-		if err != nil {
-			return err
-		}
-
-		pc, fn, err = p.GoSymTable.LineToPC(f, l)
-		if err != nil {
-			return err
-		}
-	} else {
-		fn = p.GoSymTable.LookupFunc(fname)
-		if fn == nil {
-			return fmt.Errorf("No function named %s", fname)
-		}
-
-		pc = fn.Entry
-	}
-
-	bp, err := p.Break(uintptr(pc))
+	bp, err := p.BreakByLocation(args[0])
 	if err != nil {
 		return err
 	}
 
-	fmt.Printf("Breakpoint set at %#v for %s %s:%d\n", bp.Addr, bp.FunctionName, bp.File, bp.Line)
+	fmt.Printf("Breakpoint %d set at %#v for %s %s:%d\n", bp.ID, bp.Addr, bp.FunctionName, bp.File, bp.Line)
 
 	return nil
 }

--- a/proctl/proctl_test.go
+++ b/proctl/proctl_test.go
@@ -74,7 +74,7 @@ func TestStep(t *testing.T) {
 		helloworldfunc := p.GoSymTable.LookupFunc("main.helloworld")
 		helloworldaddr := helloworldfunc.Entry
 
-		_, err := p.Break(uintptr(helloworldaddr))
+		_, err := p.Break(helloworldaddr)
 		assertNoError(err, t, "Break()")
 		assertNoError(p.Continue(), t, "Continue()")
 
@@ -111,7 +111,7 @@ func TestBreakPoint(t *testing.T) {
 		sleepytimefunc := p.GoSymTable.LookupFunc("main.helloworld")
 		sleepyaddr := sleepytimefunc.Entry
 
-		bp, err := p.Break(uintptr(sleepyaddr))
+		bp, err := p.Break(sleepyaddr)
 		assertNoError(err, t, "Break()")
 
 		breakpc := bp.Addr + 1
@@ -149,7 +149,7 @@ func TestBreakPointInSeperateGoRoutine(t *testing.T) {
 			t.Fatal("No fn exists")
 		}
 
-		_, err := p.Break(uintptr(fn.Entry))
+		_, err := p.Break(fn.Entry)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -173,7 +173,7 @@ func TestBreakPointInSeperateGoRoutine(t *testing.T) {
 
 func TestBreakPointWithNonExistantFunction(t *testing.T) {
 	withTestProcess("../_fixtures/testprog", t, func(p *DebuggedProcess) {
-		_, err := p.Break(uintptr(0))
+		_, err := p.Break(0)
 		if err == nil {
 			t.Fatal("Should not be able to break at non existant function")
 		}
@@ -183,7 +183,7 @@ func TestBreakPointWithNonExistantFunction(t *testing.T) {
 func TestClearBreakPoint(t *testing.T) {
 	withTestProcess("../_fixtures/testprog", t, func(p *DebuggedProcess) {
 		fn := p.GoSymTable.LookupFunc("main.sleepytime")
-		bp, err := p.Break(uintptr(fn.Entry))
+		bp, err := p.Break(fn.Entry)
 		assertNoError(err, t, "Break()")
 
 		int3, err := dataAtAddr(p.Pid, bp.Addr)
@@ -245,7 +245,7 @@ func TestNext(t *testing.T) {
 
 	withTestProcess(executablePath, t, func(p *DebuggedProcess) {
 		pc, _, _ := p.GoSymTable.LineToPC(fp, testcases[0].begin)
-		_, err := p.Break(uintptr(pc))
+		_, err := p.Break(pc)
 		assertNoError(err, t, "Break()")
 		assertNoError(p.Continue(), t, "Continue()")
 
@@ -284,7 +284,7 @@ func TestFindReturnAddress(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		_, err = p.Break(uintptr(start))
+		_, err = p.Break(start)
 		if err != nil {
 			t.Fatal(err)
 		}

--- a/proctl/variables_test.go
+++ b/proctl/variables_test.go
@@ -56,7 +56,7 @@ func TestVariableEvaluation(t *testing.T) {
 	withTestProcess(executablePath, t, func(p *DebuggedProcess) {
 		pc, _, _ := p.GoSymTable.LineToPC(fp, 37)
 
-		_, err := p.Break(uintptr(pc))
+		_, err := p.Break(pc)
 		assertNoError(err, t, "Break() returned an error")
 
 		err = p.Continue()
@@ -81,7 +81,7 @@ func TestVariableFunctionScoping(t *testing.T) {
 	withTestProcess(executablePath, t, func(p *DebuggedProcess) {
 		pc, _, _ := p.GoSymTable.LineToPC(fp, 37)
 
-		_, err := p.Break(uintptr(pc))
+		_, err := p.Break(pc)
 		assertNoError(err, t, "Break() returned an error")
 
 		err = p.Continue()
@@ -96,7 +96,7 @@ func TestVariableFunctionScoping(t *testing.T) {
 		// Move scopes, a1 exists here by a2 does not
 		pc, _, _ = p.GoSymTable.LineToPC(fp, 18)
 
-		_, err = p.Break(uintptr(pc))
+		_, err = p.Break(pc)
 		assertNoError(err, t, "Break() returned an error")
 
 		err = p.Continue()
@@ -164,7 +164,7 @@ func TestLocalVariables(t *testing.T) {
 	withTestProcess(executablePath, t, func(p *DebuggedProcess) {
 		pc, _, _ := p.GoSymTable.LineToPC(fp, 37)
 
-		_, err := p.Break(uintptr(pc))
+		_, err := p.Break(pc)
 		assertNoError(err, t, "Break() returned an error")
 
 		err = p.Continue()


### PR DESCRIPTION
- Gave breakpoints a monotonically increasing id (similar to gdb) for easier manipulation. 
- Centralized looking up address by location (file+line, function) to DebuggedProcess.FindLocation
- FindLocation supports arbitrary addresses and breakpoint ids
- Added BreakByLocation and ClearByLocation to DebuggedProcess and changed the commands to call them instead.
- BreakByLocation can now also use an address `b 0x400d60` will work
- ClearByLocation can take a breakpoint id or address (as well as the existing file + line and function)
