### PR TITLE
Consolidate test support/setup

### DIFF
--- a/proctl/test/support.go
+++ b/proctl/test/support.go
@@ -1,0 +1,87 @@
+package test
+
+import (
+	"crypto/rand"
+	"encoding/hex"
+	"fmt"
+	"io/ioutil"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// Fixture is a test binary.
+type Fixture struct {
+	// Name is the short name of the fixture.
+	Name string
+	// Path is the absolute path to the test binary.
+	Path string
+	// Source is the absolute path of the test binary source.
+	Source string
+}
+
+// Fixtures is a map of Fixture.Name to Fixture.
+var Fixtures map[string]Fixture = make(map[string]Fixture)
+
+// RunTestsWithFixtures will pre-compile test fixtures before running test
+// methods. Test binaries are deleted before exiting.
+func RunTestsWithFixtures(m *testing.M) {
+	// Find the fixtures directory; this is necessary because the test file's
+	// nesting level can vary. Only look up to a maxdepth of 10 (which seems
+	// like a sane alternative to recursion).
+	parent := ".."
+	fixturesDir := filepath.Join(parent, "_fixtures")
+	for depth := 0; depth < 10; depth++ {
+		if _, err := os.Stat(fixturesDir); err == nil {
+			break
+		}
+		fixturesDir = filepath.Join("..", fixturesDir)
+	}
+	if _, err := os.Stat(fixturesDir); err != nil {
+		fmt.Println("Couldn't locate fixtures directory")
+		os.Exit(1)
+	}
+
+	// Collect all files which look like fixture source files.
+	sources, err := ioutil.ReadDir(fixturesDir)
+	if err != nil {
+		fmt.Printf("Couldn't read fixtures dir: %v\n", err)
+		os.Exit(1)
+	}
+
+	// Compile the fixtures.
+	for _, src := range sources {
+		if src.IsDir() {
+			continue
+		}
+		// Make a (good enough) random temporary file name
+		r := make([]byte, 4)
+		rand.Read(r)
+		path := filepath.Join(fixturesDir, src.Name())
+		name := strings.TrimSuffix(src.Name(), filepath.Ext(src.Name()))
+		tmpfile := filepath.Join(os.TempDir(), fmt.Sprintf("%s.%s", name, hex.EncodeToString(r)))
+
+		// Build the test binary
+		if err := exec.Command("go", "build", "-gcflags=-N -l", "-o", tmpfile, path).Run(); err != nil {
+			fmt.Printf("Error compiling %s: %s\n", path, err)
+			os.Exit(1)
+		}
+		fmt.Printf("Compiled test binary %s: %s\n", name, tmpfile)
+
+		source, _ := filepath.Abs(path)
+		Fixtures[name] = Fixture{Name: name, Path: tmpfile, Source: source}
+	}
+
+	status := m.Run()
+
+	// Remove the fixtures.
+	// TODO(danmace): Not sure why yet, but doing these removes in a defer isn't
+	// working.
+	for _, f := range Fixtures {
+		os.Remove(f.Path)
+	}
+
+	os.Exit(status)
+}

--- a/proctl/variables_test.go
+++ b/proctl/variables_test.go
@@ -2,9 +2,10 @@ package proctl
 
 import (
 	"errors"
-	"path/filepath"
 	"sort"
 	"testing"
+
+	protest "github.com/derekparker/delve/proctl/test"
 )
 
 type varTest struct {
@@ -29,13 +30,6 @@ func assertVariable(t *testing.T, variable *Variable, expected varTest) {
 }
 
 func TestVariableEvaluation(t *testing.T) {
-	executablePath := "../_fixtures/testvariables"
-
-	fp, err := filepath.Abs(executablePath + ".go")
-	if err != nil {
-		t.Fatal(err)
-	}
-
 	testcases := []varTest{
 		{"a1", "foofoofoofoofoofoo", "struct string", nil},
 		{"a10", "ofo", "struct string", nil},
@@ -73,8 +67,8 @@ func TestVariableEvaluation(t *testing.T) {
 		{"NonExistent", "", "", errors.New("could not find symbol value for NonExistent")},
 	}
 
-	withTestProcess(executablePath, t, func(p *DebuggedProcess) {
-		pc, _, _ := p.goSymTable.LineToPC(fp, 57)
+	withTestProcess("testvariables", t, func(p *DebuggedProcess, fixture protest.Fixture) {
+		pc, _, _ := p.goSymTable.LineToPC(fixture.Source, 57)
 
 		_, err := p.Break(pc)
 		assertNoError(err, t, "Break() returned an error")
@@ -97,15 +91,8 @@ func TestVariableEvaluation(t *testing.T) {
 }
 
 func TestVariableFunctionScoping(t *testing.T) {
-	executablePath := "../_fixtures/testvariables"
-
-	fp, err := filepath.Abs(executablePath + ".go")
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	withTestProcess(executablePath, t, func(p *DebuggedProcess) {
-		pc, _, _ := p.goSymTable.LineToPC(fp, 57)
+	withTestProcess("testvariables", t, func(p *DebuggedProcess, fixture protest.Fixture) {
+		pc, _, _ := p.goSymTable.LineToPC(fixture.Source, 57)
 
 		_, err := p.Break(pc)
 		assertNoError(err, t, "Break() returned an error")
@@ -121,7 +108,7 @@ func TestVariableFunctionScoping(t *testing.T) {
 		assertNoError(err, t, "Unable to find variable a1")
 
 		// Move scopes, a1 exists here by a2 does not
-		pc, _, _ = p.goSymTable.LineToPC(fp, 23)
+		pc, _, _ = p.goSymTable.LineToPC(fixture.Source, 23)
 
 		_, err = p.Break(pc)
 		assertNoError(err, t, "Break() returned an error")
@@ -157,13 +144,6 @@ func (s varArray) Less(i, j int) bool {
 }
 
 func TestLocalVariables(t *testing.T) {
-	executablePath := "../_fixtures/testvariables"
-
-	fp, err := filepath.Abs(executablePath + ".go")
-	if err != nil {
-		t.Fatal(err)
-	}
-
 	testcases := []struct {
 		fn     func(*ThreadContext) ([]*Variable, error)
 		output []varTest
@@ -203,8 +183,8 @@ func TestLocalVariables(t *testing.T) {
 				{"baz", "bazburzum", "struct string", nil}}},
 	}
 
-	withTestProcess(executablePath, t, func(p *DebuggedProcess) {
-		pc, _, _ := p.goSymTable.LineToPC(fp, 57)
+	withTestProcess("testvariables", t, func(p *DebuggedProcess, fixture protest.Fixture) {
+		pc, _, _ := p.goSymTable.LineToPC(fixture.Source, 57)
 
 		_, err := p.Break(pc)
 		assertNoError(err, t, "Break() returned an error")


### PR DESCRIPTION
Add a test support package which allows shared test functionality
for both the unit and integration tests.

Tests importing the proctl/test package will gain access to a special
test entrypoint which precompiles fixtures and makes them available
to tests.