### PR TITLE
proc.(*Process).Continue skips breakpoints [WIP]

### DIFF
--- a/_fixtures/bpcountstest.go
+++ b/_fixtures/bpcountstest.go
@@ -1,0 +1,28 @@
+package main
+
+import (
+	"fmt"
+	"math/rand"
+	"sync"
+	"time"
+)
+
+func demo(id int, wait *sync.WaitGroup) {
+	for i := 0; i < 100; i++ {
+		sleep := rand.Intn(10) + 1
+		fmt.Printf("id: %d step: %d sleeping %d\n", id, i, sleep)
+		time.Sleep(time.Duration(sleep) *  time.Millisecond)
+	}
+
+	wait.Done()
+}
+
+func main() {
+	wait := new(sync.WaitGroup)
+	wait.Add(1)
+	wait.Add(1)
+	go demo(1, wait)
+	go demo(2, wait)
+
+	wait.Wait()
+}

--- a/_fixtures/bpcountstest.go
+++ b/_fixtures/bpcountstest.go
@@ -11,7 +11,7 @@ func demo(id int, wait *sync.WaitGroup) {
 	for i := 0; i < 100; i++ {
 		sleep := rand.Intn(10) + 1
 		fmt.Printf("id: %d step: %d sleeping %d\n", id, i, sleep)
-		time.Sleep(time.Duration(sleep) *  time.Millisecond)
+		time.Sleep(time.Duration(sleep) * time.Millisecond)
 	}
 
 	wait.Done()

--- a/_fixtures/issue262.go
+++ b/_fixtures/issue262.go
@@ -1,0 +1,16 @@
+package main
+
+import "fmt"
+
+func typicalFunction() (res int) {
+	defer func() {
+		res = 2
+		return
+	}()
+	res = 10
+	return // setup breakpoint here
+}
+
+func main() {
+	fmt.Println(typicalFunction())
+}

--- a/cmd/dlv/main.go
+++ b/cmd/dlv/main.go
@@ -193,18 +193,23 @@ starts and attaches to it, and enables you to immediately begin debugging your p
 							fmt.Fprintln(os.Stderr, state.Err)
 							return 0
 						}
