### PR TITLE
info vars command

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,10 +67,11 @@ Once inside a debugging session, the following commands may be used:
 * `print $var` - Evaluate a variable.
 
 * `info $type [regex]` - Outputs information about the symbol table. An optional regex filters the list. Example `info funcs unicode`. Valid types are:
-  * `sources` - Prings the path of all source files
+  * `args` - Prints the name and value of all arguments to the current function
   * `funcs` - Prings the name of all defined functions
   * `locals` - Prints the name and value of all local variables in the current context
-  * `args` - Prints the name and value of all arguments to the current function
+  * `sources` - Prings the path of all source files
+  * `vars` - Prints the name and value of all package variables in the app. Any variable that is not local or arg is considered a package variables
 
 * `exit` - Exit the debugger.
 

--- a/_fixtures/testvariables.go
+++ b/_fixtures/testvariables.go
@@ -13,6 +13,11 @@ type FooBar2 struct {
 	Baz string
 }
 
+type Nest struct {
+	Level int
+	Nest  *Nest
+}
+
 func barfoo() {
 	a1 := "bur"
 	fmt.Println(a1)
@@ -45,10 +50,12 @@ func foobar(baz string, bar FooBar) {
 		f32 = float32(1.2)
 		i32 = [2]int32{1, 2}
 		f   = barfoo
+		ms  = Nest{0, &Nest{1, &Nest{2, &Nest{3, &Nest{4, nil}}}}} // Test recursion capping
+		ba  = make([]int, 200, 200)                                // Test array size capping
 	)
 
 	barfoo()
-	fmt.Println(a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, b1, b2, baz, neg, i8, u8, u16, u32, u64, up, f32, i32, bar, f)
+	fmt.Println(a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, b1, b2, baz, neg, i8, u8, u16, u32, u64, up, f32, i32, bar, f, ms, ba)
 }
 
 func main() {

--- a/command/command.go
+++ b/command/command.go
@@ -262,7 +262,7 @@ func info(p *proctl.DebuggedProcess, args ...string) error {
 		data = filterVariables(vars, filter)
 
 	default:
-		return fmt.Errorf("unsupported info type, must be sources, funcs, locals, args, or vars")
+		return fmt.Errorf("unsupported info type, must be args, funcs, locals, sources, or vars")
 	}
 
 	// sort and output data

--- a/command/command.go
+++ b/command/command.go
@@ -254,6 +254,13 @@ func info(p *proctl.DebuggedProcess, args ...string) error {
 		}
 		data = filterVariables(vars, filter)
 
+	case "vars":
+		vars, err := p.CurrentThread.PackageVariables()
+		if err != nil {
+			return nil
+		}
+		data = filterVariables(vars, filter)
+
 	default:
 		return fmt.Errorf("unsupported info type, must be sources, funcs, locals, or args")
 	}

--- a/command/command.go
+++ b/command/command.go
@@ -262,7 +262,7 @@ func info(p *proctl.DebuggedProcess, args ...string) error {
 		data = filterVariables(vars, filter)
 
 	default:
-		return fmt.Errorf("unsupported info type, must be sources, funcs, locals, or args")
+		return fmt.Errorf("unsupported info type, must be sources, funcs, locals, args, or vars")
 	}
 
 	// sort and output data

--- a/dwarf/reader/reader.go
+++ b/dwarf/reader/reader.go
@@ -10,18 +10,18 @@ type Reader struct {
 	depth int
 }
 
-// New returns a reader for the specified dwarf data
+// New returns a reader for the specified dwarf data.
 func New(data *dwarf.Data) *Reader {
 	return &Reader{data.Reader(), 0}
 }
 
-// Seek moves the reader to an arbitrary offset
+// Seek moves the reader to an arbitrary offset.
 func (reader *Reader) Seek(off dwarf.Offset) {
 	reader.depth = 0
 	reader.Reader.Seek(off)
 }
 
