### PR TITLE
Put '> ' in front of the location marker.

### DIFF
--- a/terminal/command.go
+++ b/terminal/command.go
@@ -546,9 +546,9 @@ func printcontext(state *api.DebuggerState) error {
 		for _, arg := range state.CurrentThread.Function.Args {
 			args = append(args, arg.Value)
 		}
-		fmt.Printf("%s(%s) %s:%d\n", fn.Name, strings.Join(args, ", "), state.CurrentThread.File, state.CurrentThread.Line)
+		fmt.Printf("> %s(%s) %s:%d\n", fn.Name, strings.Join(args, ", "), state.CurrentThread.File, state.CurrentThread.Line)
 	} else {
-		fmt.Printf("%s() %s:%d\n", fn.Name, state.CurrentThread.File, state.CurrentThread.Line)
+		fmt.Printf("> %s() %s:%d\n", fn.Name, state.CurrentThread.File, state.CurrentThread.Line)
 	}
 
 	if state.BreakpointInfo != nil {


### PR DESCRIPTION
This makes parsing by external tools much easier.
It is consistent with pdb.