### PR TITLE
Variables.go 'info vars' and 'info locals' Fix

### DIFF
--- a/proctl/variables.go
+++ b/proctl/variables.go
@@ -693,7 +693,7 @@ func (thread *ThreadContext) readString(addr uintptr) (string, error) {
 	}
 	addr = uintptr(binary.LittleEndian.Uint64(val))
 	if addr == 0 {
-		return "", err
+		return "", nil
 	}
 
 	val, err = thread.readMemory(addr, strlen)


### PR DESCRIPTION
Fixed the 'index out of range' runtime error by testing for a bogus address and returning an empty string out of ReadString.