### PR TITLE
Issue 73: die should restore the terminal state

### DIFF
--- a/command/command.go
+++ b/command/command.go
@@ -37,6 +37,16 @@ type Commands struct {
 	lastCmd cmdfunc
 }
 
+func (c *Commands) Names() (names []string) {
+	for _, cc := range c.cmds {
+		for _, a := range cc.aliases {
+			names = append(names, a)
+		}
+	}
+
+	return
+}
+
 // Returns a Commands struct with default commands defined.
 func DebugCommands() *Commands {
 	c := &Commands{}
@@ -108,10 +118,24 @@ func nullCommand(p *proctl.DebuggedProcess, ars ...string) error {
 }
 
 func (c *Commands) help(p *proctl.DebuggedProcess, ars ...string) error {
-	fmt.Println("The following commands are available:")
-	for _, cmd := range c.cmds {
-		fmt.Printf("\t%s - %s\n", strings.Join(cmd.aliases, "|"), cmd.helpMsg)
+	if len(ars) > 0 {
+		cmdstr := ars[0]
+
+		for _, cmd := range c.cmds {
+			if cmd.match(cmdstr) {
+				fmt.Printf("%s - %s\n", strings.Join(cmd.aliases, "|"), cmd.helpMsg)
+				return nil
+			}
+		}
+
+		fmt.Println("no help for", cmdstr)
+	} else {
+		fmt.Println("The following commands are available:")
+		for _, cmd := range c.cmds {
+			fmt.Printf("\t%s - %s\n", strings.Join(cmd.aliases, "|"), cmd.helpMsg)
+		}
 	}
+
 	return nil
 }
 

--- a/command/command.go
+++ b/command/command.go
@@ -39,9 +39,7 @@ type Commands struct {
 
 func (c *Commands) Names() (names []string) {
 	for _, cc := range c.cmds {
-		for _, a := range cc.aliases {
-			names = append(names, a)
-		}
+		names = append(names, cc.aliases[0])
 	}
 
 	return


### PR DESCRIPTION
I didn't want to add another parameter to die(), that didn't really make sense so instead I created a Terminator object that contains things that need to be cleaned up (for now, only the liner).

Turns out I had to change a bunch of other places, to pass the Terminator instead of liner.State, so in retrospect maybe adding the liner to die wasn't such a bad idea (if you don't like this implementation I can change it)

While there I also added support for command completion and the option to get help for a specific command (I have a bunch of command line tools with similar support and I can't live without it :)