### PR TITLE
service/locations: hooked expression evaluator to location specifiers

### DIFF
--- a/_fixtures/locationsprog2.go
+++ b/_fixtures/locationsprog2.go
@@ -1,0 +1,29 @@
+package main
+
+import (
+	"fmt"
+	"runtime"
+)
+
+func afunction(s string) {
+	fmt.Println(s)
+}
+
+type someStruct struct {
+	s string
+}
+
+func (o *someStruct) structfunc(s2 string) {
+	fmt.Println(o.s, s2)
+}
+
+func main() {
+	fn1 := afunction
+	var o someStruct
+	fn2 := o.structfunc
+	fn3 := func(s string) {
+		fmt.Println("inline", s)
+	}
+	runtime.Breakpoint()
+	fmt.Println(fn1, fn2, fn3, o)
+}

--- a/proc/eval.go
+++ b/proc/eval.go
@@ -282,7 +282,7 @@ func capBuiltin(args []*Variable, nodeargs []ast.Expr) (*Variable, error) {
 		if arg.Unreadable != nil {
 			return nil, arg.Unreadable
 		}
-		if arg.base == 0 {
+		if arg.Base == 0 {
 			return newConstant(constant.MakeInt64(0), arg.mem), nil
 		}
 		return newConstant(arg.Children[1].Value, arg.mem), nil
@@ -315,7 +315,7 @@ func lenBuiltin(args []*Variable, nodeargs []ast.Expr) (*Variable, error) {
 		if arg.Unreadable != nil {
 			return nil, arg.Unreadable
 		}
-		if arg.base == 0 {
+		if arg.Base == 0 {
 			return newConstant(constant.MakeInt64(0), arg.mem), nil
 		}
 		return newConstant(arg.Children[0].Value, arg.mem), nil
@@ -507,7 +507,7 @@ func (scope *EvalScope) evalIndex(node *ast.IndexExpr) (*Variable, error) {
 
 	switch xev.Kind {
 	case reflect.Slice, reflect.Array, reflect.String:
-		if xev.base == 0 {
+		if xev.Base == 0 {
 			return nil, fmt.Errorf("can not index \"%s\"", exprToString(node.X))
 		}
 		n, err := idxev.asInt()
@@ -567,7 +567,7 @@ func (scope *EvalScope) evalReslice(node *ast.SliceExpr) (*Variable, error) {
 
 	switch xev.Kind {
 	case reflect.Slice, reflect.Array, reflect.String:
-		if xev.base == 0 {
+		if xev.Base == 0 {
 			return nil, fmt.Errorf("can not slice \"%s\"", exprToString(node.X))
 		}
 		return xev.reslice(low, high)
@@ -917,7 +917,7 @@ func (v *Variable) isNil() bool {
 	case reflect.Interface:
 		return false
 	case reflect.Slice, reflect.Map, reflect.Func, reflect.Chan:
-		return v.base == 0
+		return v.Base == 0
 	}
 	return false
 }
@@ -1039,7 +1039,7 @@ func (v *Variable) sliceAccess(idx int) (*Variable, error) {
 	if idx < 0 || int64(idx) >= v.Len {
 		return nil, fmt.Errorf("index out of bounds")
 	}
-	return v.newVariable("", v.base+uintptr(int64(idx)*v.stride), v.fieldType), nil
+	return v.newVariable("", v.Base+uintptr(int64(idx)*v.stride), v.fieldType), nil
 }
 
 func (v *Variable) mapAccess(idx *Variable) (*Variable, error) {
@@ -1081,7 +1081,7 @@ func (v *Variable) reslice(low int64, high int64) (*Variable, error) {
 		return nil, fmt.Errorf("index out of bounds")
 	}
 
-	base := v.base + uintptr(int64(low)*v.stride)
+	base := v.Base + uintptr(int64(low)*v.stride)
 	len := high - low
 
 	if high-low < 0 {
@@ -1104,7 +1104,7 @@ func (v *Variable) reslice(low int64, high int64) (*Variable, error) {
 	r := v.newVariable("", 0, typ)
 	r.Cap = len
 	r.Len = len
-	r.base = base
+	r.Base = base
 	r.stride = v.stride
 	r.fieldType = v.fieldType
 

--- a/service/debugger/debugger.go
+++ b/service/debugger/debugger.go
@@ -541,12 +541,9 @@ func (d *Debugger) FindLocation(scope api.EvalScope, locStr string) ([]api.Locat
 		return nil, err
 	}
 
-	pc, err := d.process.PC()
-	if err != nil {
-		return nil, err
-	}
+	s, _ := d.process.ConvertEvalScope(scope.GoroutineID, scope.Frame)
 
-	locs, err := loc.Find(d, pc, locStr)
+	locs, err := loc.Find(d, s, locStr)
 	for i := range locs {
 		file, line, fn := d.process.PCToLine(locs[i].PC)
 		locs[i].File = file

--- a/service/test/integration_test.go
+++ b/service/test/integration_test.go
@@ -610,6 +610,18 @@ func TestClientServer_FindLocations(t *testing.T) {
 	})
 }
 
+func TestClientServer_FindLocationsAddr(t *testing.T) {
+	withTestClient("locationsprog2", t, func(c service.Client) {
+		<-c.Continue()
+
+		afunction := findLocationHelper(t, c, "main.afunction", false, 1, 0)[0]
+		anonfunc := findLocationHelper(t, c, "locationsprog2.go:25", false, 1, 0)[0]
+
+		findLocationHelper(t, c, "*fn1", false, 1, afunction)
+		findLocationHelper(t, c, "*fn3", false, 1, anonfunc)
+	})
+}
+
 func TestClientServer_EvalVariable(t *testing.T) {
 	withTestClient("testvariables", t, func(c service.Client) {
 		state := <-c.Continue()


### PR DESCRIPTION
Location specifiers starting with '*' can be followed by any
expression supported by the evaluator.
The expression should evaluate to either an integer (which will be
interpreted as an address) or to a function pointer (which will be
dereferenced to get the function's entry point).