### PR TITLE
dev: Fixup Makefile and testsign script

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -52,7 +52,7 @@ else
 endif
 
 test-proc-run:
-	go test $(TEST_FLAGS) $(BUILD_FLAGS) $(PREFIX)/proc -run $(RUN)
+	go test $(TEST_FLAGS) $(BUILD_FLAGS) -test.run="$(RUN)" $(PREFIX)/proc
 
 test-integration-run:
-	go test $(TEST_FLAGS) $(BUILD_FLAGS) $(PREFIX)/service/test -run $(RUN)
+	go test $(TEST_FLAGS) $(BUILD_FLAGS) -test.run="$(RUN)" $(PREFIX)/service/test

--- a/scripts/testsign
+++ b/scripts/testsign
@@ -1,3 +1,3 @@
 #!/usr/bin/env bash
 codesign -s $CERT $1
-exec $1
+exec "$@"


### PR DESCRIPTION
Fixes up certain Makefile targets and the testsign script.

Makefile: Properly pass 'test.run' flag
testsign: Run will all args instead of first