### PR TITLE
Some hw breakpoint fixes

### DIFF
--- a/proctl/breakpoints_linux_amd64.go
+++ b/proctl/breakpoints_linux_amd64.go
@@ -52,12 +52,12 @@ func PtracePokeUser(tid int, off, addr uintptr) error {
 }
 
 func PtracePeekUser(tid int, off uintptr) (uintptr, error) {
-	var x uintptr // XXX: this should not be necessary
-	ret, _, err := syscall.Syscall6(syscall.SYS_PTRACE, syscall.PTRACE_PEEKUSR, uintptr(tid), uintptr(off), uintptr(unsafe.Pointer(&x)), 0, 0)
+	var val uintptr
+	_, _, err := syscall.Syscall6(syscall.SYS_PTRACE, syscall.PTRACE_PEEKUSR, uintptr(tid), uintptr(off), uintptr(unsafe.Pointer(&val)), 0, 0)
 	if err != syscall.Errno(0) {
 		return 0, err
 	}
-	return ret, nil
+	return val, nil
 }
 
 func (dbp *DebuggedProcess) BreakpointExists(addr uint64) bool {


### PR DESCRIPTION
Enable usage of dr1-dr3.  Clear control bits when a breakpoint
is disabled. Use DR_LEN_1 instead of DR_LEN_8 so breakpoint work on
unaligned adresses.

Fixes #51.