### PR TITLE
Support for dumb terminal (fixes #252)

### DIFF
--- a/terminal/command.go
+++ b/terminal/command.go
@@ -47,6 +47,8 @@ type Commands struct {
 	client  service.Client
 }
 
+var dumbTerminal = strings.ToLower(os.Getenv("TERM")) == "dumb"
+
 // Returns a Commands struct with default commands defined.
 func DebugCommands(client service.Client) *Commands {
 	c := &Commands{client: client}
@@ -724,7 +726,11 @@ func printcontext(state *api.DebuggerState) error {
 	}
 	if len(state.CurrentThread.File) == 0 {
 		fmt.Printf("Stopped at: 0x%x\n", state.CurrentThread.PC)
-		fmt.Printf("\033[34m=>\033[0m    no source available\n")
+		if dumbTerminal {
+			fmt.Printf("=>    no source available\n")
+		} else {
+			fmt.Printf("\033[34m=>\033[0m    no source available\n")
+		}
 		return nil
 	}
 	var fn *api.Function
@@ -808,10 +814,18 @@ func printfile(filename string, line int, showArrow bool) error {
 		}
 
 		var lineNum string
-		if i < 10 {
-			lineNum = fmt.Sprintf("\033[34m%s  %d\033[0m:\t", arrow, i)
+		if dumbTerminal {
+			if i < 10 {
+				lineNum = fmt.Sprintf("%s  %d:\t", arrow, i)
+			} else {
+				lineNum = fmt.Sprintf("%s %d:\t", arrow, i)
+			}
 		} else {
-			lineNum = fmt.Sprintf("\033[34m%s %d\033[0m:\t", arrow, i)
+			if i < 10 {
+				lineNum = fmt.Sprintf("\033[34m%s  %d\033[0m:\t", arrow, i)
+			} else {
+				lineNum = fmt.Sprintf("\033[34m%s %d\033[0m:\t", arrow, i)
+			}
 		}
 		context = append(context, lineNum+line)
 	}


### PR DESCRIPTION
I'm not sure if this is the best way to fix it, the other way would be to have a flag, `--no-color` for example.
Let me know which version is preferred, this or the flag and I'll adjust accordingly.
Thank you.