### PR TITLE
Support for channels, maps and unsafe.Pointers

### DIFF
--- a/_fixtures/testvariables3.go
+++ b/_fixtures/testvariables3.go
@@ -43,11 +43,13 @@ func main() {
 	var fn2 functype = nil
 	var nilslice []int = nil
 	var nilptr *int = nil
+	ch1 := make(chan int, 2)
+	var chnil chan int = nil
 
 	var amb1 = 1
 	runtime.Breakpoint()
 	for amb1 := 0; amb1 < 10; amb1++ {
 		fmt.Println(amb1)
 	}
-	fmt.Println(i1, i2, i3, p1, amb1, s1, a1, p2, p3, s2, as1, str1, f1, fn1, fn2, nilslice, nilptr)
+	fmt.Println(i1, i2, i3, p1, amb1, s1, a1, p2, p3, s2, as1, str1, f1, fn1, fn2, nilslice, nilptr, ch1, chnil)
 }

--- a/_fixtures/testvariables3.go
+++ b/_fixtures/testvariables3.go
@@ -45,11 +45,57 @@ func main() {
 	var nilptr *int = nil
 	ch1 := make(chan int, 2)
 	var chnil chan int = nil
+	m1 := map[string]astruct{
+		"Malone":          astruct{2, 3},
+		"Adenauer":        astruct{},
+		"squadrons":       astruct{},
+		"quintuplets":     astruct{},
+		"parasite":        astruct{},
+		"wristwatches":    astruct{},
+		"flashgun":        astruct{},
+		"equivocally":     astruct{},
+		"sweetbrier":      astruct{},
+		"idealism":        astruct{},
+		"tangos":          astruct{},
+		"alterable":       astruct{},
+		"quaffing":        astruct{},
+		"arsenic":         astruct{},
+		"coincidentally":  astruct{},
+		"hindrances":      astruct{},
+		"zoning":          astruct{},
+		"egging":          astruct{},
+		"inserts":         astruct{},
+		"adaptive":        astruct{},
+		"orientations":    astruct{},
+		"periling":        astruct{},
+		"lip":             astruct{},
+		"chant":           astruct{},
+		"availing":        astruct{},
+		"fern":            astruct{},
+		"flummoxes":       astruct{},
+		"meanders":        astruct{},
+		"ravenously":      astruct{},
+		"reminisce":       astruct{},
+		"snorkel":         astruct{},
+		"gutters":         astruct{},
+		"jibbed":          astruct{},
+		"tiara":           astruct{},
+		"takers":          astruct{},
+		"animates":        astruct{},
+		"Zubenelgenubi":   astruct{},
+		"bantering":       astruct{},
+		"tumblers":        astruct{},
+		"horticulturists": astruct{},
+		"thallium":        astruct{},
+	}
+	var mnil map[string]astruct = nil
+	m2 := map[int]*astruct{1: &astruct{10, 11}}
+	m3 := map[astruct]int{{1, 1}: 42, {2, 2}: 43}
 
 	var amb1 = 1
 	runtime.Breakpoint()
 	for amb1 := 0; amb1 < 10; amb1++ {
 		fmt.Println(amb1)
 	}
-	fmt.Println(i1, i2, i3, p1, amb1, s1, a1, p2, p3, s2, as1, str1, f1, fn1, fn2, nilslice, nilptr, ch1, chnil)
+	fmt.Println(i1, i2, i3, p1, amb1, s1, a1, p2, p3, s2, as1, str1, f1, fn1, fn2, nilslice, nilptr, ch1, chnil, m1, mnil, m2, m3)
 }

--- a/_fixtures/testvariables3.go
+++ b/_fixtures/testvariables3.go
@@ -3,6 +3,7 @@ package main
 import (
 	"fmt"
 	"runtime"
+	"unsafe"
 )
 
 type astruct struct {
@@ -91,11 +92,12 @@ func main() {
 	var mnil map[string]astruct = nil
 	m2 := map[int]*astruct{1: &astruct{10, 11}}
 	m3 := map[astruct]int{{1, 1}: 42, {2, 2}: 43}
+	up1 := unsafe.Pointer(&i1)
 
 	var amb1 = 1
 	runtime.Breakpoint()
 	for amb1 := 0; amb1 < 10; amb1++ {
 		fmt.Println(amb1)
 	}
-	fmt.Println(i1, i2, i3, p1, amb1, s1, a1, p2, p3, s2, as1, str1, f1, fn1, fn2, nilslice, nilptr, ch1, chnil, m1, mnil, m2, m3)
+	fmt.Println(i1, i2, i3, p1, amb1, s1, a1, p2, p3, s2, as1, str1, f1, fn1, fn2, nilslice, nilptr, ch1, chnil, m1, mnil, m2, m3, up1)
 }

--- a/proc/eval.go
+++ b/proc/eval.go
@@ -596,7 +596,7 @@ func compareOp(op token.Token, xv *Variable, yv *Variable) (bool, error) {
 			return false, fmt.Errorf("sturcture too deep for comparison")
 		}
 		eql, err = equalChildren(xv, yv, false)
-	case reflect.Slice, reflect.Map, reflect.Func:
+	case reflect.Slice, reflect.Map, reflect.Func, reflect.Chan:
 		if xv != nilVariable && yv != nilVariable {
 			return false, fmt.Errorf("can not compare %s variables", xv.Kind.String())
 		}

--- a/service/api/prettyprint.go
+++ b/service/api/prettyprint.go
@@ -53,6 +53,8 @@ func (v *Variable) writeTo(buf *bytes.Buffer, top, newlines, includeType bool, i
 			fmt.Fprintf(buf, "*")
 			v.Children[0].writeTo(buf, false, newlines, includeType, indent)
 		}
+	case reflect.UnsafePointer:
+		fmt.Fprintf(buf, "unsafe.Pointer(0x%x)", v.Children[0].Addr)
 	case reflect.String:
 		v.writeStringTo(buf)
 	case reflect.Chan:

--- a/service/api/prettyprint.go
+++ b/service/api/prettyprint.go
@@ -55,6 +55,12 @@ func (v *Variable) writeTo(buf *bytes.Buffer, top, newlines, includeType bool, i
 		}
 	case reflect.String:
 		v.writeStringTo(buf)
+	case reflect.Chan:
+		if newlines {
+			v.writeStructTo(buf, newlines, includeType, indent)
+		} else {
+			fmt.Fprintf(buf, "%s %s/%s", v.Type, v.Children[0].Value, v.Children[1].Value)
+		}
 	case reflect.Struct:
 		v.writeStructTo(buf, newlines, includeType, indent)
 	case reflect.Map:

--- a/service/api/prettyprint.go
+++ b/service/api/prettyprint.go
@@ -163,13 +163,13 @@ func (v *Variable) writeMapTo(buf *bytes.Buffer, newlines, includeType bool, ind
 		}
 	}
 
