### PR TITLE
Fixed missing header file "sys/types.h" to fix compiler error

### DIFF
--- a/proctl/breakpoints_linux_amd64.go
+++ b/proctl/breakpoints_linux_amd64.go
@@ -2,6 +2,7 @@ package proctl
 
 /*
 #include <stddef.h>
+#include <sys/types.h>
 #include <sys/user.h>
 #include <sys/debugreg.h>
 


### PR DESCRIPTION
On my installed system (cento 6.6) The header file "sys/user.h" requires "sys/types.h" to be included first.