### PR TITLE
Go 1.6beta1 compatibility

### DIFF
--- a/proc/proc.go
+++ b/proc/proc.go
@@ -705,13 +705,10 @@ func (dbp *Process) execPtraceFunc(fn func()) {
 }
 
 func (dbp *Process) getGoInformation() (ver GoVersion, isextld bool, err error) {
-	vv, err := dbp.EvalPackageVariable("runtime/internal/sys.BuildVersion")
+	vv, err := dbp.EvalPackageVariable("runtime.buildVersion")
 	if err != nil {
-		vv, err = dbp.EvalPackageVariable("runtime.buildVersion")
-		if err != nil {
-			err = fmt.Errorf("Could not determine version number: %v\n", err)
-			return
-		}
+		err = fmt.Errorf("Could not determine version number: %v\n", err)
+		return
 	}
 
 	ver, ok := parseVersionString(constant.StringVal(vv.Value))

--- a/service/test/variables_test.go
+++ b/service/test/variables_test.go
@@ -448,7 +448,7 @@ func TestEvalExpression(t *testing.T) {
 		// comparison operators
 		{"i2 == i3", false, "false", "", "", nil},
 		{"i2 == 2", false, "true", "", "", nil},
-		{"i2 == 2.0", false, "true", "", "", nil},
+		{"i2 == 2", false, "true", "", "", nil},
 		{"i2 == 3", false, "false", "", "", nil},
 		{"i2 != i3", false, "true", "", "", nil},
 		{"i2 < i3", false, "true", "", "", nil},


### PR DESCRIPTION
- Updated TestEvalExpression to work with the new behaviour of `go/constant` in go1.6beta1
- Reverted `runtime.buildVersion` change :(