### PR TITLE
migrate to go.sys subrepository

### DIFF
--- a/client/cli/cli.go
+++ b/client/cli/cli.go
@@ -2,12 +2,12 @@ package cli
 
 import (
 	"fmt"
+	sys "golang.org/x/sys/unix"
 	"io"
 	"os"
 	"os/exec"
 	"os/signal"
 	"strings"
-	"syscall"
 
 	"github.com/derekparker/delve/command"
 	"github.com/derekparker/delve/goreadline"
@@ -49,7 +49,7 @@ func Run(run bool, pid int, args []string) {
 	}
 
 	ch := make(chan os.Signal)
-	signal.Notify(ch, syscall.SIGINT)
+	signal.Notify(ch, sys.SIGINT)
 	go func() {
 		for _ = range ch {
 			if dbp.Running() {
@@ -105,7 +105,7 @@ func handleExit(dbp *proctl.DebuggedProcess, status int) {
 	}
 
 	fmt.Println("Detaching from process...")
-	err := syscall.PtraceDetach(dbp.Process.Pid)
+	err := sys.PtraceDetach(dbp.Process.Pid)
 	if err != nil {
 		die(2, "Could not detach", err)
 	}

--- a/goreadline/goreadline.go
+++ b/goreadline/goreadline.go
@@ -11,20 +11,20 @@ package goreadline
 */
 import "C"
 import (
+	sys "golang.org/x/sys/unix"
 	"os"
 	"os/signal"
-	"syscall"
 	"unsafe"
 )
 
 func init() {
 	C.rl_catch_sigwinch = 0
 	c := make(chan os.Signal, 1)
-	signal.Notify(c, syscall.SIGWINCH)
+	signal.Notify(c, sys.SIGWINCH)
 	go func() {
 		for sig := range c {
 			switch sig {
-			case syscall.SIGWINCH:
+			case sys.SIGWINCH:
 				Resize()
 			default:
 

--- a/proctl/breakpoints_linux_amd64.go
+++ b/proctl/breakpoints_linux_amd64.go
@@ -16,6 +16,7 @@ import "C"
 
 import (
 	"fmt"
+	sys "golang.org/x/sys/unix"
 	"syscall"
 )
 
@@ -43,7 +44,7 @@ func (bpe BreakPointExistsError) Error() string {
 }
 
 func PtracePokeUser(tid int, off, addr uintptr) error {
-	_, _, err := syscall.Syscall6(syscall.SYS_PTRACE, syscall.PTRACE_POKEUSR, uintptr(tid), uintptr(off), uintptr(addr), 0, 0)
+	_, _, err := sys.Syscall6(sys.SYS_PTRACE, sys.PTRACE_POKEUSR, uintptr(tid), uintptr(off), uintptr(addr), 0, 0)
 	if err != syscall.Errno(0) {
 		return err
 	}

--- a/proctl/threads.go
+++ b/proctl/threads.go
@@ -3,7 +3,7 @@ package proctl
 import (
 	"encoding/binary"
 	"fmt"
-	"syscall"
+	sys "golang.org/x/sys/unix"
 
 	"github.com/derekparker/delve/dwarf/frame"
 )
@@ -13,7 +13,7 @@ import (
 type ThreadContext struct {
 	Id      int
 	Process *DebuggedProcess
-	Status  *syscall.WaitStatus
+	Status  *sys.WaitStatus
 }
 
 type Registers interface {
@@ -91,7 +91,7 @@ func (thread *ThreadContext) Continue() error {
 		}
 	}
 
-	return syscall.PtraceCont(thread.Id, 0)
+	return sys.PtraceCont(thread.Id, 0)
 }
 
 // Single steps this thread a single instruction, ensuring that
@@ -122,7 +122,7 @@ func (thread *ThreadContext) Step() (err error) {
 		}()
 	}
 
-	err = syscall.PtraceSingleStep(thread.Id)
+	err = sys.PtraceSingleStep(thread.Id)
 	if err != nil {
 		return fmt.Errorf("step failed: %s", err.Error())
 	}

--- a/proctl/threads_linux_amd64.go
+++ b/proctl/threads_linux_amd64.go
@@ -1,9 +1,9 @@
 package proctl
 
-import "syscall"
+import sys "golang.org/x/sys/unix"
 
 type Regs struct {
-	regs *syscall.PtraceRegs
+	regs *sys.PtraceRegs
 }
 
 func (r *Regs) PC() uint64 {
@@ -16,12 +16,12 @@ func (r *Regs) SP() uint64 {
 
 func (r *Regs) SetPC(tid int, pc uint64) error {
 	r.regs.SetPC(pc)
-	return syscall.PtraceSetRegs(tid, r.regs)
+	return sys.PtraceSetRegs(tid, r.regs)
 }
 
 func registers(tid int) (Registers, error) {
-	var regs syscall.PtraceRegs
-	err := syscall.PtraceGetRegs(tid, &regs)
+	var regs sys.PtraceRegs
+	err := sys.PtraceGetRegs(tid, &regs)
 	if err != nil {
 		return nil, err
 	}
@@ -29,11 +29,11 @@ func registers(tid int) (Registers, error) {
 }
 
 func writeMemory(tid int, addr uintptr, data []byte) (int, error) {
-	return syscall.PtracePokeData(tid, addr, data)
+	return sys.PtracePokeData(tid, addr, data)
 }
 
 func readMemory(tid int, addr uintptr, data []byte) (int, error) {
-	return syscall.PtracePeekData(tid, addr, data)
+	return sys.PtracePeekData(tid, addr, data)
 }
 
 func clearHardwareBreakpoint(reg, tid int) error {


### PR DESCRIPTION
As of go version 1.4 the standard library syscall package is "locked
down" and code outside of the standard library is recommended to migrate
to the go.sys subrepository.

Reference: https://golang.org/s/go1.4-syscall