### PR TITLE
Report caller file:line in assert helper fn when test fails

### DIFF
--- a/proctl/proctl_test.go
+++ b/proctl/proctl_test.go
@@ -49,7 +49,9 @@ func dataAtAddr(pid int, addr uint64) ([]byte, error) {
 
 func assertNoError(err error, t *testing.T, s string) {
 	if err != nil {
-		t.Fatal(s, ":", err)
+		_, file, line, _ := runtime.Caller(1)
+		fname := filepath.Base(file)
+		t.Fatalf("failed assertion at %s:%d: %s : %s\n", fname, line, s, err)
 	}
 }
 


### PR DESCRIPTION
Hi,
I ran into issue #43 and noticed how the error output referenced the assert helper function instead of the actual caller. Here is a suggested fix to make it a bit easier to trace the origin, with the additional cost of importing fmt.