### PR TITLE
proc/variables: chanRecvReturnAddress uses outdated frame info

### DIFF
--- a/proc/variables.go
+++ b/proc/variables.go
@@ -152,7 +152,7 @@ func (g *G) ChanRecvBlocked() bool {
 
 // chanRecvReturnAddr returns the address of the return from a channel read.
 func (g *G) chanRecvReturnAddr(dbp *Process) (uint64, error) {
-	locs, err := dbp.stacktrace(g.PC, g.SP, 4)
+	locs, err := dbp.GoroutineStacktrace(g, 4)
 	if err != nil {
 		return 0, err
 	}


### PR DESCRIPTION
I noticed `next` was giving me an 'input/output error' on a specific point on one of my programs, it turns out it was because `chanRecvReturnAddress` was using `g.SP` instead of the `SP` register from the thread.