-						var args []string
-						var fname string
-						if state.CurrentThread != nil && state.CurrentThread.Function != nil {
-							fname = state.CurrentThread.Function.Name
-						}
-						if state.BreakpointInfo != nil {
-							for _, arg := range state.BreakpointInfo.Arguments {
-								args = append(args, arg.SinglelineString())
+						for i := range state.Threads {
+							th := state.Threads[i]
+							if th.Breakpoint == nil {
+								continue
 							}
+							var args []string
+							var fname string
+							if th.Function != nil {
+								fname = th.Function.Name
+							}
+							if th.BreakpointInfo != nil {
+								for _, arg := range th.BreakpointInfo.Arguments {
+									args = append(args, arg.SinglelineString())
+								}
+							}
+							fmt.Printf("%s(%s) %s:%d\n", fname, strings.Join(args, ", "), terminal.ShortenFilePath(th.File), th.Line)
 						}
-						fp := terminal.ShortenFilePath(state.CurrentThread.File)
-						fmt.Printf("%s(%s) %s:%d\n", fname, strings.Join(args, ", "), fp, state.CurrentThread.Line)
 					case <-sigChan:
 						server.Stop(traceAttachPid == 0)
 						return 1

--- a/proc/proc.go
+++ b/proc/proc.go
@@ -389,20 +389,8 @@ func (dbp *Process) runBreakpointConditions() error {
 
 // Resume process, does not evaluate breakpoint conditionals
 func (dbp *Process) continueOnce() error {
-	// all threads stopped over a breakpoint are made to step over it
-	for _, thread := range dbp.Threads {
-		if thread.CurrentBreakpoint != nil {
-			if err := thread.Step(); err != nil {
-				return err
-			}
-			thread.CurrentBreakpoint = nil
-		}
-	}
-	// everything is resumed
-	for _, thread := range dbp.Threads {
-		if err := thread.resume(); err != nil {
-			return dbp.exitGuard(err)
-		}
+	if err := dbp.resume(); err != nil {
+		return err
 	}
 	return dbp.run(func() error {
 		thread, err := dbp.trapWait(-1)

--- a/proc/proc.go
+++ b/proc/proc.go
@@ -746,6 +746,10 @@ func (dbp *Process) getGoInformation() (ver GoVersion, isextld bool, err error) 
 		err = fmt.Errorf("Could not determine version number: %v\n", err)
 		return
 	}
+	if vv.Unreadable != nil {
+		err = fmt.Errorf("Unreadable version number: %v\n", vv.Unreadable)
+		return
+	}
 
 	ver, ok := parseVersionString(constant.StringVal(vv.Value))
 	if !ok {

--- a/proc/proc.go
+++ b/proc/proc.go
@@ -388,13 +388,8 @@ func (dbp *Process) Continue() error {
 			return dbp.exitGuard(err)
 		}
 		dbp.SwitchThread(thread.Id)
-		for _, th := range dbp.Threads {
-			if th.CurrentBreakpoint == nil {
-				err := th.SetCurrentBreakpoint()
-				if err != nil {
-					return err
-				}
-			}
+		if err := dbp.setExtraBreakpoints(); err != nil {
+			return err
 		}
 		loc, err := thread.Location()
 		if err != nil {

--- a/proc/proc_darwin.c
+++ b/proc/proc_darwin.c
@@ -127,7 +127,7 @@ mach_port_wait(mach_port_t port_set, int nonblocking) {
 
 	// Wait for mach msg.
 	kret = mach_msg(&msg.hdr, opts,
-			0, sizeof(msg.data), port_set, 0, MACH_PORT_NULL);
+			0, sizeof(msg.data), port_set, 10, MACH_PORT_NULL);
 	if (kret == MACH_RCV_INTERRUPTED) return kret;
 	if (kret != MACH_MSG_SUCCESS) return 0;
 

--- a/proc/proc_darwin.c
+++ b/proc/proc_darwin.c
@@ -76,7 +76,7 @@ find_executable(int pid) {
 }
 
 kern_return_t
-get_threads(task_t task, void *slice) {
+get_threads(task_t task, void *slice, int limit) {
 	kern_return_t kret;
 	thread_act_array_t list;
 	mach_msg_type_number_t count;
@@ -84,6 +84,11 @@ get_threads(task_t task, void *slice) {
 	kret = task_threads(task, &list, &count);
 	if (kret != KERN_SUCCESS) {
 		return kret;
+	}
+
+	if (count > limit) {
+		vm_deallocate(mach_task_self(), (vm_address_t) list, count * sizeof(list[0]));
+		return -2;
 	}
 
 	memcpy(slice, (void*)list, count*sizeof(list[0]));

--- a/proc/proc_darwin.go
+++ b/proc/proc_darwin.go
@@ -327,3 +327,7 @@ func (dbp *Process) wait(pid, options int) (int, *sys.WaitStatus, error) {
 	wpid, err := sys.Wait4(pid, &status, options, nil)
 	return wpid, &status, err
 }
+
+func (dbp *Process) exitGuard(err error) error {
+	return err
+}

--- a/proc/proc_darwin.go
+++ b/proc/proc_darwin.go
@@ -329,5 +329,13 @@ func (dbp *Process) wait(pid, options int) (int, *sys.WaitStatus, error) {
 }
 
 func (dbp *Process) exitGuard(err error) error {
+	if err != ErrContinueThread {
+		return err
+	}
+	_, status, werr := dbp.wait(dbp.Pid, sys.WNOHANG)
+	if werr == nil && status.Exited() {
+		dbp.postExit()
+		return ProcessExitedError{Pid: dbp.Pid, Status: status.ExitStatus()}
+	}
 	return err
 }

--- a/proc/proc_darwin.go
+++ b/proc/proc_darwin.go
@@ -354,3 +354,22 @@ func (dbp *Process) exitGuard(err error) error {
 	}
 	return err
 }
+
+func (dbp *Process) resume() error {
+	// all threads stopped over a breakpoint are made to step over it
+	for _, thread := range dbp.Threads {
+		if thread.CurrentBreakpoint != nil {
+			if err := thread.Step(); err != nil {
+				return err
+			}
+			thread.CurrentBreakpoint = nil
+		}
+	}
+	// everything is resumed
+	for _, thread := range dbp.Threads {
+		if err := thread.resume(); err != nil {
+			return dbp.exitGuard(err)
+		}
+	}
+	return nil
+}

--- a/proc/proc_darwin.go
+++ b/proc/proc_darwin.go
@@ -78,7 +78,7 @@ func Launch(cmd []string) (*Process, error) {
 	if err != nil {
 		return nil, err
 	}
-	err = dbp.Continue()
+	err = dbp.continueOnce()
 	return dbp, err
 }
 

--- a/proc/proc_darwin.h
+++ b/proc/proc_darwin.h
@@ -36,7 +36,7 @@ int
 thread_count(task_t task);
 
 mach_port_t
-mach_port_wait(mach_port_t);
+mach_port_wait(mach_port_t, int);
 
 kern_return_t
 mach_send_reply(mach_msg_header_t);

--- a/proc/proc_darwin.h
+++ b/proc/proc_darwin.h
@@ -30,7 +30,7 @@ char *
 find_executable(int pid);
 
 kern_return_t
-get_threads(task_t task, void *);
+get_threads(task_t task, void *data,int limit);
 
 int
 thread_count(task_t task);
@@ -43,4 +43,3 @@ mach_send_reply(mach_msg_header_t);
 
 kern_return_t
 raise_exception(mach_port_t, mach_port_t, mach_port_t, exception_type_t);
-

--- a/proc/proc_linux.go
+++ b/proc/proc_linux.go
@@ -377,3 +377,15 @@ func (dbp *Process) wait(pid, options int) (int, *sys.WaitStatus, error) {
 		}
 	}
 }
+
+func (dbp *Process) exitGuard(err error) error {
+	if err != sys.ESRCH {
+		return err
+	}
+	if status(dbp.Pid, dbp.os.comm) == STATUS_ZOMBIE {
+		_, err := dbp.trapWait(-1)
+		return err
+	}
+
+	return err
+}

--- a/proc/proc_linux.go
+++ b/proc/proc_linux.go
@@ -378,6 +378,18 @@ func (dbp *Process) wait(pid, options int) (int, *sys.WaitStatus, error) {
 	}
 }
 
+func (dbp *Process) setExtraBreakpoints() error {
+	for _, th := range dbp.Threads {
+		if th.CurrentBreakpoint == nil {
+			err := th.SetCurrentBreakpoint()
+			if err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}
+
 func (dbp *Process) exitGuard(err error) error {
 	if err != sys.ESRCH {
 		return err

--- a/proc/proc_linux.go
+++ b/proc/proc_linux.go
@@ -303,7 +303,7 @@ func (dbp *Process) trapWait(pid int) (*Thread, error) {
 		}
 		if status.StopSignal() == sys.SIGTRAP {
 			th.running = false
-			return dbp.handleBreakpointOnThread(wpid)
+			return th, nil
 		}
 		if th != nil {
 			// TODO(dp) alert user about unexpected signals here.
@@ -380,7 +380,7 @@ func (dbp *Process) wait(pid, options int) (int, *sys.WaitStatus, error) {
 	}
 }
 
-func (dbp *Process) setExtraBreakpoints() error {
+func (dbp *Process) setCurrentBreakpoints(trapthread *Thread) error {
 	for _, th := range dbp.Threads {
 		if th.CurrentBreakpoint == nil {
 			err := th.SetCurrentBreakpoint()

--- a/proc/threads.go
+++ b/proc/threads.go
@@ -17,9 +17,10 @@ import (
 // a whole, and Status represents the last result of a `wait` call
 // on this thread.
 type Thread struct {
-	Id                int             // Thread ID or mach port
-	Status            *sys.WaitStatus // Status returned from last wait call
-	CurrentBreakpoint *Breakpoint     // Breakpoint thread is currently stopped at
+	Id                     int             // Thread ID or mach port
+	Status                 *sys.WaitStatus // Status returned from last wait call
+	CurrentBreakpoint      *Breakpoint     // Breakpoint thread is currently stopped at
+	BreakpointConditionMet bool            // Output of evaluating the breakpoint's condition
 
 	dbp            *Process
 	singleStepping bool
@@ -331,4 +332,12 @@ func (thread *Thread) SetCurrentBreakpoint() error {
 		thread.CurrentBreakpoint.TotalHitCount++
 	}
 	return nil
+}
+
+func (th *Thread) onTriggeredBreakpoint() bool {
+	return (th.CurrentBreakpoint != nil) && th.BreakpointConditionMet
+}
+
+func (th *Thread) onTriggeredTempBreakpoint() bool {
+	return th.onTriggeredBreakpoint() && th.CurrentBreakpoint.Temp
 }

--- a/proc/threads.go
+++ b/proc/threads.go
@@ -313,3 +313,22 @@ func (thread *Thread) Scope() (*EvalScope, error) {
 	}
 	return locations[0].Scope(thread), nil
 }
+
+func (thread *Thread) SetCurrentBreakpoint() error {
+	thread.CurrentBreakpoint = nil
+	pc, err := thread.PC()
+	if err != nil {
+		return err
+	}
+	if bp, ok := thread.dbp.FindBreakpoint(pc); ok {
+		thread.CurrentBreakpoint = bp
+		if err = thread.SetPC(bp.Addr); err != nil {
+			return err
+		}
+		if g, err := thread.GetG(); err == nil {
+			thread.CurrentBreakpoint.HitCount[g.Id]++
+		}
+		thread.CurrentBreakpoint.TotalHitCount++
+	}
+	return nil
+}

--- a/proc/threads_darwin.c
+++ b/proc/threads_darwin.c
@@ -135,3 +135,36 @@ thread_blocked(thread_act_t thread) {
 
 	return info.suspend_count;
 }
+
+int
+num_running_threads(task_t task) {
+	kern_return_t kret;
+	thread_act_array_t list;
+	mach_msg_type_number_t count;
+	int i, n = 0;
+
+	kret = task_threads(task, &list, &count);
+	if (kret != KERN_SUCCESS) {
+		return -kret;
+	}
+
+	for (i = 0; i < count; ++i) {
+		thread_act_t thread = list[i];
+		struct thread_basic_info info;
+		unsigned int info_count = THREAD_BASIC_INFO_COUNT;
+
+		kret = thread_info((thread_t)thread, THREAD_BASIC_INFO, (thread_info_t)&info, &info_count);
+
+		if (kret == KERN_SUCCESS) {
+			if (info.suspend_count == 0) {
+				++n;
+			} else {
+			}
+		}
+	}
+
+	kret = vm_deallocate(mach_task_self(), (vm_address_t) list, count * sizeof(list[0]));
+	if (kret != KERN_SUCCESS) return -kret;
+
+	return n;
+}

--- a/proc/threads_darwin.go
+++ b/proc/threads_darwin.go
@@ -31,7 +31,7 @@ func (t *Thread) singleStep() error {
 		return fmt.Errorf("could not single step")
 	}
 	for {
-		port := C.mach_port_wait(t.dbp.os.portSet)
+		port := C.mach_port_wait(t.dbp.os.portSet, C.int(0))
 		if port == C.mach_port_t(t.Id) {
 			break
 		}

--- a/proc/threads_darwin.h
+++ b/proc/threads_darwin.h
@@ -33,3 +33,6 @@ get_identity(mach_port_name_t, thread_identifier_info_data_t *);
 
 int
 thread_blocked(thread_act_t thread);
+
+int
+num_running_threads(task_t task);

--- a/service/api/conversions.go
+++ b/service/api/conversions.go
@@ -50,7 +50,7 @@ func ConvertThread(th *proc.Thread) *Thread {
 
 	var bp *Breakpoint
 
-	if th.CurrentBreakpoint != nil {
+	if th.CurrentBreakpoint != nil && th.BreakpointConditionMet {
 		bp = ConvertBreakpoint(th.CurrentBreakpoint)
 	}
 

--- a/service/api/conversions.go
+++ b/service/api/conversions.go
@@ -37,6 +37,7 @@ func ConvertThread(th *proc.Thread) *Thread {
 		file     string
 		line     int
 		pc       uint64
+		gid      int
 	)
 
 	loc, err := th.Location()
@@ -47,12 +48,24 @@ func ConvertThread(th *proc.Thread) *Thread {
 		function = ConvertFunction(loc.Fn)
 	}
 
+	var bp *Breakpoint
+
+	if th.CurrentBreakpoint != nil {
+		bp = ConvertBreakpoint(th.CurrentBreakpoint)
+	}
+
+	if g, _ := th.GetG(); g != nil {
+		gid = g.Id
+	}
+
 	return &Thread{
-		ID:       th.Id,
-		PC:       pc,
-		File:     file,
-		Line:     line,
-		Function: function,
+		ID:          th.Id,
+		PC:          pc,
+		File:        file,
+		Line:        line,
+		Function:    function,
+		GoroutineID: gid,
+		Breakpoint:  bp,
 	}
 }
 

--- a/service/api/types.go
+++ b/service/api/types.go
@@ -4,19 +4,15 @@ import "reflect"
 
 // DebuggerState represents the current context of the debugger.
 type DebuggerState struct {
-	// Breakpoint is the current breakpoint at which the debugged process is
-	// suspended, and may be empty if the process is not suspended.
-	Breakpoint *Breakpoint `json:"breakPoint,omitempty"`
 	// CurrentThread is the currently selected debugger thread.
 	CurrentThread *Thread `json:"currentThread,omitempty"`
 	// SelectedGoroutine is the currently selected goroutine
 	SelectedGoroutine *Goroutine `json:"currentGoroutine,omitempty"`
-	// Information requested by the current breakpoint
-	BreakpointInfo *BreakpointInfo `json:"breakPointInfo,omitrempty"`
+	// List of all the process threads
+	Threads []*Thread
 	// Exited indicates whether the debugged process has exited.
 	Exited     bool `json:"exited"`
 	ExitStatus int  `json:"exitStatus"`
-
 	// Filled by RPCClient.Continue, indicates an error
 	Err error `json:"-"`
 }
@@ -62,6 +58,14 @@ type Thread struct {
 	Line int `json:"line"`
 	// Function is function information at the program counter. May be nil.
 	Function *Function `json:"function,omitempty"`
+
+	// ID of the goroutine running on this thread
+	GoroutineID int `json:"goroutineID"`
+
+	// Breakpoint this thread is stopped at
+	Breakpoint *Breakpoint `json:"breakPoint,omitempty"`
+	// Informations requested by the current breakpoint
+	BreakpointInfo *BreakpointInfo `json:"breakPointInfo,omitrempty"`
 }
 
 type Location struct {

--- a/service/debugger/debugger.go
+++ b/service/debugger/debugger.go
@@ -165,6 +165,7 @@ func (d *Debugger) CreateBreakpoint(requestedBp *api.Breakpoint) (*api.Breakpoin
 	bp.Goroutine = requestedBp.Goroutine
 	bp.Stacktrace = requestedBp.Stacktrace
 	bp.Variables = requestedBp.Variables
+	bp.Cond = -1
 	createdBp = api.ConvertBreakpoint(bp)
 	log.Printf("created breakpoint: %#v", createdBp)
 	return createdBp, nil

--- a/service/test/integration_test.go
+++ b/service/test/integration_test.go
@@ -96,7 +96,7 @@ func TestRestart_duringStop(t *testing.T) {
 			t.Fatal(err)
 		}
 		state := <-c.Continue()
-		if state.Breakpoint == nil {
+		if state.CurrentThread.Breakpoint == nil {
 			t.Fatal("did not hit breakpoint")
 		}
 		if err := c.Restart(); err != nil {
@@ -433,12 +433,12 @@ func TestClientServer_traceContinue(t *testing.T) {
 		count := 0
 		contChan := c.Continue()
 		for state := range contChan {
-			if state.Breakpoint != nil {
+			if state.CurrentThread != nil && state.CurrentThread.Breakpoint != nil {
 				count++
 
 				t.Logf("%v", state)
 
-				bpi := state.BreakpointInfo
+				bpi := state.CurrentThread.BreakpointInfo
 
 				if bpi.Goroutine == nil {
 					t.Fatalf("No goroutine information")
@@ -494,8 +494,8 @@ func TestClientServer_traceContinue2(t *testing.T) {
 		countSayhi := 0
 		contChan := c.Continue()
 		for state := range contChan {
-			if state.Breakpoint != nil {
-				switch state.Breakpoint.ID {
+			if state.CurrentThread != nil && state.CurrentThread.Breakpoint != nil {
+				switch state.CurrentThread.Breakpoint.ID {
 				case bp1.ID:
 					countMain++
 				case bp2.ID:


### PR DESCRIPTION
This is a fix for the problem unearthed by PR #255, it is submitted for discussion, not definitive.

There are two problems with `(*Process).Continue`

1. The first is that between the time one breakpoint is triggered and the point where we loop over all threads and `Halt` eacho one the second goroutine may hit the breakpoint too, this second hit gets lost
2. The second problem is that the way `Continue` resumes the process has a race condition with the tracee

Let's that thread A hit the breakpoint and thread B was sleeping when `Continue` called `Halt` on it. After we finish processing the breakpoint on A we call `Continue` again, `Continue` then loops through all threads, it calls `resume` on B, then moves onto thread A, sees that it's on a breakpoint so it calls `(*Thread).Step()`.
If thread B happens to get to the breakpoint while `(*Thread).Step` on thread A is happening the breakpoint gets skipped, because we temporarily cleared it.

You can test this by reverting the changes and running `TestBreakpointCounts`. The fact that multiple breakpoints can be hit simultaneously needs to be propagated all the way to the client, either by changing CurrentBreakpoint in State to a slice or by returning one breakpoint at a time in Debugger.