### PR TITLE
proc/variables: bugfix: hang on ptr loop including interfaces

### DIFF
--- a/_fixtures/testvariables3.go
+++ b/_fixtures/testvariables3.go
@@ -35,6 +35,10 @@ func (b *bstruct) Error() string {
 	return "not an error"
 }
 
+type dstruct struct {
+	x interface{}
+}
+
 func main() {
 	i1 := 1
 	i2 := 2
@@ -118,6 +122,9 @@ func main() {
 	parr := &arr1
 	cpx1 := complex(1, 2)
 	const1 := constant.MakeInt64(3)
+	recursive1 := dstruct{}
+	recursive1.x = &recursive1
+	var iface5 interface{} = &recursive1
 
 	var amb1 = 1
 	runtime.Breakpoint()
@@ -125,5 +132,5 @@ func main() {
 		fmt.Println(amb1)
 	}
 	runtime.Breakpoint()
-	fmt.Println(i1, i2, i3, p1, amb1, s1, s3, a1, p2, p3, s2, as1, str1, f1, fn1, fn2, nilslice, nilptr, ch1, chnil, m1, mnil, m2, m3, up1, i4, i5, i6, err1, err2, errnil, iface1, iface2, ifacenil, arr1, parr, cpx1, const1, iface3, iface4)
+	fmt.Println(i1, i2, i3, p1, amb1, s1, s3, a1, p2, p3, s2, as1, str1, f1, fn1, fn2, nilslice, nilptr, ch1, chnil, m1, mnil, m2, m3, up1, i4, i5, i6, err1, err2, errnil, iface1, iface2, ifacenil, arr1, parr, cpx1, const1, iface3, iface4, recursive1, recursive1.x, iface5)
 }

--- a/proc/proc_test.go
+++ b/proc/proc_test.go
@@ -1054,3 +1054,12 @@ func TestRecursiveStructure(t *testing.T) {
 		t.Logf("v: %v\n", v)
 	})
 }
+
+func TestIssue316(t *testing.T) {
+	// A pointer loop that includes one interface should not send dlv into an infinite loop
+	withTestProcess("testvariables3", t, func(p *Process, fixture protest.Fixture) {
+		assertNoError(p.Continue(), t, "Continue()")
+		_, err := evalVariable(p, "iface5")
+		assertNoError(err, t, "EvalVariable()")
+	})
+}

--- a/proc/variables.go
+++ b/proc/variables.go
@@ -1464,7 +1464,7 @@ func (v *Variable) loadInterface(recurseLevel int, loadData bool) {
 
 	v.Children = []Variable{*data}
 	if loadData {
-		v.Children[0].loadValue()
+		v.Children[0].loadValueInternal(recurseLevel)
 	}
 	return
 }


### PR DESCRIPTION
`recurseLevel` value should not be reset when evaluating the contents
of an interface variable

Fixes #316