### PR TITLE
RFC: Introduce structured variable values

### DIFF
--- a/proc/variables.go
+++ b/proc/variables.go
@@ -28,12 +28,13 @@ const (
 
 // Represents a variable.
 type Variable struct {
-	Addr      uintptr
-	Name      string
-	Value     string
-	Type      string
-	dwarfType dwarf.Type
-	thread    *Thread
+	Addr        uintptr
+	Name        string
+	Value       string
+	ValueObject interface{}
+	Type        string
+	dwarfType   dwarf.Type
+	thread      *Thread
 
 	Len       int64
 	Cap       int64
@@ -540,31 +541,35 @@ func (v *Variable) resolveTypedefs() *Variable {
 
 // Extracts the value of the variable at the given address.
 func (v *Variable) loadValue(printStructName bool) (err error) {
-	v.Value, err = v.loadValueInternal(printStructName, 0)
-	return
+	val, err := v.loadValueInternal(0)
+	if err != nil {
+		return err
+	}
+	v.Value = fmt.Sprintf("%s", val)
+	v.ValueObject = val
+	return nil
 }
 
-func (v *Variable) loadValueInternal(printStructName bool, recurseLevel int) (string, error) {
+func (v *Variable) loadValueInternal(recurseLevel int) (interface{}, error) {
 	v = v.resolveTypedefs()
 
 	switch t := v.dwarfType.(type) {
 	case *dwarf.PtrType:
 		ptrv, err := v.maybeDereference()
 		if err != nil {
-			return "", err
+			return nil, err
 		}
 
 		if ptrv.Addr == 0 {
-			return fmt.Sprintf("%s nil", t.String()), nil
+			return nil, nil
 		}
 
 		// Don't increase the recursion level when dereferencing pointers
-		val, err := ptrv.loadValueInternal(printStructName, recurseLevel)
+		derefed, err := ptrv.loadValueInternal(recurseLevel)
 		if err != nil {
-			return "", err
+			return nil, err
 		}
-
-		return fmt.Sprintf("*%s", val), nil
+		return derefed, nil
 	case *dwarf.StructType:
 		switch {
 		case t.StructName == "string":
@@ -576,38 +581,39 @@ func (v *Variable) loadValueInternal(printStructName bool, recurseLevel int) (st
 			// the value of all the members of the struct.
 			if recurseLevel <= maxVariableRecurse {
 				errcount := 0
-				fields := make([]string, 0, len(t.Field))
+				fields := map[string]interface{}{}
 				for i, field := range t.Field {
 					var (
 						err      error
-						val      string
+						val      interface{}
 						fieldvar *Variable
 					)
 
 					fieldvar, err = v.toField(field)
 					if err == nil {
-						val, err = fieldvar.loadValueInternal(printStructName, recurseLevel+1)
+						val, err = fieldvar.loadValueInternal(recurseLevel + 1)
 					}
 					if err != nil {
 						errcount++
 						val = fmt.Sprintf("<unreadable: %s>", err.Error())
 					}
 
-					fields = append(fields, fmt.Sprintf("%s: %s", field.Name, val))
+					fields[field.Name] = val
 
 					if errcount > maxErrCount {
-						fields = append(fields, fmt.Sprintf("...+%d more", len(t.Field)-i))
+						fields[field.Name] = fmt.Sprintf("...+%d more", len(t.Field)-i)
 					}
 				}
-				if printStructName {
-					return fmt.Sprintf("%s {%s}", t.StructName, strings.Join(fields, ", ")), nil
-				}
-				return fmt.Sprintf("{%s}", strings.Join(fields, ", ")), nil
+				// if printStructName {
+				// 	return fmt.Sprintf("%s {%s}", t.StructName, strings.Join(fields, ", ")), nil
+				// }
+				//return fmt.Sprintf("{%s}", strings.Join(fields, ", ")), nil
+				return fields, nil
 			}
 			// no fields
-			if printStructName {
-				return fmt.Sprintf("%s {...}", t.StructName), nil
-			}
+			// if printStructName {
+			// 	return fmt.Sprintf("%s {...}", t.StructName), nil
+			// }
 			return "{...}", nil
 		}
 	case *dwarf.ArrayType:
@@ -632,7 +638,7 @@ func (v *Variable) loadValueInternal(printStructName bool, recurseLevel int) (st
 		fmt.Printf("Unknown type: %T\n", t)
 	}
 
-	return "", fmt.Errorf("could not find value for type %s", v.dwarfType)
+	return nil, fmt.Errorf("could not find value for type %s", v.dwarfType)
 }
 
 func (v *Variable) setValue(value string) error {
@@ -746,8 +752,8 @@ func (v *Variable) loadSliceInfo(t *dwarf.StructType) error {
 	return nil
 }
 
-func (v *Variable) loadArrayValues(recurseLevel int) (string, error) {
-	vals := make([]string, 0)
+func (v *Variable) loadArrayValues(recurseLevel int) ([]interface{}, error) {
+	vals := make([]interface{}, 0)
 	errcount := 0
 
 	for i := int64(0); i < v.Len; i++ {
@@ -757,10 +763,10 @@ func (v *Variable) loadArrayValues(recurseLevel int) (string, error) {
 			break
 		}
 
-		var val string
+		var val interface{}
 		fieldvar, err := newVariable("", uintptr(int64(v.base)+(i*v.stride)), v.fieldType, v.thread)
 		if err == nil {
-			val, err = fieldvar.loadValueInternal(false, recurseLevel+1)
+			val, err = fieldvar.loadValueInternal(recurseLevel + 1)
 		}
 		if err != nil {
 			errcount++
@@ -774,11 +780,13 @@ func (v *Variable) loadArrayValues(recurseLevel int) (string, error) {
 		}
 	}
 
-	if v.Cap < 0 {
-		return fmt.Sprintf("%s [%s]", v.dwarfType, strings.Join(vals, ",")), nil
-	} else {
-		return fmt.Sprintf("[]%s len: %d, cap: %d, [%s]", v.fieldType, v.Len, v.Cap, strings.Join(vals, ",")), nil
-	}
+	// TODO: what's this for?
+	// if v.Cap < 0 {
+	// 	vals = append(vals, fmt.Sprintf("%s [%s]", v.dwarfType, strings.Join(vals, ",")))
+	// } else {
+	// 	vals = append(vals, fmt.Sprintf("[]%s len: %d, cap: %d, [%s]", v.fieldType, v.Len, v.Cap, strings.Join(vals, ",")))
+	// }
+	return vals, nil
 }
 
 func (v *Variable) readComplex(size int64) (string, error) {

--- a/service/api/conversions.go
+++ b/service/api/conversions.go
@@ -49,10 +49,25 @@ func ConvertThread(th *proc.Thread) *Thread {
 
 // convertVar converts an internal variable to an API Variable.
 func ConvertVar(v *proc.Variable) Variable {
+	obj := ValueObject{}
+	switch val := v.ValueObject.(type) {
+	case map[string]interface{}:
+		obj.Type = "Map"
+		obj.Map = &val
+	case string:
+		obj.Type = "String"
+		obj.String = &val
+	case []interface{}:
+		obj.Type = "Array"
+		obj.Array = &val
+	default:
+		obj.Type = "Unknown"
+	}
 	return Variable{
-		Name:  v.Name,
-		Value: v.Value,
-		Type:  v.Type,
+		Name:        v.Name,
+		Value:       v.Value,
+		ValueObject: obj,
+		Type:        v.Type,
 	}
 }
 

--- a/service/api/types.go
+++ b/service/api/types.go
@@ -100,9 +100,17 @@ type Function struct {
 
 // Variable describes a variable.
 type Variable struct {
-	Name  string `json:"name"`
-	Value string `json:"value"`
-	Type  string `json:"type"`
+	Name        string      `json:"name"`
+	Value       string      `json:"value"`
+	Type        string      `json:"type"`
+	ValueObject ValueObject `json:"valueObject,omitempty"`
+}
+
+type ValueObject struct {
+	Type   string                  `json:"type"`
+	Map    *map[string]interface{} `json:"map,omitempty"`
+	String *string                 `json:"string,omitempty"`
+	Array  *[]interface{}          `json:"array,omitempty"`
 }
 
 // Goroutine represents the information relevant to Delve from the runtime's


### PR DESCRIPTION
### :construction: WIP, for discussion only :construction:

Hello again! I'd like to get some early feedback on some changes I've made locally to support [GoTools](https://github.com/ironcladlou/GoTools) integration. This provides an alternative (and/or replacement) to the current string rendering of variable data. Instead of building up a string while loading variable data from the debugged process, I instead build up an `interface{}` which is one of `string` (primitives), `[]interface{}` (arrays), or `map[string]interface{}` (structs). This lets delve generically represent arbitrary Go variable types internally. The variable's value object is exposed via a new union type in the API called `Variable.ValueObject`.

The net result is that clients will get a parseable JSON object graph they can render however they like.

This could be expanded so that nested values (in arrays or maps) have type information (e.g. the types of fields or array elements), but I'm not sure if it's worth the complexity yet.

I'm not going to try and tackle porting unit tests (which could be rewriting cases or writing a backwards-compatible renderer) until I've got some feedback.