-// SeekToEntry moves the reader to an arbitrary entry
+// SeekToEntry moves the reader to an arbitrary entry.
 func (reader *Reader) SeekToEntry(entry *dwarf.Entry) error {
 	reader.Seek(entry.Offset)
 	// Consume the current entry so .Next works as intended
@@ -62,7 +62,7 @@ func (reader *Reader) SeekToFunction(pc uint64) (*dwarf.Entry, error) {
 
 // SeekToType moves the reader to the type specified by the entry,
 // optionally resolving typedefs and pointer types. If the reader is set
-// to a struct type the NextMemberVariable call can be used to walk all member data
+// to a struct type the NextMemberVariable call can be used to walk all member data.
 func (reader *Reader) SeekToType(entry *dwarf.Entry, resolveTypedefs bool, resolvePointerTypes bool) (*dwarf.Entry, error) {
 	offset, ok := entry.Val(dwarf.AttrType).(dwarf.Offset)
 	if !ok {
@@ -97,7 +97,7 @@ func (reader *Reader) SeekToType(entry *dwarf.Entry, resolveTypedefs bool, resol
 	return nil, fmt.Errorf("no type entry found")
 }
 
-// NextScopeVariable moves the reader to the next debug entry that describes a local variable and returns the entry
+// NextScopeVariable moves the reader to the next debug entry that describes a local variable and returns the entry.
 func (reader *Reader) NextScopeVariable() (*dwarf.Entry, error) {
 	for entry, err := reader.Next(); entry != nil; entry, err = reader.Next() {
 		if err != nil {
@@ -121,7 +121,7 @@ func (reader *Reader) NextScopeVariable() (*dwarf.Entry, error) {
 	return nil, nil
 }
 
-// NextMememberVariable moves the reader to the next debug entry that describes a member variable and returns the entry
+// NextMememberVariable moves the reader to the next debug entry that describes a member variable and returns the entry.
 func (reader *Reader) NextMemberVariable() (*dwarf.Entry, error) {
 	for entry, err := reader.Next(); entry != nil; entry, err = reader.Next() {
 		if err != nil {
@@ -145,8 +145,8 @@ func (reader *Reader) NextMemberVariable() (*dwarf.Entry, error) {
 	return nil, nil
 }
 
-// NextPackage moves the reader to the next debug entry that describes a package variable
-// any TagVariable entry that is not inside a sub prgram entry and is marked external is considered a package variable
+// NextPackageVariable moves the reader to the next debug entry that describes a package variable.
+// Any TagVariable entry that is not inside a sub prgram entry and is marked external is considered a package variable.
 func (reader *Reader) NextPackageVariable() (*dwarf.Entry, error) {
 	for entry, err := reader.Next(); entry != nil; entry, err = reader.Next() {
 		if err != nil {

--- a/dwarf/reader/reader.go
+++ b/dwarf/reader/reader.go
@@ -144,3 +144,28 @@ func (reader *Reader) NextMemberVariable() (*dwarf.Entry, error) {
 	// No more items
 	return nil, nil
 }
+
+// NextPackage moves the reader to the next debug entry that describes a package variable
+// any TagVariable entry that is not inside a sub prgram entry and is marked external is considered a package variable
+func (reader *Reader) NextPackageVariable() (*dwarf.Entry, error) {
+	for entry, err := reader.Next(); entry != nil; entry, err = reader.Next() {
+		if err != nil {
+			return nil, err
+		}
+
+		if entry.Tag == dwarf.TagVariable {
+			ext, ok := entry.Val(dwarf.AttrExternal).(bool)
+			if ok && ext {
+				return entry, nil
+			}
+		}
+
+		// Ignore everything inside sub programs
+		if entry.Tag == dwarf.TagSubprogram {
+			reader.SkipChildren()
+		}
+	}
+
+	// No more items
+	return nil, nil
+}

--- a/proctl/variables.go
+++ b/proctl/variables.go
@@ -924,14 +924,11 @@ func (thread *ThreadContext) PackageVariables() ([]*Variable, error) {
 		}
 
 		// Ignore errors trying to extract values
-		_, err := thread.extractVariableFromEntry(entry)
+		val, err := thread.extractVariableFromEntry(entry)
 		if err != nil {
-			fmt.Printf("ERR: %s\n", err.Error())
+			continue
 		}
-		if err == nil {
-			//			fmt.Printf("%s %s\n", val.Name, val.Value)
-			//			vars = append(vars, val)
-		}
+		vars = append(vars, val)
 	}
 
 	return vars, nil

--- a/proctl/variables.go
+++ b/proctl/variables.go
@@ -529,7 +529,6 @@ func (thread *ThreadContext) extractVariableFromEntry(entry *dwarf.Entry) (*Vari
 
 	val, err := thread.extractValue(instructions, 0, t, true)
 	if err != nil {
-		fmt.Printf("NAME: %s\n", n)
 		return nil, err
 	}
 

--- a/proctl/variables_test.go
+++ b/proctl/variables_test.go
@@ -68,11 +68,13 @@ func TestVariableEvaluation(t *testing.T) {
 		{"u8", "255", "uint8", nil},
 		{"up", "5", "uintptr", nil},
 		{"f", "main.barfoo", "func()", nil},
+		{"ba", "[]int len: 200, cap: 200, [0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,...+136 more]", "struct []int", nil},
+		{"ms", "main.Nest {Level: 0, Nest: *main.Nest {Level: 1, Nest: *main.Nest {...}}}", "main.Nest", nil},
 		{"NonExistent", "", "", errors.New("could not find symbol value for NonExistent")},
 	}
 
 	withTestProcess(executablePath, t, func(p *DebuggedProcess) {
-		pc, _, _ := p.GoSymTable.LineToPC(fp, 50)
+		pc, _, _ := p.GoSymTable.LineToPC(fp, 57)
 
 		_, err := p.Break(pc)
 		assertNoError(err, t, "Break() returned an error")
@@ -103,7 +105,7 @@ func TestVariableFunctionScoping(t *testing.T) {
 	}
 
 	withTestProcess(executablePath, t, func(p *DebuggedProcess) {
-		pc, _, _ := p.GoSymTable.LineToPC(fp, 50)
+		pc, _, _ := p.GoSymTable.LineToPC(fp, 57)
 
 		_, err := p.Break(pc)
 		assertNoError(err, t, "Break() returned an error")
@@ -118,7 +120,7 @@ func TestVariableFunctionScoping(t *testing.T) {
 		assertNoError(err, t, "Unable to find variable a1")
 
 		// Move scopes, a1 exists here by a2 does not
-		pc, _, _ = p.GoSymTable.LineToPC(fp, 18)
+		pc, _, _ = p.GoSymTable.LineToPC(fp, 23)
 
 		_, err = p.Break(pc)
 		assertNoError(err, t, "Break() returned an error")
@@ -182,10 +184,12 @@ func TestLocalVariables(t *testing.T) {
 				{"a9", "*main.FooBar nil", "*main.FooBar", nil},
 				{"b1", "true", "bool", nil},
 				{"b2", "false", "bool", nil},
+				{"ba", "[]int len: 200, cap: 200, [0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,...+136 more]", "struct []int", nil},
 				{"f", "main.barfoo", "func()", nil},
 				{"f32", "1.2", "float32", nil},
 				{"i32", "[2]int32 [1,2]", "[2]int32", nil},
 				{"i8", "1", "int8", nil},
+				{"ms", "main.Nest {Level: 0, Nest: *main.Nest {Level: 1, Nest: *main.Nest {...}}}", "main.Nest", nil},
 				{"neg", "-1", "int", nil},
 				{"u16", "65535", "uint16", nil},
 				{"u32", "4294967295", "uint32", nil},
@@ -199,7 +203,7 @@ func TestLocalVariables(t *testing.T) {
 	}
 
 	withTestProcess(executablePath, t, func(p *DebuggedProcess) {
-		pc, _, _ := p.GoSymTable.LineToPC(fp, 50)
+		pc, _, _ := p.GoSymTable.LineToPC(fp, 57)
 
 		_, err := p.Break(pc)
 		assertNoError(err, t, "Break() returned an error")


### PR DESCRIPTION
The last of the info commands, prints out all package level variables and values.  With this code, running info vars after starting the testvariables does not show any unparseable or unreadable variables! Built on #45 and #46 

- Adds support for UndefinedType which will always have a value of (unknown)
- Adds support for VoidType which will always have a value of (void)
- Fixes reading null fn pointers.
- When a TypedefType is found, recurse down until finding something that is not a typedef, some types are typedefs of typedefs etc.

The code is complete but I found a bug during testing. For certain data structures that are very deep (linked lists) and structures that are large and have many nested structs, extractVariableFromEntry goes crazy continually recursively reading nested structs until the application panics and runs out of memory.

We should probably stop recursing after N levels (2?). What should we display in that case? Perhaps ... to indicate there is more there, but we can't display it. Once proper handling of evalVariable for package variables is complete the user could dig in that way.