### PR TITLE
proc, terminal: fix package docstrings

### DIFF
--- a/proc/doc.go
+++ b/proc/doc.go
@@ -1,4 +1,4 @@
-// proc is a low-level package that provides methods to manipulate
+// Package proc is a low-level package that provides methods to manipulate
 // the process we are debugging.
 //
 // proc implements all core functionality including:

--- a/terminal/command.go
+++ b/terminal/command.go
@@ -1,4 +1,4 @@
-// Package command implements functions for responding to user
+// Package terminal implements functions for responding to user
 // input and dispatching to appropriate backend commands.
 package terminal
 


### PR DESCRIPTION
Noticed on godoc.org that these weren't quite right.