### PR TITLE
terminal: correct CSI sequence in (*Term).Println

### DIFF
--- a/terminal/terminal.go
+++ b/terminal/terminal.go
@@ -17,7 +17,7 @@ import (
 const (
 	historyFile             string = ".dbg_history"
 	TerminalBlueEscapeCode  string = "\033[34m"
-	TerminalWhiteEscapeCode string = "\033[37m"
+	TerminalResetEscapeCode string = "\033[0m"
 )
 
 type Term struct {
@@ -127,7 +127,7 @@ func (t *Term) Run() (error, int) {
 
 func (t *Term) Println(prefix, str string) {
 	if !t.dumb {
-		prefix = fmt.Sprintf("%s%s%s", TerminalBlueEscapeCode, prefix, TerminalWhiteEscapeCode)
+		prefix = fmt.Sprintf("%s%s%s", TerminalBlueEscapeCode, prefix, TerminalResetEscapeCode)
 	}
 	fmt.Printf("%s%s\n", prefix, str)
 }


### PR DESCRIPTION
`<esc>[0m` (reset) should be used instead of `<esc>[37m` (set foreground
color to white)

Before:
![before](http://i.imgur.com/zgUyGhM.png)

After:
![after](http://i.imgur.com/hHW6d6K.png)