### PR TITLE
Fix 2 x panic: runtime error: index out of range

### DIFF
--- a/cmd/dlv/main.go
+++ b/cmd/dlv/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"errors"
 	"fmt"
 	"net"
 	"os"
@@ -106,6 +107,12 @@ starts and attaches to it, and enables you to immediately begin debugging your p
 	execCommand := &cobra.Command{
 		Use:   "exec [./path/to/binary]",
 		Short: "Runs precompiled binary, attaches and begins debug session.",
+		PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
+			if len(args) == 0 {
+				return errors.New("you must provide a path to a binary")
+			}
+			return nil
+		},
 		Run: func(cmd *cobra.Command, args []string) {
 			os.Exit(execute(0, args, conf))
 		},
@@ -239,6 +246,12 @@ starts and attaches to it, and enable you to immediately begin debugging your pr
 		Use:   "attach [pid]",
 		Short: "Attach to running process and begin debugging.",
 		Long:  "Attach to running process and begin debugging.",
+		PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
+			if len(args) == 0 {
+				return errors.New("you must provide a PID")
+			}
+			return nil
+		},
 		Run: func(cmd *cobra.Command, args []string) {
 			pid, err := strconv.Atoi(args[0])
 			if err != nil {


### PR DESCRIPTION
```
/Users/quentinperez/go/src/github.com/derekparker/delve/proc/proc_darwin.go:39 +0x8ad
/Users/quentinperez/go/src/github.com/derekparker/delve/service/debugger/debugger.go:57 +0x37d
```

```
/Users/quentinperez/go/src/github.com/derekparker/delve/cmd/dlv/main.go:243 +0x264
```