### PR TITLE
proc: Fix parsing of 'BuildVersion' on Go tip

### DIFF
--- a/proc/proc.go
+++ b/proc/proc.go
@@ -702,10 +702,13 @@ func (dbp *Process) execPtraceFunc(fn func()) {
 }
 
 func (dbp *Process) getGoInformation() (ver GoVersion, isextld bool, err error) {
-	vv, err := dbp.EvalPackageVariable("runtime.buildVersion")
+	vv, err := dbp.EvalPackageVariable("runtime/internal/sys.BuildVersion")
 	if err != nil {
-		err = fmt.Errorf("Could not determine version number: %v\n", err)
-		return
+		vv, err = dbp.EvalPackageVariable("runtime.buildVersion")
+		if err != nil {
+			err = fmt.Errorf("Could not determine version number: %v\n", err)
+			return
+		}
 	}
 
 	ver, ok := parseVersionString(constant.StringVal(vv.Value))


### PR DESCRIPTION
Fixes #301