### PR TITLE
Dont panic if .debug_frame section is not found.

### DIFF
--- a/proctl/proctl_linux_amd64.go
+++ b/proctl/proctl_linux_amd64.go
@@ -109,13 +109,17 @@ func (dbp *DebuggedProcess) findExecutable() (*elf.File, error) {
 func (dbp *DebuggedProcess) parseDebugFrame(exe *elf.File, wg *sync.WaitGroup) {
 	defer wg.Done()
 
-	debugFrame, err := exe.Section(".debug_frame").Data()
-	if err != nil {
-		fmt.Println("could not get .debug_frame section", err)
+	if sec := exe.Section(".debug_frame"); sec != nil {
+		debugFrame, err := exe.Section(".debug_frame").Data()
+		if err != nil {
+			fmt.Println("could not get .debug_frame section", err)
+			os.Exit(1)
+		}
+		dbp.FrameEntries = frame.Parse(debugFrame)
+	} else {
+		fmt.Println("No debug symbols found")
 		os.Exit(1)
 	}
-
-	dbp.FrameEntries = frame.Parse(debugFrame)
 }
 
 func (dbp *DebuggedProcess) obtainGoSymbols(exe *elf.File, wg *sync.WaitGroup) {


### PR DESCRIPTION
Attempting to debug a process with no symbols causes dlv to panic because .debug_frame section is missing. Fixed up logic to log + exit instead.

Last PR until you get a chance to review everything, thanks for all your work on this.