### PR TITLE
Visually align registers & show 16 bytes for each

### DIFF
--- a/proc/registers_darwin_amd64.go
+++ b/proc/registers_darwin_amd64.go
@@ -62,7 +62,7 @@ func (r *Regs) String() string {
 		{"Gs_base", r.gs_base},
 	}
 	for _, reg := range regs {
-		fmt.Fprintf(&buf, "%s = 0x%x\n", reg.k, reg.v)
+		fmt.Fprintf(&buf, "%8s = %0#16x\n", reg.k, reg.v)
 	}
 	return buf.String()
 }

--- a/proc/registers_linux_amd64.go
+++ b/proc/registers_linux_amd64.go
@@ -43,7 +43,7 @@ func (r *Regs) String() string {
 		{"Gs", r.regs.Gs},
 	}
 	for _, reg := range regs {
-		fmt.Fprintf(&buf, "%s = 0x%x\n", reg.k, reg.v)
+		fmt.Fprintf(&buf, "%8s = %0#16x\n", reg.k, reg.v)
 	}
 	return buf.String()
 }


### PR DESCRIPTION
This change right-aligns the register names in the output of the "regs" command, and pads out the display of the hex value of each register to 16 bytes. This makes scanning registers for set values a bit easier.

For example, the current output for regs looks like:

```
(dlv) regs
Rip = 0x135830
Rsp = 0xc20809c838
Rax = 0xc20801eb00
Rbx = 0x135830
Rcx = 0x65646f6370697a3a
Rdx = 0x10127b8
Rdi = 0x41e710
Rsi = 0xc20806ea4b
Rbp = 0x5
R8 = 0x0
R9 = 0xc2080d6580
R10 = 0x3576a0
R11 = 0xc208092090
R12 = 0xc20800bb38
R13 = 0xa3b208270c78
R14 = 0x140005dd94bec400
R15 = 0xc20800aef0
Rflags = 0x202
Cs = 0x2b
Fs = 0x0
Gs = 0x0
Gs_base = 0x7fff7b0823f0
```

With the change:

```
(dlv) regs
     Rip = 0x000000000000002000
     Rsp = 0x0000000002081bbf90
     Rax = 0x000000000208180120
     Rbx = 0x0000000002081c8090
     Rcx = 0x000000000208180120
     Rdx = 0x000000000000000000
     Rdi = 0x000000000000000000
     Rsi = 0x00000000020817cddf
     Rbp = 0x0000000002081b2200
      R8 = 0x000000000000000041
      R9 = 0x000000000000000010
     R10 = 0x000000000000000010
     R11 = 0x0000000000000bdb80
     R12 = 0x000000a7881052c371
     R13 = 0x000000ad2a1bd83978
     R14 = 0x0014000fff507cec00
     R15 = 0x000000000000000000
  Rflags = 0x000000000000000206
      Cs = 0x00000000000000002b
      Fs = 0x000000000000000000
      Gs = 0x000000000000140000
 Gs_base = 0x000000000000154e00
```