### PR TITLE
proc: bugfix: clearing temp breakpoints

### DIFF
--- a/_fixtures/issue305.go
+++ b/_fixtures/issue305.go
@@ -1,0 +1,7 @@
+package main
+
+func main() {
+	for i := 0; i < 10; i++ {
+		println(i)
+	}
+}

--- a/proc/proc.go
+++ b/proc/proc.go
@@ -353,6 +353,7 @@ func (dbp *Process) Continue() error {
 		if err := dbp.pickCurrentThread(trapthread); err != nil {
 			return err
 		}
+
 		switch {
 		case dbp.CurrentThread.CurrentBreakpoint == nil:
 			// runtime.Breakpoint or manual stop
@@ -367,6 +368,9 @@ func (dbp *Process) Continue() error {
 		case dbp.CurrentThread.onTriggeredTempBreakpoint():
 			return dbp.clearTempBreakpoints()
 		case dbp.CurrentThread.onTriggeredBreakpoint():
+			if dbp.CurrentThread.onNextGoroutine() {
+				return dbp.clearTempBreakpoints()
+			}
 			return nil
 		default:
 			// not a manual stop, not on runtime.Breakpoint, not on a breakpoint, just repeat

--- a/proc/proc_test.go
+++ b/proc/proc_test.go
@@ -1315,6 +1315,25 @@ func TestIssue262(t *testing.T) {
 	})
 }
 
+func TestIssue305(t *testing.T) {
+	// If 'next' hits a breakpoint on the goroutine it's stepping through the temp breakpoints aren't cleared
+	// preventing further use of 'next' command
+	withTestProcess("issue305", t, func(p *Process, fixture protest.Fixture) {
+		addr, _, err := p.goSymTable.LineToPC(fixture.Source, 5)
+		assertNoError(err, t, "LineToPC()")
+		_, err = p.SetBreakpoint(addr)
+		assertNoError(err, t, "SetBreakpoint()")
+
+		assertNoError(p.Continue(), t, "Continue()")
+
+		assertNoError(p.Next(), t, "Next() 1")
+		assertNoError(p.Next(), t, "Next() 2")
+		assertNoError(p.Next(), t, "Next() 3")
+		assertNoError(p.Next(), t, "Next() 4")
+		assertNoError(p.Next(), t, "Next() 5")
+	})
+}
+
 func TestIssue341(t *testing.T) {
 	// pointer loop through map entries
 	withTestProcess("testvariables3", t, func(p *Process, fixture protest.Fixture) {

--- a/proc/threads.go
+++ b/proc/threads.go
@@ -359,3 +359,17 @@ func (thread *Thread) onRuntimeBreakpoint() bool {
 	}
 	return loc.Fn != nil && loc.Fn.Name == "runtime.breakpoint"
 }
+
+// Returns true if this thread is on the goroutine requested by the current 'next' command
+func (th *Thread) onNextGoroutine() bool {
+	var bp *Breakpoint
+	for i := range th.dbp.Breakpoints {
+		if th.dbp.Breakpoints[i].Temp {
+			bp = th.dbp.Breakpoints[i]
+		}
+	}
+	if bp == nil {
+		return false
+	}
+	return bp.checkCondition(th)
+}

--- a/proc/variables.go
+++ b/proc/variables.go
@@ -20,7 +20,7 @@ const (
 	maxVariableRecurse = 1  // How far to recurse when evaluating nested types.
 	maxArrayValues     = 64 // Max value for reading large arrays.
 	maxErrCount        = 3  // Max number of read errors to accept while evaluating slices, arrays and structs
-	
+
 	maxArrayStridePrefetch = 1024 // Maximum size of array stride for which we will prefetch the array contents
 
 	chanRecv = "chan receive"


### PR DESCRIPTION
Temp breakpoints should be cleared even if a non-temp breakpoint is
triggered on the same goroutine that the temp breakpoints are set on.