### PR TITLE
terminal/command: bugfix: goroutines doesn't work without arguments

### DIFF
--- a/terminal/command.go
+++ b/terminal/command.go
@@ -235,6 +235,8 @@ func goroutines(t *Term, argstr string) error {
 			fgl = fglRuntimeCurrent
 		case "-g":
 			fgl = fglGo
+		case "":
+			// nothing to do
 		default:
 			return fmt.Errorf("wrong argument: '%s'", args[0])
 		}


### PR DESCRIPTION
Splitting an empty string results in a one element array with a
single empty string element.

See: http://play.golang.org/p/EzVX64Q82A