### PR TITLE
Support for interface types and some builtin functions

### DIFF
--- a/_fixtures/testvariables3.go
+++ b/_fixtures/testvariables3.go
@@ -26,6 +26,14 @@ func afunc(x int) int {
 
 type functype func(int) int
 
+func (a *astruct) Error() string {
+	return "not an error"
+}
+
+func (b *bstruct) Error() string {
+	return "not an error"
+}
+
 func main() {
 	i1 := 1
 	i2 := 2
@@ -96,11 +104,16 @@ func main() {
 	i4 := 800
 	i5 := -3
 	i6 := -500
+	var err1 error = c1.sa[0]
+	var err2 error = c1.pb
+	var errnil error = nil
+	var iface1 interface{} = c1.sa[0]
+	var ifacenil interface{} = nil
 
 	var amb1 = 1
 	runtime.Breakpoint()
 	for amb1 := 0; amb1 < 10; amb1++ {
 		fmt.Println(amb1)
 	}
-	fmt.Println(i1, i2, i3, p1, amb1, s1, a1, p2, p3, s2, as1, str1, f1, fn1, fn2, nilslice, nilptr, ch1, chnil, m1, mnil, m2, m3, up1, i4, i5, i6)
+	fmt.Println(i1, i2, i3, p1, amb1, s1, a1, p2, p3, s2, as1, str1, f1, fn1, fn2, nilslice, nilptr, ch1, chnil, m1, mnil, m2, m3, up1, i4, i5, i6, err1, err2, errnil, iface1, ifacenil)
 }

--- a/_fixtures/testvariables3.go
+++ b/_fixtures/testvariables3.go
@@ -93,11 +93,14 @@ func main() {
 	m2 := map[int]*astruct{1: &astruct{10, 11}}
 	m3 := map[astruct]int{{1, 1}: 42, {2, 2}: 43}
 	up1 := unsafe.Pointer(&i1)
+	i4 := 800
+	i5 := -3
+	i6 := -500
 
 	var amb1 = 1
 	runtime.Breakpoint()
 	for amb1 := 0; amb1 < 10; amb1++ {
 		fmt.Println(amb1)
 	}
-	fmt.Println(i1, i2, i3, p1, amb1, s1, a1, p2, p3, s2, as1, str1, f1, fn1, fn2, nilslice, nilptr, ch1, chnil, m1, mnil, m2, m3, up1)
+	fmt.Println(i1, i2, i3, p1, amb1, s1, a1, p2, p3, s2, as1, str1, f1, fn1, fn2, nilslice, nilptr, ch1, chnil, m1, mnil, m2, m3, up1, i4, i5, i6)
 }

--- a/_fixtures/testvariables3.go
+++ b/_fixtures/testvariables3.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"fmt"
+	"go/constant"
 	"runtime"
 	"unsafe"
 )
@@ -109,15 +110,20 @@ func main() {
 	var err2 error = c1.pb
 	var errnil error = nil
 	var iface1 interface{} = c1.sa[0]
+	var iface2 interface{} = "test"
+	var iface3 interface{} = map[string]constant.Value{}
+	var iface4 interface{} = []constant.Value{constant.MakeInt64(4)}
 	var ifacenil interface{} = nil
 	arr1 := [4]int{0, 1, 2, 3}
 	parr := &arr1
 	cpx1 := complex(1, 2)
+	const1 := constant.MakeInt64(3)
 
 	var amb1 = 1
 	runtime.Breakpoint()
 	for amb1 := 0; amb1 < 10; amb1++ {
 		fmt.Println(amb1)
 	}
-	fmt.Println(i1, i2, i3, p1, amb1, s1, s3, a1, p2, p3, s2, as1, str1, f1, fn1, fn2, nilslice, nilptr, ch1, chnil, m1, mnil, m2, m3, up1, i4, i5, i6, err1, err2, errnil, iface1, ifacenil, arr1, parr, cpx1)
+	runtime.Breakpoint()
+	fmt.Println(i1, i2, i3, p1, amb1, s1, s3, a1, p2, p3, s2, as1, str1, f1, fn1, fn2, nilslice, nilptr, ch1, chnil, m1, mnil, m2, m3, up1, i4, i5, i6, err1, err2, errnil, iface1, iface2, ifacenil, arr1, parr, cpx1, const1, iface3, iface4)
 }

--- a/_fixtures/testvariables3.go
+++ b/_fixtures/testvariables3.go
@@ -41,6 +41,7 @@ func main() {
 	i3 := 3
 	p1 := &i1
 	s1 := []string{"one", "two", "three", "four", "five"}
+	s3 := make([]int, 0, 6)
 	a1 := [5]string{"one", "two", "three", "four", "five"}
 	c1 := cstruct{&bstruct{astruct{1, 2}}, []*astruct{&astruct{1, 2}, &astruct{2, 3}, &astruct{4, 5}}}
 	s2 := []astruct{{1, 2}, {3, 4}, {5, 6}, {7, 8}, {9, 10}, {11, 12}, {13, 14}, {15, 16}}
@@ -109,11 +110,14 @@ func main() {
 	var errnil error = nil
 	var iface1 interface{} = c1.sa[0]
 	var ifacenil interface{} = nil
+	arr1 := [4]int{0, 1, 2, 3}
+	parr := &arr1
+	cpx1 := complex(1, 2)
 
 	var amb1 = 1
 	runtime.Breakpoint()
 	for amb1 := 0; amb1 < 10; amb1++ {
 		fmt.Println(amb1)
 	}
-	fmt.Println(i1, i2, i3, p1, amb1, s1, a1, p2, p3, s2, as1, str1, f1, fn1, fn2, nilslice, nilptr, ch1, chnil, m1, mnil, m2, m3, up1, i4, i5, i6, err1, err2, errnil, iface1, ifacenil)
+	fmt.Println(i1, i2, i3, p1, amb1, s1, s3, a1, p2, p3, s2, as1, str1, f1, fn1, fn2, nilslice, nilptr, ch1, chnil, m1, mnil, m2, m3, up1, i4, i5, i6, err1, err2, errnil, iface1, ifacenil, arr1, parr, cpx1)
 }

--- a/dwarf/reader/reader.go
+++ b/dwarf/reader/reader.go
@@ -104,6 +104,8 @@ func (reader *Reader) AddrForMember(member string, initialInstructions []byte) (
 	}
 }
 
+var TypeNotFoundErr = errors.New("no type entry found")
+
 // SeekToType moves the reader to the type specified by the entry,
 // optionally resolving typedefs and pointer types. If the reader is set
 // to a struct type the NextMemberVariable call can be used to walk all member data.
@@ -138,7 +140,7 @@ func (reader *Reader) SeekToType(entry *dwarf.Entry, resolveTypedefs bool, resol
 		reader.Seek(offset)
 	}
 
-	return nil, fmt.Errorf("no type entry found")
+	return nil, TypeNotFoundErr
 }
 
 // SeekToTypeNamed moves the reader to the type specified by the name.
