### PR TITLE
proc/variables: Support for embedded structs

### DIFF
--- a/_fixtures/testvariables4.go
+++ b/_fixtures/testvariables4.go
@@ -1,0 +1,33 @@
+package main
+
+import (
+    "fmt"
+    "runtime"
+)
+
+type A struct {
+    val int
+}
+
+type C struct {
+	s string
+}
+
+type B struct {
+    A
+	*C
+    a   A
+    ptr *A
+}
+
+func main() {
+    b  := B{A: A{-314}, C: &C{"hello"}, a: A{42}, ptr: &A{1337}}
+    fmt.Println(b)
+    fmt.Println(b.val)
+    fmt.Println(b.A.val)
+    fmt.Println(b.a.val)
+    fmt.Println(b.ptr.val)
+    fmt.Println(b.C.s)
+    fmt.Println(b.s)
+    runtime.Breakpoint()
+}

--- a/_fixtures/testvariables4.go
+++ b/_fixtures/testvariables4.go
@@ -22,6 +22,7 @@ type B struct {
 
 func main() {
     b  := B{A: A{-314}, C: &C{"hello"}, a: A{42}, ptr: &A{1337}}
+    runtime.Breakpoint()
     fmt.Println(b)
     fmt.Println(b.val)
     fmt.Println(b.A.val)
@@ -29,5 +30,4 @@ func main() {
     fmt.Println(b.ptr.val)
     fmt.Println(b.C.s)
     fmt.Println(b.s)
-    runtime.Breakpoint()
 }

--- a/proc/variables.go
+++ b/proc/variables.go
@@ -127,7 +127,12 @@ func newVariable(name string, addr uintptr, dwarfType dwarf.Type, thread *Thread
 func (v *Variable) toField(field *dwarf.StructField) (*Variable, error) {
 	name := ""
 	if v.Name != "" {
-		name = fmt.Sprintf("%s.%s", v.Name, field.Name)
+		parts := strings.Split(field.Name, ".")
+		if len(parts) > 1 {
+			name = fmt.Sprintf("%s.%s", v.Name, parts[1])
+		} else {
+			name = fmt.Sprintf("%s.%s", v.Name, field.Name)	
+		}
 	}
 	return newVariable(name, uintptr(int64(v.Addr)+field.ByteOffset), field.Type, v.thread)
 }
@@ -442,6 +447,13 @@ func (scope *EvalScope) packageVarAddr(name string) (*Variable, error) {
 	return nil, fmt.Errorf("could not find symbol value for %s", name)
 }
 
+func (v *Variable) toFieldNilChecked(field *dwarf.StructField, name string) (*Variable, error) {
+	if v.Addr == 0 {
+		return nil, fmt.Errorf("%s is nil", name)
+	}
+	return v.toField(field)
+}
+
 func (v *Variable) structMember(memberName string) (*Variable, error) {
 	structVar, err := v.maybeDereference()
 	structVar.Name = v.Name
@@ -449,17 +461,44 @@ func (v *Variable) structMember(memberName string) (*Variable, error) {
 		return nil, err
 	}
 	structVar = structVar.resolveTypedefs()
-
 	switch t := structVar.dwarfType.(type) {
 	case *dwarf.StructType:
 		for _, field := range t.Field {
 			if field.Name != memberName {
 				continue
 			}
-			if structVar.Addr == 0 {
-				return nil, fmt.Errorf("%s is nil", v.Name)
+			return structVar.toFieldNilChecked(field, v.Name)
+		}
+		// Check for embedded field only if field was
+		// not a regular struct member
+		for _, field := range t.Field {
+			isEmbeddedStructMember :=
+				(field.Type.String() == ("struct " + field.Name)) ||
+				(len(field.Name) > 1 &&
+					field.Name[0] == '*' &&
+					field.Type.String()[1:] == ("struct " + field.Name[1:]))
+			if !isEmbeddedStructMember {
+				continue
 			}
-			return structVar.toField(field)
+			// Check for embedded field referenced by type name
+			parts := strings.Split(field.Name, ".")
+			if len(parts) > 1 && parts[1] == memberName {
+				embeddedVar, err := structVar.toFieldNilChecked(field, v.Name)
+				if err != nil {
+					return nil, err
+				}
+				return embeddedVar, nil
+			}
+			// Recursively check for promoted fields on the embedded field
+			embeddedVar, err := structVar.toFieldNilChecked(field, v.Name)
+			if err != nil {
+				return nil, err
+			}
+			embeddedVar.Name = structVar.Name
+			embeddedField, err := embeddedVar.structMember(memberName)
+			if embeddedField != nil {
+				return embeddedField, nil
+			}
 		}
 		return nil, fmt.Errorf("%s has no member %s", v.Name, memberName)
 	default:

--- a/proc/variables_test.go
+++ b/proc/variables_test.go
@@ -391,3 +391,29 @@ func TestPointerSetting(t *testing.T) {
 		pval("*5")
 	})
 }
+
+func TestEmbeddedStruct(t *testing.T) {
+	withTestProcess("testvariables4", t, func(p *Process, fixture protest.Fixture) {
+		testcases := []varTest{
+			{"b.val", "-314", "", "int", nil},
+			{"b.A.val", "-314", "", "int", nil},
+			{"b.a.val", "42", "", "int", nil},
+			{"b.ptr.val", "1337", "", "int", nil},
+			{"b.C.s", "hello", "", "struct string", nil},
+			{"b.s", "hello", "", "struct string", nil},
+		}
+		assertNoError(p.Continue(), t, "Continue()")
+
+		for _, tc := range testcases {
+			variable, err := evalVariable(p, tc.name)
+			if tc.err == nil {
+				assertNoError(err, t, "EvalVariable() returned an error")
+				assertVariable(t, variable, tc)
+			} else {
+				if tc.err.Error() != err.Error() {
+					t.Fatalf("Unexpected error. Expected %s got %s", tc.err.Error(), err.Error())
+				}
+			}
+		}
+	})
+}


### PR DESCRIPTION
Embedded structs are encoded in DWARF as fields with
package-qualified names.  They define an anonymous field
on the struct with the non-qualified name, as well as
promoted fields for each field of the embedded struct so
long as these are not shadowed by fields of the containing
struct.

Fixes #220.