### PR TITLE
ClearBreakpoint should clear a hardware breakpoint from all threads

### DIFF
--- a/proc/breakpoints.go
+++ b/proc/breakpoints.go
@@ -152,18 +152,3 @@ type NoBreakpointError struct {
 func (nbp NoBreakpointError) Error() string {
 	return fmt.Sprintf("no breakpoint at %#v", nbp.addr)
 }
-
-func (dbp *Process) clearBreakpoint(tid int, addr uint64) (*Breakpoint, error) {
-	thread := dbp.Threads[tid]
-	if bp, ok := dbp.Breakpoints[addr]; ok {
-		if _, err := bp.Clear(thread); err != nil {
-			return nil, err
-		}
-		if bp.hardware {
-			dbp.arch.SetHardwareBreakpointUsage(bp.reg, false)
-		}
-		delete(dbp.Breakpoints, addr)
-		return bp, nil
-	}
-	return nil, NoBreakpointError{addr: addr}
-}


### PR DESCRIPTION
additionally fixes a bug when Detach is called on an exiting/exited thread: dbp.CurrentThread could point to a thread that has already been removed from dbp.Threads by trapWait which will lead to a nil pointer dereference caused proc.Process.clearBreakpoint getting nil from dbp.Threads[tid]