### PR TITLE
Conditional Breakpoints (backend)

### DIFF
--- a/proc/eval.go
+++ b/proc/eval.go
@@ -54,7 +54,9 @@ func (scope *EvalScope) evalAST(t ast.Expr) (*Variable, error) {
 	case *ast.SelectorExpr: // <expression>.<identifier>
 		// try to interpret the selector as a package variable
 		if maybePkg, ok := node.X.(*ast.Ident); ok {
-			if v, err := scope.packageVarAddr(maybePkg.Name + "." + node.Sel.Name); err == nil {
+			if maybePkg.Name == "runtime" && node.Sel.Name == "curg" {
+				return scope.Thread.getGVariable()
+			} else if v, err := scope.packageVarAddr(maybePkg.Name + "." + node.Sel.Name); err == nil {
 				return v, nil
 			}
 		}

--- a/proc/proc.go
+++ b/proc/proc.go
@@ -497,7 +497,11 @@ func (dbp *Process) GoroutinesInfo() ([]*G, error) {
 	allgptr := binary.LittleEndian.Uint64(faddr)
 
 	for i := uint64(0); i < allglen; i++ {
-		g, err := parseG(dbp.CurrentThread, allgptr+(i*uint64(dbp.arch.PtrSize())), true)
+		gvar, err := dbp.CurrentThread.newGVariable(uintptr(allgptr+(i*uint64(dbp.arch.PtrSize()))), true)
+		if err != nil {
+			return nil, err
+		}
+		g, err := gvar.parseG()
 		if err != nil {
 			return nil, err
 		}

--- a/proc/proc.go
+++ b/proc/proc.go
@@ -6,10 +6,13 @@ import (
 	"encoding/binary"
 	"errors"
 	"fmt"
+	"go/ast"
 	"go/constant"
+	"go/token"
 	"os"
 	"path/filepath"
 	"runtime"
+	"strconv"
 	"strings"
 	"sync"
 
@@ -297,7 +300,17 @@ func (dbp *Process) Next() (err error) {
 	if !goroutineExiting {
 		for i := range dbp.Breakpoints {
 			if dbp.Breakpoints[i].Temp {
-				dbp.Breakpoints[i].Cond = g.ID
+				dbp.Breakpoints[i].Cond = &ast.BinaryExpr{
+					Op: token.EQL,
+					X: &ast.SelectorExpr{
+						X: &ast.SelectorExpr{
+							X:   &ast.Ident{Name: "runtime"},
+							Sel: &ast.Ident{Name: "curg"},
+						},
+						Sel: &ast.Ident{Name: "goid"},
+					},
+					Y: &ast.BasicLit{Kind: token.INT, Value: strconv.Itoa(g.ID)},
+				}
 			}
 		}
 	}
@@ -374,18 +387,43 @@ func (dbp *Process) Continue() error {
 					}
 				}
 			}
-			return nil
+			return dbp.conditionErrors()
 		case dbp.CurrentThread.onTriggeredTempBreakpoint():
-			return dbp.clearTempBreakpoints()
-		case dbp.CurrentThread.onTriggeredBreakpoint():
-			if dbp.CurrentThread.onNextGoroutine() {
-				return dbp.clearTempBreakpoints()
+			err := dbp.clearTempBreakpoints()
+			if err != nil {
+				return err
 			}
-			return nil
+			return dbp.conditionErrors()
+		case dbp.CurrentThread.onTriggeredBreakpoint():
+			onNextGoroutine, err := dbp.CurrentThread.onNextGoroutine()
+			if err != nil {
+				return err
+			}
+			if onNextGoroutine {
+				err := dbp.clearTempBreakpoints()
+				if err != nil {
+					return err
+				}
+			}
+			return dbp.conditionErrors()
 		default:
 			// not a manual stop, not on runtime.Breakpoint, not on a breakpoint, just repeat
 		}
 	}
+}
+
+func (dbp *Process) conditionErrors() error {
+	var condErr error
+	for _, th := range dbp.Threads {
+		if th.CurrentBreakpoint != nil && th.BreakpointConditionError != nil {
+			if condErr == nil {
+				condErr = th.BreakpointConditionError
+			} else {
+				return fmt.Errorf("multiple errors evaluating conditions")
+			}
+		}
+	}
+	return condErr
 }
 
 // pick a new dbp.CurrentThread, with the following priority:
@@ -665,6 +703,8 @@ func (dbp *Process) run(fn func() error) error {
 	}
 	for _, th := range dbp.Threads {
 		th.CurrentBreakpoint = nil
+		th.BreakpointConditionMet = false
+		th.BreakpointConditionError = nil
 	}
 	if err := fn(); err != nil {
 		return err

--- a/proc/threads.go
+++ b/proc/threads.go
@@ -17,10 +17,12 @@ import (
 // a whole, and Status represents the last result of a `wait` call
 // on this thread.
 type Thread struct {
-	ID                     int             // Thread ID or mach port
-	Status                 *WaitStatus     // Status returned from last wait call
-	CurrentBreakpoint      *Breakpoint     // Breakpoint thread is currently stopped at
-	BreakpointConditionMet bool            // Output of evaluating the breakpoint's condition
+	ID                       int             // Thread ID or mach port
+	Status                   *WaitStatus // Status returned from last wait call
+	CurrentBreakpoint        *Breakpoint     // Breakpoint thread is currently stopped at
+	BreakpointConditionMet   bool            // Output of evaluating the breakpoint's condition
+	BreakpointConditionError error           // Error evaluating the breakpoint's condition
+
 	dbp            *Process
 	singleStepping bool
 	running        bool
@@ -362,7 +364,7 @@ func (thread *Thread) SetCurrentBreakpoint() error {
 		if err = thread.SetPC(bp.Addr); err != nil {
 			return err
 		}
-		thread.BreakpointConditionMet = bp.checkCondition(thread)
+		thread.BreakpointConditionMet, thread.BreakpointConditionError = bp.checkCondition(thread)
 		if thread.onTriggeredBreakpoint() {
 			if g, err := thread.GetG(); err == nil {
 				thread.CurrentBreakpoint.HitCount[g.ID]++
@@ -390,7 +392,7 @@ func (thread *Thread) onRuntimeBreakpoint() bool {
 }
 
 // Returns true if this thread is on the goroutine requested by the current 'next' command
-func (th *Thread) onNextGoroutine() bool {
+func (th *Thread) onNextGoroutine() (bool, error) {
 	var bp *Breakpoint
 	for i := range th.dbp.Breakpoints {
 		if th.dbp.Breakpoints[i].Temp {
@@ -398,7 +400,7 @@ func (th *Thread) onNextGoroutine() bool {
 		}
 	}
 	if bp == nil {
-		return false
+		return false, nil
 	}
 	return bp.checkCondition(th)
 }

--- a/service/debugger/debugger.go
+++ b/service/debugger/debugger.go
@@ -172,7 +172,7 @@ func (d *Debugger) CreateBreakpoint(requestedBp *api.Breakpoint) (*api.Breakpoin
 	bp.Goroutine = requestedBp.Goroutine
 	bp.Stacktrace = requestedBp.Stacktrace
 	bp.Variables = requestedBp.Variables
-	bp.Cond = -1
+	bp.Cond = nil
 	createdBp = api.ConvertBreakpoint(bp)
 	log.Printf("created breakpoint: %#v", createdBp)
 	return createdBp, nil


### PR DESCRIPTION
Changed `Breakpoint.Cond` to accept any expression that can be evaluated instead of just an integer.
Added fake variable `runtime.curg` to `eval.go` so that temp breakpoints used by `Next` can be expressed as a comparision on `runtime.curg.goid`.