### PR TITLE
Improve the help text for dlv

### DIFF
--- a/cmd/dlv/main.go
+++ b/cmd/dlv/main.go
@@ -11,10 +11,10 @@ import (
 
 const version string = "0.5.0.beta"
 
-var usage string = fmt.Sprintf(`Delve version %s
+var usage string = `Delve version %s
 
 flags:
-  -v Print version
+%s
 
 Invoke with the path to a binary:
 
@@ -24,9 +24,11 @@ or use the following commands:
   run - Build, run, and attach to program
   test - Build test binary, run and attach to it
   attach - Attach to running process
-`, version)
+`
 
 func init() {
+	flag.Usage = help
+
 	// We must ensure here that we are running on the same thread during
 	// the execution of dbg. This is due to the fact that ptrace(2) expects
 	// all commands after PTRACE_ATTACH to come from the same thread.
@@ -34,13 +36,14 @@ func init() {
 }
 
 func main() {
-	var printv bool
+	var printv, printhelp bool
 
 	flag.BoolVar(&printv, "v", false, "Print version number and exit.")
+	flag.BoolVar(&printhelp, "h", false, "Print help text and exit.")
 	flag.Parse()
 
 	if flag.NFlag() == 0 && len(flag.Args()) == 0 {
-		fmt.Println(usage)
+		help()
 		os.Exit(0)
 	}
 
@@ -49,5 +52,20 @@ func main() {
 		os.Exit(0)
 	}
 
+	if printhelp {
+		help()
+		os.Exit(0)
+	}
+
 	cli.Run(os.Args[1:])
+}
+
+// help prints help text to os.Stderr.
+func help() {
+	flags := ""
+	flag.VisitAll(func(f *flag.Flag) {
+		doc := fmt.Sprintf("  -%s=%s: %s\n", f.Name, f.DefValue, f.Usage)
+		flags += doc
+	})
+	fmt.Fprintf(os.Stderr, usage, version, flags)
 }


### PR DESCRIPTION
This patch makes a few small changes to `dlv` to try to make the default help text work a little better.

* It adds support for the `-h` flag.
* It generates flag help text from the `flag.Flag` objects.
* it overrides `flag.Usage` with a custom `help()` function.