### PR TITLE
Add default answer hint to kill process prompt

### DIFF
--- a/terminal/terminal.go
+++ b/terminal/terminal.go
@@ -132,11 +132,11 @@ func handleExit(client service.Client, t *Term) (error, int) {
 		}
 	}
 
-	answer, err := t.line.Prompt("Would you like to kill the process? [y/n] ")
+	answer, err := t.line.Prompt("Would you like to kill the process? [y/N] ")
 	if err != nil {
 		return io.EOF, 2
 	}
-	answer = strings.TrimSuffix(answer, "\n")
+	answer = strings.ToLower(strings.TrimSpace(answer))
 
 	kill := (answer == "y")
 	err = client.Detach(kill)


### PR DESCRIPTION
Before exiting, dlv asks, "Would you like to kill the process? [y/n] ". This provides no hint as to what will happen if one just presses enter, nor is there any output to indicate what happened. A common convention in this situation is to capitalize the choice that will be assumed if just enter is pressed. This patch does so, and also allows answering with a capitalized Y or N and being messy with the space bar.
