### PR TITLE
terminal,proc: Improved goroutine printing

### DIFF
--- a/proc/proc.go
+++ b/proc/proc.go
@@ -488,9 +488,7 @@ func (dbp *Process) GoroutinesInfo() ([]*G, error) {
 			}
 			g.thread = thread
 			// Prefer actual thread location information.
-			g.File = loc.File
-			g.Line = loc.Line
-			g.Func = loc.Fn
+			g.Current = *loc
 		}
 		if g.Status != Gdead {
 			allg = append(allg, g)

--- a/service/api/conversions.go
+++ b/service/api/conversions.go
@@ -81,11 +81,10 @@ func ConvertFunction(fn *gosym.Func) *Function {
 // convertGoroutine converts an internal Goroutine to an API Goroutine.
 func ConvertGoroutine(g *proc.G) *Goroutine {
 	return &Goroutine{
-		ID:       g.Id,
-		PC:       g.PC,
-		File:     g.File,
-		Line:     g.Line,
-		Function: ConvertFunction(g.Func),
+		ID:          g.Id,
+		Current:     ConvertLocation(g.Current),
+		UserCurrent: ConvertLocation(g.UserCurrent()),
+		Go:          ConvertLocation(g.Go()),
 	}
 }
 

--- a/service/api/types.go
+++ b/service/api/types.go
@@ -114,14 +114,12 @@ type Variable struct {
 type Goroutine struct {
 	// ID is a unique identifier for the goroutine.
 	ID int `json:"id"`
-	// PC is the current program counter for the goroutine.
-	PC uint64 `json:"pc"`
-	// File is the file for the program counter.
-	File string `json:"file"`
-	// Line is the line number for the program counter.
-	Line int `json:"line"`
-	// Function is function information at the program counter. May be nil.
-	Function *Function `json:"function,omitempty"`
+	// Current location of the goroutine
+	Current Location
+	// Current location of the goroutine, excluding calls inside runtime
+	UserCurrent Location
+	// Location of the go instruction that started this goroutine
+	Go Location
 }
 
 // DebuggerCommand is a command which changes the debugger's execution state.


### PR DESCRIPTION
Three locations are returned for goroutines: its current location,
its current location excluding unexported runtime functions and
the location of its go instruction.
The command 'goroutines' takes a new parameter to select which
location to print (defaulting to current location w/o runtime)