### PR TITLE
travis: allow failures on tip

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,3 +8,7 @@ os:
 go:
   - tip
   - 1.5
+
+matrix:
+  allow_failures:
+    - go: tip


### PR DESCRIPTION
Make Go tip an "allowed failure" in travis.

@aarzilli there is a failing test on master that only fails on tip: `TestEvalExpression`. I think in general however, we should stay on top of changes to `tip` of Go, but let's not mark a build as failed if it doesn't pass against tip.