### PR TITLE
Add process control for Linux x86

### DIFF
--- a/proctl/proctl_linux_x86.go
+++ b/proctl/proctl_linux_x86.go
@@ -1,0 +1,1 @@
+proctl_linux_amd64.go

--- a/proctl/threads_linux_x86.go
+++ b/proctl/threads_linux_x86.go
@@ -1,0 +1,37 @@
+package proctl
+
+import "syscall"
+
+type Regs struct {
+	regs *syscall.PtraceRegs
+}
+
+func (r *Regs) PC() uint64 {
+	return r.regs.PC()
+}
+
+func (r *Regs) SP() uint64 {
+	return uint64(r.regs.Esp)
+}
+
+func (r *Regs) SetPC(tid int, pc uint64) error {
+	r.regs.SetPC(pc)
+	return syscall.PtraceSetRegs(tid, r.regs)
+}
+
+func registers(tid int) (Registers, error) {
+	var regs syscall.PtraceRegs
+	err := syscall.PtraceGetRegs(tid, &regs)
+	if err != nil {
+		return nil, err
+	}
+	return &Regs{&regs}, nil
+}
+
+func writeMemory(tid int, addr uintptr, data []byte) (int, error) {
+	return syscall.PtracePokeData(tid, addr, data)
+}
+
+func readMemory(tid int, addr uintptr, data []byte) (int, error) {
+	return syscall.PtracePeekData(tid, addr, data)
+}


### PR DESCRIPTION
Hi Derek,

I need to run Delve under Linux x86 (32 bit). So I just made very little change to you code. I jusr create a symlink proctl_linux_x86.go -> proctl_linux_amd64.go and copy threads_linux_amd64.go to threads_linux_x86.go. In the last file I only chenge the name of the register. I know that this is just a dirty fix but it works.

Sincerly
Massimo