### PR TITLE
 proc/variables: prefetch of target process memory 

### DIFF
--- a/_fixtures/testvariables3.go
+++ b/_fixtures/testvariables3.go
@@ -48,6 +48,11 @@ type dstruct struct {
 
 type maptype map[string]interface{}
 
+type benchstruct struct {
+	a [64]byte
+	b [64]byte
+}
+
 func main() {
 	i1 := 1
 	i2 := 2
@@ -138,6 +143,12 @@ func main() {
 	var iface2fn2 interface{} = afunc2
 	var mapinf maptype = map[string]interface{}{}
 	mapinf["inf"] = mapinf
+	var bencharr [64]benchstruct
+	var benchparr [64]*benchstruct
+
+	for i := range benchparr {
+		benchparr[i] = &benchstruct{}
+	}
 
 	var amb1 = 1
 	runtime.Breakpoint()
@@ -145,5 +156,5 @@ func main() {
 		fmt.Println(amb1)
 	}
 	runtime.Breakpoint()
-	fmt.Println(i1, i2, i3, p1, amb1, s1, s3, a1, p2, p3, s2, as1, str1, f1, fn1, fn2, nilslice, nilptr, ch1, chnil, m1, mnil, m2, m3, up1, i4, i5, i6, err1, err2, errnil, iface1, iface2, ifacenil, arr1, parr, cpx1, const1, iface3, iface4, recursive1, recursive1.x, iface5, iface2fn1, iface2fn2, mapinf)
+	fmt.Println(i1, i2, i3, p1, amb1, s1, s3, a1, p2, p3, s2, as1, str1, f1, fn1, fn2, nilslice, nilptr, ch1, chnil, m1, mnil, m2, m3, up1, i4, i5, i6, err1, err2, errnil, iface1, iface2, ifacenil, arr1, parr, cpx1, const1, iface3, iface4, recursive1, recursive1.x, iface5, iface2fn1, iface2fn2, bencharr, benchparr, mapinf)
 }

--- a/proc/mem.go
+++ b/proc/mem.go
@@ -1,0 +1,54 @@
+package proc
+
+const cacheEnabled = true
+
+type memoryReadWriter interface {
+	readMemory(addr uintptr, size int) (data []byte, err error)
+	writeMemory(addr uintptr, data []byte) (written int, err error)
+}
+
+type memCache struct {
+	cacheAddr uintptr
+	cache     []byte
+	mem       memoryReadWriter
+}
+
+func (m *memCache) contains(addr uintptr, size int) bool {
+	return addr >= m.cacheAddr && (addr+uintptr(size)) <= (m.cacheAddr+uintptr(len(m.cache)))
+}
+
+func (m *memCache) readMemory(addr uintptr, size int) (data []byte, err error) {
+	if m.contains(addr, size) {
+		d := make([]byte, size)
+		copy(d, m.cache[addr-m.cacheAddr:])
+		return d, nil
+	}
+
+	return m.mem.readMemory(addr, size)
+}
+
+func (m *memCache) writeMemory(addr uintptr, data []byte) (written int, err error) {
+	return m.mem.writeMemory(addr, data)
+}
+
+func cacheMemory(mem memoryReadWriter, addr uintptr, size int) memoryReadWriter {
+	if !cacheEnabled {
+		return mem
+	}
+	if cacheMem, isCache := mem.(*memCache); isCache {
+		if cacheMem.contains(addr, size) {
+			return mem
+		} else {
+			cache, err := cacheMem.mem.readMemory(addr, size)
+			if err != nil {
+				return mem
+			}
+			return &memCache{addr, cache, mem}
+		}
+	}
+	cache, err := mem.readMemory(addr, size)
+	if err != nil {
+		return mem
+	}
+	return &memCache{addr, cache, mem}
+}


### PR DESCRIPTION
Prefetch the entire memory of structs and arrays and cache it instead
of issuing readMemory calls only when we get down to primitive types.
This reduces the number of system calls to ptrace that variables makes.

Improves performance in general, greatly improving it in some
particular cases (involving large structs).

```
Benchmarks without prefetching:
	BenchmarkArray-4         	      10	 132189944 ns/op	   0.06 MB/s
	BenchmarkArrayPointer-4  	       5	 202538503 ns/op	   0.04 MB/s
	BenchmarkMap-4           	     500	   3804336 ns/op	   0.27 MB/s
	BenchmarkGoroutinesInfo-4	      10	 126397104 ns/op
	BenchmarkLocalVariables-4	     500	   2494846 ns/op

Benchmarks with prefetching:
	BenchmarkArray-4         	     200	  10719087 ns/op	   0.76 MB/s
	BenchmarkArrayPointer-4  	     100	  11931326 ns/op	   0.73 MB/s
	BenchmarkMap-4           	    1000	   1466479 ns/op	   0.70 MB/s
	BenchmarkGoroutinesInfo-4	      10	 103407004 ns/op
	BenchmarkLocalVariables-4	    1000	   1530395 ns/op

Improvement factors:
	BenchmarkArray				12.33x
	BenchmarkArrayPointer		16.97x
	BenchmarkMap				 2.59x
	BenchmarkGoroutinesInfo		 1.22x
	BenchmarkLocalVariables		 1.63x
```