### PR TITLE
Breakpoint Names and conditions

### DIFF
--- a/proc/breakpoints.go
+++ b/proc/breakpoints.go
@@ -19,6 +19,7 @@ type Breakpoint struct {
 
 	Addr         uint64 // Address breakpoint is set for.
 	OriginalData []byte // If software breakpoint, the data we replace with breakpoint instruction.
+	Name         string // User defined name of the breakpoint
 	ID           int    // Monotonically increasing ID.
 	Temp         bool   // Whether this is a temp breakpoint (for next'ing).
 

--- a/service/api/conversions.go
+++ b/service/api/conversions.go
@@ -1,8 +1,11 @@
 package api
 
 import (
+	"bytes"
 	"debug/gosym"
 	"go/constant"
+	"go/printer"
+	"go/token"
 	"golang.org/x/debug/dwarf"
 	"reflect"
 	"strconv"
@@ -14,6 +17,7 @@ import (
 // an api.Breakpoint.
 func ConvertBreakpoint(bp *proc.Breakpoint) *Breakpoint {
 	b := &Breakpoint{
+		Name:          bp.Name,
 		ID:            bp.ID,
 		FunctionName:  bp.FunctionName,
 		File:          bp.File,
@@ -30,6 +34,10 @@ func ConvertBreakpoint(bp *proc.Breakpoint) *Breakpoint {
 	for idx := range bp.HitCount {
 		b.HitCount[strconv.Itoa(idx)] = bp.HitCount[idx]
 	}
+
+	var buf bytes.Buffer
+	printer.Fprint(&buf, token.NewFileSet(), bp.Cond)
+	b.Cond = buf.String()
 
 	return b
 }

--- a/service/api/types.go
+++ b/service/api/types.go
@@ -1,8 +1,12 @@
 package api
 
 import (
+	"errors"
+	"fmt"
 	"github.com/derekparker/delve/proc"
 	"reflect"
+	"strconv"
+	"unicode"
 )
 
 // DebuggerState represents the current context of the debugger.
@@ -25,6 +29,8 @@ type DebuggerState struct {
 type Breakpoint struct {
 	// ID is a unique identifier for the breakpoint.
 	ID int `json:"id"`
+	// User defined name of the breakpoint
+	Name string `json:"name"`
 	// Addr is the address of the breakpoint.
 	Addr uint64 `json:"addr"`
 	// File is the source file for the breakpoint.
@@ -34,6 +40,9 @@ type Breakpoint struct {
 	// FunctionName is the name of the function at the current breakpoint, and
 	// may not always be available.
 	FunctionName string `json:"functionName,omitempty"`
+
+	// Breakpoint condition
+	Cond string
 
 	// tracepoint flag
 	Tracepoint bool `json:"continue"`
@@ -47,6 +56,20 @@ type Breakpoint struct {
 	HitCount map[string]uint64 `json:"hitCount"`
 	// number of times a breakpoint has been reached
 	TotalHitCount uint64 `json:"totalHitCount"`
+}
+
+func ValidBreakpointName(name string) error {
+	if _, err := strconv.Atoi(name); err == nil {
+		return errors.New("breakpoint name can not be a number")
+	}
+
+	for _, ch := range name {
+		if !(unicode.IsLetter(ch) || unicode.IsDigit(ch)) {
+			return fmt.Errorf("invalid character in breakpoint name '%c'", ch)
+		}
+	}
+
+	return nil
 }
 
 // Thread is a thread within the debugged process.

--- a/service/client.go
+++ b/service/client.go
@@ -36,12 +36,19 @@ type Client interface {
 
 	// GetBreakpoint gets a breakpoint by ID.
 	GetBreakpoint(id int) (*api.Breakpoint, error)
+	// GetBreakpointByName gets a breakpoint by name.
+	GetBreakpointByName(name string) (*api.Breakpoint, error)
 	// CreateBreakpoint creates a new breakpoint.
 	CreateBreakpoint(*api.Breakpoint) (*api.Breakpoint, error)
 	// ListBreakpoints gets all breakpoints.
 	ListBreakpoints() ([]*api.Breakpoint, error)
 	// ClearBreakpoint deletes a breakpoint by ID.
 	ClearBreakpoint(id int) (*api.Breakpoint, error)
+	// ClearBreakpointByName deletes a breakpoint by name
+	ClearBreakpointByName(name string) (*api.Breakpoint, error)
+	// Allows user to update an existing breakpoint for example to change the information
+	// retrieved when the breakpoint is hit or to change, add or remove the break condition
+	AmendBreakpoint(*api.Breakpoint) error
 
 	// ListThreads lists all threads.
 	ListThreads() ([]*api.Thread, error)

--- a/service/rpc/client.go
+++ b/service/rpc/client.go
@@ -139,6 +139,12 @@ func (c *RPCClient) GetBreakpoint(id int) (*api.Breakpoint, error) {
 	return breakpoint, err
 }
 
+func (c *RPCClient) GetBreakpointByName(name string) (*api.Breakpoint, error) {
+	breakpoint := new(api.Breakpoint)
+	err := c.call("GetBreakpointByName", name, breakpoint)
+	return breakpoint, err
+}
+
 func (c *RPCClient) CreateBreakpoint(breakPoint *api.Breakpoint) (*api.Breakpoint, error) {
 	newBreakpoint := new(api.Breakpoint)
 	err := c.call("CreateBreakpoint", breakPoint, &newBreakpoint)
@@ -155,6 +161,17 @@ func (c *RPCClient) ClearBreakpoint(id int) (*api.Breakpoint, error) {
 	bp := new(api.Breakpoint)
 	err := c.call("ClearBreakpoint", id, bp)
 	return bp, err
+}
+
+func (c *RPCClient) ClearBreakpointByName(name string) (*api.Breakpoint, error) {
+	bp := new(api.Breakpoint)
+	err := c.call("ClearBreakpointByName", name, bp)
+	return bp, err
+}
+
+func (c *RPCClient) AmendBreakpoint(bp *api.Breakpoint) error {
+	err := c.call("AmendBreakpoint", bp, nil)
+	return err
 }
 
 func (c *RPCClient) ListThreads() ([]*api.Thread, error) {

--- a/service/rpc/server.go
+++ b/service/rpc/server.go
@@ -121,6 +121,15 @@ func (s *RPCServer) GetBreakpoint(id int, breakpoint *api.Breakpoint) error {
 	return nil
 }
 
+func (s *RPCServer) GetBreakpointByName(name string, breakpoint *api.Breakpoint) error {
+	bp := s.debugger.FindBreakpointByName(name)
+	if bp == nil {
+		return fmt.Errorf("no breakpoint with name %s", name)
+	}
+	*breakpoint = *bp
+	return nil
+}
+
 type StacktraceGoroutineArgs struct {
 	Id    int
 	Depth int
@@ -161,6 +170,24 @@ func (s *RPCServer) ClearBreakpoint(id int, breakpoint *api.Breakpoint) error {
 	}
 	*breakpoint = *deleted
 	return nil
+}
+
+func (s *RPCServer) ClearBreakpointByName(name string, breakpoint *api.Breakpoint) error {
+	bp := s.debugger.FindBreakpointByName(name)
+	if bp == nil {
+		return fmt.Errorf("no breakpoint with name %s", name)
+	}
+	deleted, err := s.debugger.ClearBreakpoint(bp)
+	if err != nil {
+		return err
+	}
+	*breakpoint = *deleted
+	return nil
+}
+
+func (s *RPCServer) AmendBreakpoint(amend *api.Breakpoint, unused *int) error {
+	*unused = 0
+	return s.debugger.AmendBreakpoint(amend)
 }
 
 func (s *RPCServer) ListThreads(arg interface{}, threads *[]*api.Thread) (err error) {


### PR DESCRIPTION
I've implemented the mailing list proposal.

This PR builds on top of PR #346 of course.

I've also refactored `terminal/command.go` so that every time we print a location or a breakpoint two new functions, `formatLocation` and `formatBreakpoint`, are used instead of adhoc printf format strings.

This PR introduces a second switch statement for subcommands, similar to the one in `scopePrefix`, maybe this would be a good time to do issue #240 before this gets out of hand.