### PR TITLE
Handle process natural death a bit better

### DIFF
--- a/client/cli/cli.go
+++ b/client/cli/cli.go
@@ -87,9 +87,14 @@ func Run(run bool, pid int, args []string) {
 		}
 
 		cmd := cmds.Find(cmdstr)
-		err = cmd(dbp, args...)
-		if err != nil {
-			fmt.Fprintf(os.Stderr, "Command failed: %s\n", err)
+		if err := cmd(dbp, args...); err != nil {
+			switch err.(type) {
+			case proctl.ProcessExitedError:
+				pe := err.(proctl.ProcessExitedError)
+				fmt.Fprintf(os.Stderr, "Process exited with status %d\n", pe.Status)
+			default:
+				fmt.Fprintf(os.Stderr, "Command failed: %s\n", err)
+			}
 		}
 	}
 }

--- a/proctl/proctl.go
+++ b/proctl/proctl.go
@@ -45,6 +45,17 @@ func (mse ManualStopError) Error() string {
 	return "Manual stop requested"
 }
 
+// ProcessExitedError indicates that the process has exited and contains both
+// process id and exit status.
+type ProcessExitedError struct {
+	Pid    int
+	Status int
+}
+
+func (pe ProcessExitedError) Error() string {
+	return fmt.Sprintf("process %d has exited with status %d", pe.Pid, pe.Status)
+}
+
 // Attach to an existing process with the given PID.
 func Attach(pid int) (*DebuggedProcess, error) {
 	dbp, err := newDebugProcess(pid, true)
@@ -238,7 +249,7 @@ func (dbp *DebuggedProcess) Continue() error {
 	}
 
 	fn := func() error {
-		wpid, _, err := trapWait(dbp, -1)
+		wpid, err := trapWait(dbp, -1)
 		if err != nil {
 			return err
 		}
@@ -379,12 +390,4 @@ func (dbp *DebuggedProcess) run(fn func() error) error {
 		}
 	}
 	return nil
-}
-
-type ProcessExitedError struct {
-	pid int
-}
-
-func (pe ProcessExitedError) Error() string {
-	return fmt.Sprintf("process %d has exited", pe.pid)
 }

--- a/proctl/proctl_darwin.go
+++ b/proctl/proctl_darwin.go
@@ -172,14 +172,14 @@ func (dbp *DebuggedProcess) findExecutable() (*macho.File, error) {
 	return macho.Open(C.GoString(pathptr))
 }
 
-func trapWait(dbp *DebuggedProcess, pid int) (int, *sys.WaitStatus, error) {
+func trapWait(dbp *DebuggedProcess, pid int) (int, error) {
 	port := C.mach_port_wait(dbp.os.exceptionPort)
 	if port == 0 {
-		return -1, nil, ProcessExitedError{}
+		return -1, ProcessExitedError{Pid: dbp.Pid}
 	}
 
 	dbp.updateThreadList()
-	return int(port), nil, nil
+	return int(port), nil
 }
 
 func wait(pid, options int) (int, *sys.WaitStatus, error) {

--- a/proctl/proctl_test.go
+++ b/proctl/proctl_test.go
@@ -71,6 +71,22 @@ func currentLineNumber(p *DebuggedProcess, t *testing.T) (string, int) {
 	return f, l
 }
 
+func TestExit(t *testing.T) {
+	withTestProcess("../_fixtures/continuetestprog", t, func(p *DebuggedProcess) {
+		err := p.Continue()
+		pe, ok := err.(ProcessExitedError)
+		if !ok {
+			t.Fatalf("Continue() returned unexpected error type")
+		}
+		if pe.Status != 0 {
+			t.Errorf("Unexpected error status: %d", pe.Status)
+		}
+		if pe.Pid != p.Pid {
+			t.Errorf("Unexpected process id: %d", pe.Pid)
+		}
+	})
+}
+
 func TestStep(t *testing.T) {
 	withTestProcess("../_fixtures/testprog", t, func(p *DebuggedProcess) {
 		helloworldfunc := p.GoSymTable.LookupFunc("main.helloworld")

--- a/proctl/threads.go
+++ b/proctl/threads.go
@@ -35,7 +35,7 @@ type Registers interface {
 func (thread *ThreadContext) Registers() (Registers, error) {
 	regs, err := registers(thread)
 	if err != nil {
-		return nil, fmt.Errorf("could not get registers %s", err)
+		return nil, fmt.Errorf("could not get registers: %s", err)
 	}
 	return regs, nil
 }
@@ -70,13 +70,13 @@ func (thread *ThreadContext) PrintInfo() error {
 // we step over any breakpoints. It will restore the instruction,
 // step, and then restore the breakpoint and continue.
 func (thread *ThreadContext) Continue() error {
-	// Check whether we are stopped at a breakpoint, and
-	// if so, single step over it before continuing.
 	regs, err := thread.Registers()
 	if err != nil {
-		return fmt.Errorf("could not get registers %s", err)
+		return err
 	}
 
+	// Check whether we are stopped at a breakpoint, and
+	// if so, single step over it before continuing.
 	if _, ok := thread.Process.BreakPoints[regs.PC()-1]; ok {
 		err := thread.Step()
 		if err != nil {
@@ -195,7 +195,7 @@ func (thread *ThreadContext) continueToReturnAddress(pc uint64, fde *frame.Frame
 				return err
 			}
 			// Wait on -1, just in case scheduler switches threads for this G.
-			wpid, _, err := trapWait(thread.Process, -1)
+			wpid, err := trapWait(thread.Process, -1)
 			if err != nil {
 				return err
 			}


### PR DESCRIPTION
The error message when the process exits normally is a bit annoying, so I figure we could use the ProcessExitedError value to capture this along with the exit status. Also, the wait status, as returned by trapWait isn't actually used anywhere so I removed it. Finally, a small cleanup in the Registers() error reporting causing an unnecessarily long message chain.