### PR TITLE
workaround: proc/eval: go sometimes inserts &v instead of v

### DIFF
--- a/service/test/variables_test.go
+++ b/service/test/variables_test.go
@@ -548,6 +548,9 @@ func TestEvalExpression(t *testing.T) {
 		{"uint8(i5)", false, "253", "", "uint8", nil},
 		{"int8(i5)", false, "-3", "", "int8", nil},
 		{"int8(i6)", false, "12", "", "int8", nil},
+
+		// misc
+		{"i1", true, "1", "", "int", nil},
 	}
 
 	withTestProcess("testvariables3", t, func(p *proc.Process, fixture protest.Fixture) {


### PR DESCRIPTION
For example: in testvariables3.go the `main` function instead of having an entry for `i1` has an entry for `&i1`. I guess this could be considered a go bug and I think at some point fixing it was discussed in the issue tracker, however it doesn't seem like it's getting fixed in 1.6 and it happens frequently in ordinary code.