### PR TITLE
proc: don't deref nil pointer if getG fails

### DIFF
--- a/proc/threads.go
+++ b/proc/threads.go
@@ -308,6 +308,8 @@ func (thread *Thread) getG() (g *G, err error) {
 		return nil, err
 	}
 	g, err = parseG(thread, regs.CX(), false)
-	g.thread = thread
+	if err == nil {
+		g.thread = thread
+	}
 	return
 }


### PR DESCRIPTION
    $ ./dlv run
    Type 'help' for list of commands.
    (dlv) break main
    Breakpoint 1 set at 0x45fa20 for main .../src/go/src/runtime/rt0_linux_amd64.s:63
    (dlv) continue
    current loc: main .../src/go/src/runtime/rt0_linux_amd64.s:63
       58: GLOBL _rt0_amd64_linux_lib_argc<>(SB),NOPTR, $8
       59: DATA _rt0_amd64_linux_lib_argv<>(SB)/8, $0
       60: GLOBL _rt0_amd64_linux_lib_argv<>(SB),NOPTR, $8
       61: 
       62: TEXT main(SB),NOSPLIT,$-8
    => 63:  MOVQ    $runtime·rt0_go(SB), AX
       64:  JMP     AX
    
    (dlv) stack
    panic: runtime error: invalid memory address or nil pointer dereference
    [signal 0xb code=0x1 addr=0x0 pc=0x61a52c]
    
    goroutine 13 [running]:
    github.com/derekparker/delve/proc.(*Thread).getG(0xc8207fb4d0, 0x0, 0x7fc168636000, 0xc820d484c0)
            .../go/src/github.com/derekparker/delve/proc/threads.go:311 +0x4dc
    github.com/derekparker/delve/proc.(*Process).GoroutinesInfo(0xc8201300b0, 0x0, 0x0, 0x0, 0x0, 0x0)
            .../go/src/github.com/derekparker/delve/proc/proc.go:444 +0x8b7
    github.com/derekparker/delve/service/debugger.(*Debugger).Stacktrace(0xc82000e8e0, 0x1, 0xa, 0x0, 0x0, 0x0, 0x0, 0x0)
            .../go/src/github.com/derekparker/delve/service/debugger/debugger.go:326 +0x8ba
    github.com/derekparker/delve/service/rpc.(*RPCServer).StacktraceGoroutine(0xc82000a7c0, 0xc82000ef70, 0xc8207fca80, 0x0, 0x0)
            .../go/src/github.com/derekparker/delve/service/rpc/server.go:103 +0x51
    reflect.Value.call(0x8c7880, 0x99b210, 0x13, 0x9b9c60, 0x4, 0xc8207ffee8, 0x3, 0x3, 0x0, 0x0, ...)
            .../src/go/src/reflect/value.go:432 +0x120a
    reflect.Value.Call(0x8c7880, 0x99b210, 0x13, 0xc8207ffee8, 0x3, 0x3, 0x0, 0x0, 0x0)
            .../src/go/src/reflect/value.go:300 +0xb1
    net/rpc.(*service).call(0xc8207f1500, 0xc8207f14c0, 0xc82015caf0, 0xc820116d80, 0xc8207fc2a0, 0x804ee0, 0xc82000ef70, 0x16, 0x7ffb40, 0xc8207fca80, ...)
            .../src/go/src/net/rpc/server.go:383 +0x1c1
    created by net/rpc.(*Server).ServeCodec
            .../src/go/src/net/rpc/server.go:477 +0x4ac