### PR TITLE
proc/variables: bugfix: makes TestEvalExpression more robust

### DIFF
--- a/service/test/variables_test.go
+++ b/service/test/variables_test.go
@@ -537,7 +537,7 @@ func TestEvalExpression(t *testing.T) {
 		{"nil[0]", false, "", "", "", fmt.Errorf("expression \"nil\" (nil) does not support indexing")},
 		{"nil[2:10]", false, "", "", "", fmt.Errorf("can not slice \"nil\" (type nil)")},
 		{"nil.member", false, "", "", "", fmt.Errorf("type nil is not a struct")},
-		{"(map[string]int)(0x4000)", false, "", "", "", fmt.Errorf("can not convert \"0x4000\" to *struct hash<string,int>")},
+		{"(map[string]main.astruct)(0x4000)", false, "", "", "", fmt.Errorf("can not convert \"0x4000\" to *struct hash<string,main.astruct>")},
 
 		// typecasts
 		{"uint(i2)", false, "2", "", "uint", nil},


### PR DESCRIPTION
Fixes #320