### PR TITLE
Better handling of arrays and slices

### DIFF
--- a/_fixtures/testvariables.go
+++ b/_fixtures/testvariables.go
@@ -30,14 +30,21 @@ func foobar(baz string, bar FooBar) {
 		a8  = FooBar2{Bur: 10, Baz: "feh"}
 		a9  = (*FooBar)(nil)
 		a10 = a1[2:5]
+		b1  = true
+		b2  = false
 		neg = -1
 		i8  = int8(1)
+		u8  = uint8(255)
+		u16 = uint16(65535)
+		u32 = uint32(4294967295)
+		u64 = uint64(18446744073709551615)
+		up  = uintptr(5)
 		f32 = float32(1.2)
 		i32 = [2]int32{1, 2}
 	)
 
 	barfoo()
-	fmt.Println(a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, baz, neg, i8, f32, i32, bar)
+	fmt.Println(a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, b1, b2, baz, neg, i8, u8, u16, u32, u64, up, f32, i32, bar)
 }
 
 func main() {

--- a/_fixtures/testvariables.go
+++ b/_fixtures/testvariables.go
@@ -31,6 +31,8 @@ func foobar(baz string, bar FooBar) {
 		a9  = (*FooBar)(nil)
 		a10 = a1[2:5]
 		a11 = [3]FooBar{{1, "a"}, {2, "b"}, {3, "c"}}
+		a12 = []FooBar{{4, "d"}, {5, "e"}}
+		a13 = []*FooBar{{6, "f"}, {7, "g"}, {8, "h"}}
 		b1  = true
 		b2  = false
 		neg = -1
@@ -46,7 +48,7 @@ func foobar(baz string, bar FooBar) {
 	)
 
 	barfoo()
-	fmt.Println(a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, b1, b2, baz, neg, i8, u8, u16, u32, u64, up, f32, i32, bar, f)
+	fmt.Println(a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, b1, b2, baz, neg, i8, u8, u16, u32, u64, up, f32, i32, bar, f)
 }
 
 func main() {

--- a/_fixtures/testvariables.go
+++ b/_fixtures/testvariables.go
@@ -41,10 +41,11 @@ func foobar(baz string, bar FooBar) {
 		up  = uintptr(5)
 		f32 = float32(1.2)
 		i32 = [2]int32{1, 2}
+		f   = barfoo
 	)
 
 	barfoo()
-	fmt.Println(a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, b1, b2, baz, neg, i8, u8, u16, u32, u64, up, f32, i32, bar)
+	fmt.Println(a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, b1, b2, baz, neg, i8, u8, u16, u32, u64, up, f32, i32, bar, f)
 }
 
 func main() {

--- a/_fixtures/testvariables.go
+++ b/_fixtures/testvariables.go
@@ -30,6 +30,7 @@ func foobar(baz string, bar FooBar) {
 		a8  = FooBar2{Bur: 10, Baz: "feh"}
 		a9  = (*FooBar)(nil)
 		a10 = a1[2:5]
+		a11 = [3]FooBar{{1, "a"}, {2, "b"}, {3, "c"}}
 		b1  = true
 		b2  = false
 		neg = -1
@@ -45,7 +46,7 @@ func foobar(baz string, bar FooBar) {
 	)
 
 	barfoo()
-	fmt.Println(a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, b1, b2, baz, neg, i8, u8, u16, u32, u64, up, f32, i32, bar, f)
+	fmt.Println(a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, b1, b2, baz, neg, i8, u8, u16, u32, u64, up, f32, i32, bar, f)
 }
 
 func main() {

--- a/proctl/variables.go
+++ b/proctl/variables.go
@@ -616,8 +616,12 @@ func (thread *ThreadContext) extractValue(instructions []byte, addr int64, typ i
 		return thread.readIntArray(ptraddress, t)
 	case *dwarf.IntType:
 		return thread.readInt(ptraddress, t.ByteSize)
+	case *dwarf.UintType:
+		return thread.readUint(ptraddress, t.ByteSize)
 	case *dwarf.FloatType:
 		return thread.readFloat(ptraddress, t.ByteSize)
+	case *dwarf.BoolType:
+		return thread.readBool(ptraddress)
 	}
 
 	return "", fmt.Errorf("could not find value for type %s", typ)
@@ -693,7 +697,7 @@ func (thread *ThreadContext) readIntArray(addr uintptr, t *dwarf.ArrayType) (str
 }
 
 func (thread *ThreadContext) readInt(addr uintptr, size int64) (string, error) {
-	var n int
+	var n int64
 
 	val, err := thread.readMemory(addr, uintptr(size))
 	if err != nil {
@@ -702,16 +706,38 @@ func (thread *ThreadContext) readInt(addr uintptr, size int64) (string, error) {
 
 	switch size {
 	case 1:
-		n = int(val[0])
+		n = int64(val[0])
 	case 2:
-		n = int(binary.LittleEndian.Uint16(val))
+		n = int64(binary.LittleEndian.Uint16(val))
 	case 4:
-		n = int(binary.LittleEndian.Uint32(val))
+		n = int64(binary.LittleEndian.Uint32(val))
 	case 8:
-		n = int(binary.LittleEndian.Uint64(val))
+		n = int64(binary.LittleEndian.Uint64(val))
 	}
 
-	return strconv.Itoa(n), nil
+	return strconv.FormatInt(n, 10), nil
+}
+
+func (thread *ThreadContext) readUint(addr uintptr, size int64) (string, error) {
+	var n uint64
+
+	val, err := thread.readMemory(addr, uintptr(size))
+	if err != nil {
+		return "", err
+	}
+
+	switch size {
+	case 1:
+		n = uint64(val[0])
+	case 2:
+		n = uint64(binary.LittleEndian.Uint16(val))
+	case 4:
+		n = uint64(binary.LittleEndian.Uint32(val))
+	case 8:
+		n = uint64(binary.LittleEndian.Uint64(val))
+	}
+
+	return strconv.FormatUint(n, 10), nil
 }
 
 func (thread *ThreadContext) readFloat(addr uintptr, size int64) (string, error) {
@@ -733,6 +759,19 @@ func (thread *ThreadContext) readFloat(addr uintptr, size int64) (string, error)
 	}
 
 	return "", fmt.Errorf("could not read float")
+}
+
+func (thread *ThreadContext) readBool(addr uintptr) (string, error) {
+	val, err := thread.readMemory(addr, uintptr(1))
+	if err != nil {
+		return "", err
+	}
+
+	if val[0] == 0 {
+		return "false", nil
+	}
+
+	return "true", nil
 }
 
 func (thread *ThreadContext) readMemory(addr uintptr, size uintptr) ([]byte, error) {
@@ -770,7 +809,8 @@ func (thread *ThreadContext) variablesByTag(tag dwarf.Tag) ([]*Variable, error) 
 		if entry.Tag == tag {
 			val, err := thread.extractVariableFromEntry(entry)
 			if err != nil {
-				return nil, err
+				// skip variables that we can't parse yet
+				continue
 			}
 
 			vars = append(vars, val)

--- a/proctl/variables_test.go
+++ b/proctl/variables_test.go
@@ -49,7 +49,6 @@ func TestVariableEvaluation(t *testing.T) {
 		{"a9", "*main.FooBar nil", "*main.FooBar", nil},
 		{"baz", "bazburzum", "struct string", nil},
 		{"neg", "-1", "int", nil},
-		{"i8", "1", "int8", nil},
 		{"f32", "1.2", "float32", nil},
 		{"a6.Baz", "8", "int", nil},
 		{"a7.Baz", "5", "int", nil},
@@ -58,11 +57,18 @@ func TestVariableEvaluation(t *testing.T) {
 		{"a9.NonExistent", "nil", "int", errors.New("a9 has no member NonExistent")},
 		{"a8", "main.FooBar2 {Bur: 10, Baz: feh}", "main.FooBar2", nil}, // reread variable after member
 		{"i32", "[2]int32 [1 2]", "[2]int32", nil},
+		{"b1", "true", "bool", nil},
+		{"b2", "false", "bool", nil}, {"i8", "1", "int8", nil},
+		{"u16", "65535", "uint16", nil},
+		{"u32", "4294967295", "uint32", nil},
+		{"u64", "18446744073709551615", "uint64", nil},
+		{"u8", "255", "uint8", nil},
+		{"up", "5", "uintptr", nil},
 		{"NonExistent", "", "", errors.New("could not find symbol value for NonExistent")},
 	}
 
 	withTestProcess(executablePath, t, func(p *DebuggedProcess) {
-		pc, _, _ := p.GoSymTable.LineToPC(fp, 39)
+		pc, _, _ := p.GoSymTable.LineToPC(fp, 46)
 
 		_, err := p.Break(pc)
 		assertNoError(err, t, "Break() returned an error")
@@ -93,7 +99,7 @@ func TestVariableFunctionScoping(t *testing.T) {
 	}
 
 	withTestProcess(executablePath, t, func(p *DebuggedProcess) {
-		pc, _, _ := p.GoSymTable.LineToPC(fp, 39)
+		pc, _, _ := p.GoSymTable.LineToPC(fp, 46)
 
 		_, err := p.Break(pc)
 		assertNoError(err, t, "Break() returned an error")
@@ -167,10 +173,17 @@ func TestLocalVariables(t *testing.T) {
 				{"a7", "*main.FooBar {Baz: 5, Bur: strum}", "*main.FooBar", nil},
 				{"a8", "main.FooBar2 {Bur: 10, Baz: feh}", "main.FooBar2", nil},
 				{"a9", "*main.FooBar nil", "*main.FooBar", nil},
+				{"b1", "true", "bool", nil},
+				{"b2", "false", "bool", nil},
 				{"f32", "1.2", "float32", nil},
 				{"i32", "[2]int32 [1 2]", "[2]int32", nil},
 				{"i8", "1", "int8", nil},
-				{"neg", "-1", "int", nil}}},
+				{"neg", "-1", "int", nil},
+				{"u16", "65535", "uint16", nil},
+				{"u32", "4294967295", "uint32", nil},
+				{"u64", "18446744073709551615", "uint64", nil},
+				{"u8", "255", "uint8", nil},
+				{"up", "5", "uintptr", nil}}},
 		{(*ThreadContext).FunctionArguments,
 			[]varTest{
 				{"bar", "main.FooBar {Baz: 10, Bur: lorem}", "main.FooBar", nil},
@@ -178,7 +191,7 @@ func TestLocalVariables(t *testing.T) {
 	}
 
 	withTestProcess(executablePath, t, func(p *DebuggedProcess) {
-		pc, _, _ := p.GoSymTable.LineToPC(fp, 39)
+		pc, _, _ := p.GoSymTable.LineToPC(fp, 46)
 
 		_, err := p.Break(pc)
 		assertNoError(err, t, "Break() returned an error")

--- a/proctl/variables_test.go
+++ b/proctl/variables_test.go
@@ -40,10 +40,12 @@ func TestVariableEvaluation(t *testing.T) {
 		{"a1", "foofoofoofoofoofoo", "struct string", nil},
 		{"a10", "ofo", "struct string", nil},
 		{"a11", "[3]main.FooBar [{Baz: 1, Bur: a},{Baz: 2, Bur: b},{Baz: 3, Bur: c}]", "[3]main.FooBar", nil},
+		{"a12", "[]main.FooBar len: 2, cap: 2, [{Baz: 4, Bur: d},{Baz: 5, Bur: e}]", "struct []main.FooBar", nil},
+		{"a13", "[]*main.FooBar len: 3, cap: 3, [*{Baz: 6, Bur: f},*{Baz: 7, Bur: g},*{Baz: 8, Bur: h}]", "struct []*main.FooBar", nil},
 		{"a2", "6", "int", nil},
 		{"a3", "7.23", "float64", nil},
 		{"a4", "[2]int [1,2]", "[2]int", nil},
-		{"a5", "len: 5 cap: 5 [1 2 3 4 5]", "struct []int", nil},
+		{"a5", "[]int len: 5, cap: 5, [1,2,3,4,5]", "struct []int", nil},
 		{"a6", "main.FooBar {Baz: 8, Bur: word}", "main.FooBar", nil},
 		{"a7", "*main.FooBar {Baz: 5, Bur: strum}", "*main.FooBar", nil},
 		{"a8", "main.FooBar2 {Bur: 10, Baz: feh}", "main.FooBar2", nil},
@@ -70,7 +72,7 @@ func TestVariableEvaluation(t *testing.T) {
 	}
 
 	withTestProcess(executablePath, t, func(p *DebuggedProcess) {
-		pc, _, _ := p.GoSymTable.LineToPC(fp, 48)
+		pc, _, _ := p.GoSymTable.LineToPC(fp, 50)
 
 		_, err := p.Break(pc)
 		assertNoError(err, t, "Break() returned an error")
@@ -101,7 +103,7 @@ func TestVariableFunctionScoping(t *testing.T) {
 	}
 
 	withTestProcess(executablePath, t, func(p *DebuggedProcess) {
-		pc, _, _ := p.GoSymTable.LineToPC(fp, 48)
+		pc, _, _ := p.GoSymTable.LineToPC(fp, 50)
 
 		_, err := p.Break(pc)
 		assertNoError(err, t, "Break() returned an error")
@@ -168,10 +170,12 @@ func TestLocalVariables(t *testing.T) {
 				{"a1", "foofoofoofoofoofoo", "struct string", nil},
 				{"a10", "ofo", "struct string", nil},
 				{"a11", "[3]main.FooBar [{Baz: 1, Bur: a},{Baz: 2, Bur: b},{Baz: 3, Bur: c}]", "[3]main.FooBar", nil},
+				{"a12", "[]main.FooBar len: 2, cap: 2, [{Baz: 4, Bur: d},{Baz: 5, Bur: e}]", "struct []main.FooBar", nil},
+				{"a13", "[]*main.FooBar len: 3, cap: 3, [*{Baz: 6, Bur: f},*{Baz: 7, Bur: g},*{Baz: 8, Bur: h}]", "struct []*main.FooBar", nil},
 				{"a2", "6", "int", nil},
 				{"a3", "7.23", "float64", nil},
 				{"a4", "[2]int [1,2]", "[2]int", nil},
-				{"a5", "len: 5 cap: 5 [1 2 3 4 5]", "struct []int", nil},
+				{"a5", "[]int len: 5, cap: 5, [1,2,3,4,5]", "struct []int", nil},
 				{"a6", "main.FooBar {Baz: 8, Bur: word}", "main.FooBar", nil},
 				{"a7", "*main.FooBar {Baz: 5, Bur: strum}", "*main.FooBar", nil},
 				{"a8", "main.FooBar2 {Bur: 10, Baz: feh}", "main.FooBar2", nil},
@@ -195,7 +199,7 @@ func TestLocalVariables(t *testing.T) {
 	}
 
 	withTestProcess(executablePath, t, func(p *DebuggedProcess) {
-		pc, _, _ := p.GoSymTable.LineToPC(fp, 48)
+		pc, _, _ := p.GoSymTable.LineToPC(fp, 50)
 
 		_, err := p.Break(pc)
 		assertNoError(err, t, "Break() returned an error")

--- a/proctl/variables_test.go
+++ b/proctl/variables_test.go
@@ -39,9 +39,10 @@ func TestVariableEvaluation(t *testing.T) {
 	testcases := []varTest{
 		{"a1", "foofoofoofoofoofoo", "struct string", nil},
 		{"a10", "ofo", "struct string", nil},
+		{"a11", "[3]main.FooBar [{Baz: 1, Bur: a},{Baz: 2, Bur: b},{Baz: 3, Bur: c}]", "[3]main.FooBar", nil},
 		{"a2", "6", "int", nil},
 		{"a3", "7.23", "float64", nil},
-		{"a4", "[2]int [1 2]", "[2]int", nil},
+		{"a4", "[2]int [1,2]", "[2]int", nil},
 		{"a5", "len: 5 cap: 5 [1 2 3 4 5]", "struct []int", nil},
 		{"a6", "main.FooBar {Baz: 8, Bur: word}", "main.FooBar", nil},
 		{"a7", "*main.FooBar {Baz: 5, Bur: strum}", "*main.FooBar", nil},
@@ -56,7 +57,7 @@ func TestVariableEvaluation(t *testing.T) {
 		{"a9.Baz", "nil", "int", errors.New("a9 is nil")},
 		{"a9.NonExistent", "nil", "int", errors.New("a9 has no member NonExistent")},
 		{"a8", "main.FooBar2 {Bur: 10, Baz: feh}", "main.FooBar2", nil}, // reread variable after member
-		{"i32", "[2]int32 [1 2]", "[2]int32", nil},
+		{"i32", "[2]int32 [1,2]", "[2]int32", nil},
 		{"b1", "true", "bool", nil},
 		{"b2", "false", "bool", nil}, {"i8", "1", "int8", nil},
 		{"u16", "65535", "uint16", nil},
@@ -69,7 +70,7 @@ func TestVariableEvaluation(t *testing.T) {
 	}
 
 	withTestProcess(executablePath, t, func(p *DebuggedProcess) {
-		pc, _, _ := p.GoSymTable.LineToPC(fp, 47)
+		pc, _, _ := p.GoSymTable.LineToPC(fp, 48)
 
 		_, err := p.Break(pc)
 		assertNoError(err, t, "Break() returned an error")
@@ -100,7 +101,7 @@ func TestVariableFunctionScoping(t *testing.T) {
 	}
 
 	withTestProcess(executablePath, t, func(p *DebuggedProcess) {
-		pc, _, _ := p.GoSymTable.LineToPC(fp, 47)
+		pc, _, _ := p.GoSymTable.LineToPC(fp, 48)
 
 		_, err := p.Break(pc)
 		assertNoError(err, t, "Break() returned an error")
@@ -166,9 +167,10 @@ func TestLocalVariables(t *testing.T) {
 			[]varTest{
 				{"a1", "foofoofoofoofoofoo", "struct string", nil},
 				{"a10", "ofo", "struct string", nil},
+				{"a11", "[3]main.FooBar [{Baz: 1, Bur: a},{Baz: 2, Bur: b},{Baz: 3, Bur: c}]", "[3]main.FooBar", nil},
 				{"a2", "6", "int", nil},
 				{"a3", "7.23", "float64", nil},
-				{"a4", "[2]int [1 2]", "[2]int", nil},
+				{"a4", "[2]int [1,2]", "[2]int", nil},
 				{"a5", "len: 5 cap: 5 [1 2 3 4 5]", "struct []int", nil},
 				{"a6", "main.FooBar {Baz: 8, Bur: word}", "main.FooBar", nil},
 				{"a7", "*main.FooBar {Baz: 5, Bur: strum}", "*main.FooBar", nil},
@@ -178,7 +180,7 @@ func TestLocalVariables(t *testing.T) {
 				{"b2", "false", "bool", nil},
 				{"f", "main.barfoo", "func()", nil},
 				{"f32", "1.2", "float32", nil},
-				{"i32", "[2]int32 [1 2]", "[2]int32", nil},
+				{"i32", "[2]int32 [1,2]", "[2]int32", nil},
 				{"i8", "1", "int8", nil},
 				{"neg", "-1", "int", nil},
 				{"u16", "65535", "uint16", nil},
@@ -193,7 +195,7 @@ func TestLocalVariables(t *testing.T) {
 	}
 
 	withTestProcess(executablePath, t, func(p *DebuggedProcess) {
-		pc, _, _ := p.GoSymTable.LineToPC(fp, 47)
+		pc, _, _ := p.GoSymTable.LineToPC(fp, 48)
 
 		_, err := p.Break(pc)
 		assertNoError(err, t, "Break() returned an error")

--- a/proctl/variables_test.go
+++ b/proctl/variables_test.go
@@ -64,11 +64,12 @@ func TestVariableEvaluation(t *testing.T) {
 		{"u64", "18446744073709551615", "uint64", nil},
 		{"u8", "255", "uint8", nil},
 		{"up", "5", "uintptr", nil},
+		{"f", "main.barfoo", "func()", nil},
 		{"NonExistent", "", "", errors.New("could not find symbol value for NonExistent")},
 	}
 
 	withTestProcess(executablePath, t, func(p *DebuggedProcess) {
-		pc, _, _ := p.GoSymTable.LineToPC(fp, 46)
+		pc, _, _ := p.GoSymTable.LineToPC(fp, 47)
 
 		_, err := p.Break(pc)
 		assertNoError(err, t, "Break() returned an error")
@@ -99,7 +100,7 @@ func TestVariableFunctionScoping(t *testing.T) {
 	}
 
 	withTestProcess(executablePath, t, func(p *DebuggedProcess) {
-		pc, _, _ := p.GoSymTable.LineToPC(fp, 46)
+		pc, _, _ := p.GoSymTable.LineToPC(fp, 47)
 
 		_, err := p.Break(pc)
 		assertNoError(err, t, "Break() returned an error")
@@ -175,6 +176,7 @@ func TestLocalVariables(t *testing.T) {
 				{"a9", "*main.FooBar nil", "*main.FooBar", nil},
 				{"b1", "true", "bool", nil},
 				{"b2", "false", "bool", nil},
+				{"f", "main.barfoo", "func()", nil},
 				{"f32", "1.2", "float32", nil},
 				{"i32", "[2]int32 [1 2]", "[2]int32", nil},
 				{"i8", "1", "int8", nil},
@@ -191,7 +193,7 @@ func TestLocalVariables(t *testing.T) {
 	}
 
 	withTestProcess(executablePath, t, func(p *DebuggedProcess) {
-		pc, _, _ := p.GoSymTable.LineToPC(fp, 46)
+		pc, _, _ := p.GoSymTable.LineToPC(fp, 47)
 
 		_, err := p.Break(pc)
 		assertNoError(err, t, "Break() returned an error")


### PR DESCRIPTION
Built on #45 
- Generalized arrays and slices, print/eval supports arrays and slices of all types.