### PR TITLE
proc/eval: Return an error when slicing a map over its length

### DIFF
--- a/proc/eval.go
+++ b/proc/eval.go
@@ -327,6 +327,10 @@ func (scope *EvalScope) evalReslice(node *ast.SliceExpr) (*Variable, error) {
 			return nil, fmt.Errorf("second slice argument must be empty for maps")
 		}
 		xev.mapSkip += int(low)
+		xev.loadValue()
+		if xev.Unreadable != nil {
+			return nil, xev.Unreadable
+		}
 		return xev, nil
 	default:
 		return nil, fmt.Errorf("can not slice \"%s\" (type %s)", exprToString(node.X), xev.DwarfType.String())

--- a/proc/variables.go
+++ b/proc/variables.go
@@ -1113,6 +1113,7 @@ func (v *Variable) loadMap(recurseLevel int) {
 
 	for skip := 0; skip < v.mapSkip; skip++ {
 		if ok := it.next(); !ok {
+			v.Unreadable = fmt.Errorf("map index out of bounds")
 			return
 		}
 	}

--- a/service/test/variables_test.go
+++ b/service/test/variables_test.go
@@ -396,6 +396,7 @@ func TestEvalExpression(t *testing.T) {
 		{"m2[*p1].B", false, "11", "", "int", nil},
 		{"m3[as1]", false, "42", "", "int", nil},
 		{"mnil[\"Malone\"]", false, "", "", "", fmt.Errorf("key not found")},
+		{"m1[80:]", false, "", "", "", fmt.Errorf("map index out of bounds")},
 
 		// combined expressions
 		{"c1.pb.a.A", true, "1", "", "int", nil},


### PR DESCRIPTION
Fixes #288