@@ -168,7 +170,7 @@ func (reader *Reader) SeekToTypeNamed(name string) (*dwarf.Entry, error) {
 		}
 	}
 
-	return nil, errors.New("no type entry found")
+	return nil, TypeNotFoundErr
 }
 
 // Finds the entry for 'name'.

--- a/proc/eval.go
+++ b/proc/eval.go
@@ -932,15 +932,6 @@ func equalChildren(xv, yv *Variable, shortcircuit bool) (bool, error) {
 	return r, nil
 }
 
-func (dbp *Process) findType(name string) (dwarf.Type, error) {
-	reader := dbp.DwarfReader()
-	typentry, err := reader.SeekToTypeNamed(name)
-	if err != nil {
-		return nil, err
-	}
-	return dbp.dwarf.Type(typentry.Offset)
-}
-
 func (v *Variable) asInt() (int64, error) {
 	if v.DwarfType == nil {
 		if v.Value.Kind() != constant.Int {

--- a/proc/eval.go
+++ b/proc/eval.go
@@ -139,6 +139,9 @@ func (scope *EvalScope) evalTypeCast(node *ast.CallExpr) (*Variable, error) {
 
 	switch ttyp := typ.(type) {
 	case *dwarf.PtrType:
+		if ptrTypeKind(ttyp) != reflect.Ptr {
+			return nil, converr
+		}
 		switch argv.Kind {
 		case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
 			// ok

--- a/proc/proc.go
+++ b/proc/proc.go
@@ -39,6 +39,9 @@ type Process struct {
 	// Normally SelectedGoroutine is CurrentThread.GetG, it will not be only if SwitchGoroutine is called with a goroutine that isn't attached to a thread
 	SelectedGoroutine *G
 
+	// Maps package names to package paths, needed to lookup types inside DWARF info
+	packageMap map[string]string
+
 	allGCache               []*G
 	dwarf                   *dwarf.Data
 	goSymTable              *gosym.Table

--- a/proc/types.go
+++ b/proc/types.go
@@ -1,0 +1,123 @@
+package proc
+
+import (
+	"debug/dwarf"
+	"go/ast"
+	"strings"
+)
+
+// Do not call this function directly it isn't able to deal correctly with package paths
+func (dbp *Process) findType(name string) (dwarf.Type, error) {
+	reader := dbp.DwarfReader()
+	typentry, err := reader.SeekToTypeNamed(name)
+	if err != nil {
+		return nil, err
+	}
+	return dbp.dwarf.Type(typentry.Offset)
+}
+
+func (dbp *Process) pointerTo(typ dwarf.Type) dwarf.Type {
+	return &dwarf.PtrType{dwarf.CommonType{int64(dbp.arch.PtrSize()), ""}, typ}
+}
+
+func (dbp *Process) findTypeExpr(expr ast.Expr) (dwarf.Type, error) {
+	dbp.loadPackageMap()
+	dbp.expandPackagesInType(expr)
+	if snode, ok := expr.(*ast.StarExpr); ok {
+		// Pointer types only appear in the dwarf informations when
+		// a pointer to the type is used in the target program, here
+		// we create a pointer type on the fly so that the user can
+		// specify a pointer to any variable used in the target program
+		ptyp, err := dbp.findType(exprToString(snode.X))
+		if err != nil {
+			return nil, err
+		}
+		return dbp.pointerTo(ptyp), nil
+	}
+	return dbp.findType(exprToString(expr))
+}
+
+func complexType(typename string) bool {
+	dot := 0
+	for _, ch := range typename {
+		switch ch {
+		case '*', '[', '<', '{', '(', ' ':
+			return true
+		case '.':
+			dot++
+			if dot > 1 {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+func (dbp *Process) loadPackageMap() error {
+	if dbp.packageMap != nil {
+		return nil
+	}
+	dbp.packageMap = map[string]string{}
+	reader := dbp.DwarfReader()
+	for entry, err := reader.Next(); entry != nil; entry, err = reader.Next() {
+		if err != nil {
+			return err
+		}
+
+		if entry.Tag != dwarf.TagTypedef && entry.Tag != dwarf.TagBaseType && entry.Tag != dwarf.TagClassType && entry.Tag != dwarf.TagStructType {
+			continue
+		}
+
+		typename, ok := entry.Val(dwarf.AttrName).(string)
+		if !ok || complexType(typename) {
+			continue
+		}
+
+		dot := strings.Index(typename, ".")
+		if dot < 0 {
+			continue
+		}
+		path := typename[:dot]
+		slash := strings.LastIndex(path, "/")
+		if slash < 0 || slash+1 >= len(path) {
+			continue
+		}
+		name := path[slash+1:]
+		dbp.packageMap[name] = path
+	}
+	return nil
+}
+
+func (dbp *Process) expandPackagesInType(expr ast.Expr) {
+	switch e := expr.(type) {
+	case *ast.ArrayType:
+		dbp.expandPackagesInType(e.Elt)
+	case *ast.ChanType:
+		dbp.expandPackagesInType(e.Value)
+	case *ast.FuncType:
+		for i := range e.Params.List {
+			dbp.expandPackagesInType(e.Params.List[i].Type)
+		}
+		for i := range e.Results.List {
+			dbp.expandPackagesInType(e.Results.List[i].Type)
+		}
+	case *ast.MapType:
+		dbp.expandPackagesInType(e.Key)
+		dbp.expandPackagesInType(e.Value)
+	case *ast.ParenExpr:
+		dbp.expandPackagesInType(e.X)
+	case *ast.SelectorExpr:
+		switch x := e.X.(type) {
+		case *ast.Ident:
+			if path, ok := dbp.packageMap[x.Name]; ok {
+				x.Name = path
+			}
+		default:
+			dbp.expandPackagesInType(e.X)
+		}
+	case *ast.StarExpr:
+		dbp.expandPackagesInType(e.X)
+	default:
+		// nothing to do
+	}
+}

--- a/proc/variables.go
+++ b/proc/variables.go
@@ -118,14 +118,7 @@ func newVariable(name string, addr uintptr, dwarfType dwarf.Type, thread *Thread
 		thread:    thread,
 	}
 
-	v.RealType = v.DwarfType
-	for {
-		if tt, ok := v.RealType.(*dwarf.TypedefType); ok {
-			v.RealType = tt.Type
-		} else {
-			break
-		}
-	}
+	v.RealType = resolveTypedef(v.DwarfType)
 
 	switch t := v.RealType.(type) {
 	case *dwarf.PtrType:
@@ -199,6 +192,16 @@ func newVariable(name string, addr uintptr, dwarfType dwarf.Type, thread *Thread
 	}
 
 	return v
+}
+
+func resolveTypedef(typ dwarf.Type) dwarf.Type {
+	for {
+		if tt, ok := typ.(*dwarf.TypedefType); ok {
+			typ = tt.Type
+		} else {
+			return typ
+		}
+	}
 }
 
 func newConstant(val constant.Value, thread *Thread) *Variable {

--- a/proc/variables.go
+++ b/proc/variables.go
@@ -234,6 +234,16 @@ func (v *Variable) clone() *Variable {
 	return &r
 }
 
+func (v *Variable) TypeString() string {
+	if v == nilVariable {
+		return "nil"
+	}
+	if v.DwarfType != nil {
+		return v.DwarfType.String()
+	}
+	return v.Kind.String()
+}
+
 func (v *Variable) toField(field *dwarf.StructField) (*Variable, error) {
 	if v.Unreadable != nil {
 		return v.clone(), nil
@@ -643,7 +653,11 @@ func (v *Variable) structMember(memberName string) (*Variable, error) {
 		}
 		return nil, fmt.Errorf("%s has no member %s", v.Name, memberName)
 	default:
-		return nil, fmt.Errorf("%s (type %s) is not a struct", v.Name, structVar.DwarfType)
+		if v.Name == "" {
+			return nil, fmt.Errorf("type %s is not a struct", structVar.TypeString())
+		} else {
+			return nil, fmt.Errorf("%s (type %s) is not a struct", v.Name, structVar.TypeString())
+		}
 	}
 }
 

--- a/service/api/conversions.go
+++ b/service/api/conversions.go
@@ -68,10 +68,16 @@ func ConvertVar(v *proc.Variable) *Variable {
 
 	if v.DwarfType != nil {
 		r.Type = v.DwarfType.String()
+		if r.Type == "*void" {
+			r.Type = "unsafe.Pointer"
+		}
 	}
 
 	if v.RealType != nil {
 		r.RealType = v.RealType.String()
+		if r.RealType == "*void" {
+			r.Type = "unsafe.Pointer"
+		}
 	}
 
 	if v.Unreadable != nil {

--- a/service/api/prettyprint.go
+++ b/service/api/prettyprint.go
@@ -61,7 +61,11 @@ func (v *Variable) writeTo(buf *bytes.Buffer, top, newlines, includeType bool, i
 		if newlines {
 			v.writeStructTo(buf, newlines, includeType, indent)
 		} else {
-			fmt.Fprintf(buf, "%s %s/%s", v.Type, v.Children[0].Value, v.Children[1].Value)
+			if len(v.Children) == 0 {
+				fmt.Fprintf(buf, "%s nil", v.Type)
+			} else {
+				fmt.Fprintf(buf, "%s %s/%s", v.Type, v.Children[0].Value, v.Children[1].Value)
+			}
 		}
 	case reflect.Struct:
 		v.writeStructTo(buf, newlines, includeType, indent)

--- a/service/api/prettyprint.go
+++ b/service/api/prettyprint.go
@@ -69,6 +69,19 @@ func (v *Variable) writeTo(buf *bytes.Buffer, top, newlines, includeType bool, i
 		}
 	case reflect.Struct:
 		v.writeStructTo(buf, newlines, includeType, indent)
+	case reflect.Interface:
+		if includeType {
+			if v.Children[0].Kind == reflect.Invalid {
+				fmt.Fprintf(buf, "%s ", v.Type)
+				if v.Children[0].Addr == 0 {
+					fmt.Fprintf(buf, "nil")
+					return
+				}
+			} else {
+				fmt.Fprintf(buf, "%s(%s) ", v.Type, v.Children[0].Type)
+			}
+		}
+		v.Children[0].writeTo(buf, false, newlines, false, indent)
 	case reflect.Map:
 		v.writeMapTo(buf, newlines, includeType, indent)
 	case reflect.Func:
@@ -192,7 +205,7 @@ func (v *Variable) shouldNewlineArray(newlines bool) bool {
 	kind, hasptr := (&v.Children[0]).recursiveKind()
 
 	switch kind {
-	case reflect.Slice, reflect.Array, reflect.Struct, reflect.Map:
+	case reflect.Slice, reflect.Array, reflect.Struct, reflect.Map, reflect.Interface:
 		return true
 	case reflect.String:
 		if hasptr {
@@ -233,7 +246,7 @@ func (v *Variable) shouldNewlineStruct(newlines bool) bool {
 		kind, hasptr := (&v.Children[i]).recursiveKind()
 
 		switch kind {
-		case reflect.Slice, reflect.Array, reflect.Struct, reflect.Map:
+		case reflect.Slice, reflect.Array, reflect.Struct, reflect.Map, reflect.Interface:
 			return true
 		case reflect.String:
 			if hasptr {

--- a/service/test/variables_test.go
+++ b/service/test/variables_test.go
@@ -387,6 +387,7 @@ func TestEvalExpression(t *testing.T) {
 
 		// channels
 		{"ch1", true, "chan int 0/2", "", "chan int", nil},
+		{"chnil", true, "chan int nil", "", "chan int", nil},
 		{"ch1+1", false, "", "", "", fmt.Errorf("can not convert 1 constant to chan int")},
 
 		// maps
@@ -463,6 +464,7 @@ func TestEvalExpression(t *testing.T) {
 		{"c1.sa[0] == nil", false, "false", "", "", nil},
 		{"c1.sa[0] != nil", false, "true", "", "", nil},
 		{"nilslice == nil", false, "true", "", "", nil},
+		{"nil == nilslice", false, "true", "", "", nil},
 		{"nilslice != nil", false, "false", "", "", nil},
 		{"nilptr == nil", false, "true", "", "", nil},
 		{"nilptr != nil", false, "false", "", "", nil},
@@ -474,10 +476,12 @@ func TestEvalExpression(t *testing.T) {
 		{"m1 == nil", false, "false", "", "", nil},
 		{"mnil == m1", false, "", "", "", fmt.Errorf("can not compare map variables")},
 		{"mnil == nil", false, "true", "", "", nil},
+		{"nil == 2", false, "", "", "", fmt.Errorf("can not compare int to nil")},
+		{"2 == nil", false, "", "", "", fmt.Errorf("can not compare int to nil")},
 
 		// errors
 		{"&3", false, "", "", "", fmt.Errorf("can not take address of \"3\"")},
-		{"*3", false, "", "", "", fmt.Errorf("expression \"3\" can not be dereferenced")},
+		{"*3", false, "", "", "", fmt.Errorf("expression \"3\" (int) can not be dereferenced")},
 		{"&(i2 + i3)", false, "", "", "", fmt.Errorf("can not take address of \"(i2 + i3)\"")},
 		{"i2 + p1", false, "", "", "", fmt.Errorf("mismatched types \"int\" and \"*int\"")},
 		{"i2 + f1", false, "", "", "", fmt.Errorf("mismatched types \"int\" and \"float64\"")},
@@ -487,6 +491,12 @@ func TestEvalExpression(t *testing.T) {
 		{"*(i2 + i3)", false, "", "", "", fmt.Errorf("expression \"(i2 + i3)\" (int) can not be dereferenced")},
 		{"i2.member", false, "", "", "", fmt.Errorf("i2 (type int) is not a struct")},
 		{"fmt.Println(\"hello\")", false, "", "", "", fmt.Errorf("no type entry found")},
+		{"*nil", false, "", "", "", fmt.Errorf("nil can not be dereferenced")},
+		{"!nil", false, "", "", "", fmt.Errorf("operator ! can not be applied to \"nil\"")},
+		{"&nil", false, "", "", "", fmt.Errorf("can not take address of \"nil\"")},
+		{"nil[0]", false, "", "", "", fmt.Errorf("expression \"nil\" (nil) does not support indexing")},
+		{"nil[2:10]", false, "", "", "", fmt.Errorf("can not slice \"nil\" (type nil)")},
+		{"nil.member", false, "", "", "", fmt.Errorf("type nil is not a struct")},
 
 		// typecasts
 		{"uint(i2)", false, "2", "", "uint", nil},
@@ -508,7 +518,7 @@ func TestEvalExpression(t *testing.T) {
 				assertVariable(t, variable, tc)
 			} else {
 				if err == nil {
-					t.Fatalf("Expected error %s, got non (%s)", tc.err.Error(), tc.name)
+					t.Fatalf("Expected error %s, got no error (%s)", tc.err.Error(), tc.name)
 				}
 				if tc.err.Error() != err.Error() {
 					t.Fatalf("Unexpected error. Expected %s got %s", tc.err.Error(), err.Error())

--- a/service/test/variables_test.go
+++ b/service/test/variables_test.go
@@ -533,6 +533,7 @@ func TestEvalExpression(t *testing.T) {
 		{"nil[0]", false, "", "", "", fmt.Errorf("expression \"nil\" (nil) does not support indexing")},
 		{"nil[2:10]", false, "", "", "", fmt.Errorf("can not slice \"nil\" (type nil)")},
 		{"nil.member", false, "", "", "", fmt.Errorf("type nil is not a struct")},
+		{"(map[string]int)(0x4000)", false, "", "", "", fmt.Errorf("can not convert \"0x4000\" to *struct hash<string,int>")},
 
 		// typecasts
 		{"uint(i2)", false, "2", "", "uint", nil},

--- a/service/test/variables_test.go
+++ b/service/test/variables_test.go
@@ -404,6 +404,9 @@ func TestEvalExpression(t *testing.T) {
 		{"err2", true, "error(*struct main.bstruct) *{a: main.astruct {A: 1, B: 2}}", "", "error", nil},
 		{"errnil", true, "error nil", "", "error", nil},
 		{"iface1", true, "interface {}(*struct main.astruct) *{A: 1, B: 2}", "", "interface {}", nil},
+		{"iface2", true, "interface {}(*struct string) *\"test\"", "", "interface {}", nil},
+		{"iface3", true, "interface {}(map[string]go/constant.Value) []", "", "interface {}", nil},
+		{"iface4", true, "interface {}(*struct []go/constant.Value) *[*4]", "", "interface {}", nil},
 		{"ifacenil", true, "interface {} nil", "", "interface {}", nil},
 		{"err1 == err2", false, "false", "", "", nil},
 		{"err1 == iface1", false, "", "", "", fmt.Errorf("mismatched types \"error\" and \"interface {}\"")},
@@ -412,6 +415,7 @@ func TestEvalExpression(t *testing.T) {
 		{"err1.(*main.astruct)", false, "*struct main.astruct {A: 1, B: 2}", "", "*struct main.astruct", nil},
 		{"err1.(*main.bstruct)", false, "", "", "", fmt.Errorf("interface conversion: error is *struct main.astruct, not *struct main.bstruct")},
 		{"errnil.(*main.astruct)", false, "", "", "", fmt.Errorf("interface conversion: error is nil, not *main.astruct")},
+		{"const1", true, "go/constant.Value(*go/constant.int64Val) *3", "", "go/constant.Value", nil},
 
 		// combined expressions
 		{"c1.pb.a.A", true, "1", "", "int", nil},

--- a/service/test/variables_test.go
+++ b/service/test/variables_test.go
@@ -344,7 +344,7 @@ func TestComplexSetting(t *testing.T) {
 		h("3.2i", "(0 + 3.2i)")
 		h("1.1", "(1.1 + 0i)")
 		h("1 + 3.3i", "(1 + 3.3i)")
-		h("complex128(1.2, 3.4)", "(1.2 + 3.4i)")
+		h("complex(1.2, 3.4)", "(1.2 + 3.4i)")
 	})
 }
 
@@ -462,6 +462,28 @@ func TestEvalExpression(t *testing.T) {
 		{"c1.pb.a == *(c1.sa[1])", false, "false", "", "", nil},
 		{"c1.pb.a != *(c1.sa[1])", false, "true", "", "", nil},
 
+		// builtins
+		{"cap(parr)", false, "4", "", "", nil},
+		{"len(parr)", false, "4", "", "", nil},
+		{"cap(p1)", false, "", "", "", fmt.Errorf("invalid argument p1 (type *int) for cap")},
+		{"len(p1)", false, "", "", "", fmt.Errorf("invalid argument p1 (type *int) for len")},
+		{"cap(a1)", false, "5", "", "", nil},
+		{"len(a1)", false, "5", "", "", nil},
+		{"cap(s3)", false, "6", "", "", nil},
+		{"len(s3)", false, "0", "", "", nil},
+		{"cap(nilslice)", false, "0", "", "", nil},
+		{"len(nilslice)", false, "0", "", "", nil},
+		{"cap(ch1)", false, "2", "", "", nil},
+		{"len(ch1)", false, "0", "", "", nil},
+		{"cap(chnil)", false, "0", "", "", nil},
+		{"len(chnil)", false, "0", "", "", nil},
+		{"len(m1)", false, "41", "", "", nil},
+		{"len(mnil)", false, "0", "", "", nil},
+		{"imag(cpx1)", false, "2", "", "", nil},
+		{"real(cpx1)", false, "1", "", "", nil},
+		{"imag(3i)", false, "3", "", "", nil},
+		{"real(4)", false, "4", "", "", nil},
+
 		// nil
 		{"nil", false, "nil", "", "", nil},
 		{"nil+1", false, "", "", "", fmt.Errorf("operator + can not be applied to \"nil\"")},
@@ -504,7 +526,7 @@ func TestEvalExpression(t *testing.T) {
 		{"i2 << i3", false, "", "", "int", fmt.Errorf("shift count type int, must be unsigned integer")},
 		{"*(i2 + i3)", false, "", "", "", fmt.Errorf("expression \"(i2 + i3)\" (int) can not be dereferenced")},
 		{"i2.member", false, "", "", "", fmt.Errorf("i2 (type int) is not a struct")},
-		{"fmt.Println(\"hello\")", false, "", "", "", fmt.Errorf("no type entry found")},
+		{"fmt.Println(\"hello\")", false, "", "", "", fmt.Errorf("function calls are not supported")},
 		{"*nil", false, "", "", "", fmt.Errorf("nil can not be dereferenced")},
 		{"!nil", false, "", "", "", fmt.Errorf("operator ! can not be applied to \"nil\"")},
 		{"&nil", false, "", "", "", fmt.Errorf("can not take address of \"nil\"")},

--- a/service/test/variables_test.go
+++ b/service/test/variables_test.go
@@ -487,6 +487,16 @@ func TestEvalExpression(t *testing.T) {
 		{"*(i2 + i3)", false, "", "", "", fmt.Errorf("expression \"(i2 + i3)\" (int) can not be dereferenced")},
 		{"i2.member", false, "", "", "", fmt.Errorf("i2 (type int) is not a struct")},
 		{"fmt.Println(\"hello\")", false, "", "", "", fmt.Errorf("no type entry found")},
+
+		// typecasts
+		{"uint(i2)", false, "2", "", "uint", nil},
+		{"int8(i2)", false, "2", "", "int8", nil},
+		{"int(f1)", false, "3", "", "int", nil},
+		{"complex128(f1)", false, "(3 + 0i)", "", "complex128", nil},
+		{"uint8(i4)", false, "32", "", "uint8", nil},
+		{"uint8(i5)", false, "253", "", "uint8", nil},
+		{"int8(i5)", false, "-3", "", "int8", nil},
+		{"int8(i6)", false, "12", "", "int8", nil},
 	}
 
 	withTestProcess("testvariables3", t, func(p *proc.Process, fixture protest.Fixture) {

--- a/service/test/variables_test.go
+++ b/service/test/variables_test.go
@@ -399,6 +399,20 @@ func TestEvalExpression(t *testing.T) {
 		{"mnil[\"Malone\"]", false, "", "", "", fmt.Errorf("key not found")},
 		{"m1[80:]", false, "", "", "", fmt.Errorf("map index out of bounds")},
 
+		// interfaces
+		{"err1", true, "error(*struct main.astruct) *{A: 1, B: 2}", "", "error", nil},
+		{"err2", true, "error(*struct main.bstruct) *{a: main.astruct {A: 1, B: 2}}", "", "error", nil},
+		{"errnil", true, "error nil", "", "error", nil},
+		{"iface1", true, "interface {}(*struct main.astruct) *{A: 1, B: 2}", "", "interface {}", nil},
+		{"ifacenil", true, "interface {} nil", "", "interface {}", nil},
+		{"err1 == err2", false, "false", "", "", nil},
+		{"err1 == iface1", false, "", "", "", fmt.Errorf("mismatched types \"error\" and \"interface {}\"")},
+		{"errnil == nil", false, "false", "", "", nil},
+		{"nil == errnil", false, "false", "", "", nil},
+		{"err1.(*main.astruct)", false, "*struct main.astruct {A: 1, B: 2}", "", "*struct main.astruct", nil},
+		{"err1.(*main.bstruct)", false, "", "", "", fmt.Errorf("interface conversion: error is *struct main.astruct, not *struct main.bstruct")},
+		{"errnil.(*main.astruct)", false, "", "", "", fmt.Errorf("interface conversion: error is nil, not *main.astruct")},
+
 		// combined expressions
 		{"c1.pb.a.A", true, "1", "", "int", nil},
 		{"c1.sa[1].B", false, "3", "", "int", nil},


### PR DESCRIPTION
Added len, cap, imag and real (complex was already there, I refactored the code).

For interfaces I return a `Variable` with the interface type in `DwarfType` and a single element in `Children` containing the concrete value of the interface variable with its correct type.

To access member fields of the concrete value of an interface variable a type assertion can be used:
```
ifaceVar.(*concreteStructType).someField
```