### PR TITLE
Update CONTRIBUTING.md to not abbreviate dlv -version

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -8,7 +8,7 @@ If you'd like to join the discussion, hop on #delve-dbgr on irc.freenode.net.
 
 When filing an issue, make sure to answer these five questions:
 
-1. What version of Delve are you using (`dlv -v`)?
+1. What version of Delve are you using (`dlv -version`)?
 2. What version of Go are you using? (`go version`)?
 3. What operating system and processor architecture are you using?
 4. What did you do?


### PR DESCRIPTION
CONTRIBUTING.md says to get the delve version with `dlv -v`. This fails:

```
$ dlv -v
flag provided but not defined: -v
Delve version 0.5.0.beta
flags:
  -addr=localhost:0: Debugging server listen address.
  -headless=false: Run in headless mode.
  -log=false: Enable debugging server logging.
  -version=false: Print version number and exit.

Invoke with the path to a binary:
  dlv ./path/to/prog
or use the following commands:
  run - Build, run, and attach to program
  test - Build test binary, run and attach to it
  attach - Attach to running process
```

The flag cannot be abbreviated. This works:

```
$ dlv -version
Delve version: 0.5.0.beta
```