-	if len(v.Children) != int(v.Len) {
+	if len(v.Children)/2 != int(v.Len) {
 		if nl {
 			fmt.Fprintf(buf, "\n%s%s", indent, indentString)
 		} else {
 			fmt.Fprintf(buf, ",")
 		}
-		fmt.Fprintf(buf, "...+%d more", int(v.Len)-len(v.Children))
+		fmt.Fprintf(buf, "...+%d more", int(v.Len)-(len(v.Children)/2))
 	}
 
 	if nl {

--- a/service/test/variables_test.go
+++ b/service/test/variables_test.go
@@ -385,6 +385,10 @@ func TestEvalExpression(t *testing.T) {
 		{"p3", true, "*int nil", "", "*int", nil},
 		{"*p3", false, "", "", "int", fmt.Errorf("nil pointer dereference")},
 
+		// channels
+		{"ch1", true, "chan int 0/2", "", "chan int", nil},
+		{"ch1+1", false, "", "", "", fmt.Errorf("can not convert 1 constant to chan int")},
+
 		// combined expressions
 		{"c1.pb.a.A", true, "1", "", "int", nil},
 		{"c1.sa[1].B", false, "3", "", "int", nil},
@@ -455,6 +459,9 @@ func TestEvalExpression(t *testing.T) {
 		{"nilptr != nil", false, "false", "", "", nil},
 		{"p1 == nil", false, "false", "", "", nil},
 		{"p1 != nil", false, "true", "", "", nil},
+		{"ch1 == nil", false, "false", "", "", nil},
+		{"chnil == nil", false, "true", "", "", nil},
+		{"ch1 == chnil", false, "", "", "", fmt.Errorf("can not compare chan variables")},
 
 		// errors
 		{"&3", false, "", "", "", fmt.Errorf("can not take address of \"3\"")},

--- a/service/test/variables_test.go
+++ b/service/test/variables_test.go
@@ -565,5 +565,16 @@ func TestMapEvaluation(t *testing.T) {
 			t.Fatalf("Wrong number of children (after slicing): %d", len(m1sliced.Children)/2)
 		}
 	})
+}
 
+func TestUnsafePointer(t *testing.T) {
+	withTestProcess("testvariables3", t, func(p *proc.Process, fixture protest.Fixture) {
+		assertNoError(p.Continue(), t, "Continue() returned an error")
+		up1v, err := evalVariable(p, "up1")
+		assertNoError(err, t, "EvalVariable(up1)")
+		up1 := api.ConvertVar(up1v)
+		if ss := up1.SinglelineString(); !strings.HasPrefix(ss, "unsafe.Pointer(") {
+			t.Fatalf("wrong value for up1: %s", ss)
+		}
+	})
 }


### PR DESCRIPTION
Added support for some of the leftover types to proc/variables and proc/eval.

Chan and unsafe.Pointer support is mostly cosmetic, with a few extra rules for comparisons of chans in eval. 

Support for maps is, of course, a lot more involved. My iterator code is derived from `go/src/runtime/hashmap.go`, I use the same code for loading maps that I use to access a map key, which means map access is currently O(n) instead of amortized constant, but this way I did not have to implement the hashing functions.

For maps I only return maxArrayValues at a time, like we already do for slices, arrays and strings. Since there would be no way to get anything but the first 64 pairs I have allowed the slicing syntax to also work on maps:
```
someMap[128:]
```
will return 64 key/value pairs from someMap skipping the first 128 pairs. This looks somewhat unnatural but it's at least consistent with what we do with slices, strings and arrays.
By the way, the iteration order over maps (and therefore the order in which keys will appear when printed) is deterministic in my implementation, I did not copy the randomization that's done by go's map iterators.