### PR TITLE
proc: step now goes to next line, including funcs

### DIFF
--- a/_fixtures/teststep.go
+++ b/_fixtures/teststep.go
@@ -1,0 +1,15 @@
+package main
+
+import (
+	"fmt"
+	"runtime"
+)
+
+func callme() {
+	fmt.Println("hi")
+}
+
+func main() {
+	runtime.Breakpoint()
+	callme()
+}

--- a/proc/proc_darwin.go
+++ b/proc/proc_darwin.go
@@ -396,7 +396,7 @@ func (dbp *Process) resume() error {
 	// all threads stopped over a breakpoint are made to step over it
 	for _, thread := range dbp.Threads {
 		if thread.CurrentBreakpoint != nil {
-			if err := thread.Step(); err != nil {
+			if err := thread.StepInstruction(); err != nil {
 				return err
 			}
 			thread.CurrentBreakpoint = nil

--- a/proc/proc_linux.go
+++ b/proc/proc_linux.go
@@ -417,7 +417,7 @@ func (dbp *Process) resume() error {
 	// all threads stopped over a breakpoint are made to step over it
 	for _, thread := range dbp.Threads {
 		if thread.CurrentBreakpoint != nil {
-			if err := thread.Step(); err != nil {
+			if err := thread.StepInstruction(); err != nil {
 				return err
 			}
 			thread.CurrentBreakpoint = nil

--- a/proc/proc_windows.go
+++ b/proc/proc_windows.go
@@ -461,7 +461,7 @@ func (dbp *Process) resume() error {
 	thread := dbp.Threads[dbp.os.breakThread]
 	// This relies on the same assumptions as dbp.setCurrentBreakpoints
 	if thread.CurrentBreakpoint != nil {
-		if err := thread.Step(); err != nil {
+		if err := thread.StepInstruction(); err != nil {
 			return err
 		}
 		thread.CurrentBreakpoint = nil

--- a/proc/threads.go
+++ b/proc/threads.go
@@ -4,10 +4,11 @@ import (
 	"debug/gosym"
 	"encoding/binary"
 	"fmt"
-	"golang.org/x/debug/dwarf"
 	"path/filepath"
 	"reflect"
 	"runtime"
+
+	"golang.org/x/debug/dwarf"
 
 	"github.com/derekparker/delve/dwarf/frame"
 )
@@ -53,20 +54,20 @@ func (thread *Thread) Continue() error {
 	// Check whether we are stopped at a breakpoint, and
 	// if so, single step over it before continuing.
 	if _, ok := thread.dbp.FindBreakpoint(pc); ok {
-		if err := thread.Step(); err != nil {
+		if err := thread.StepInstruction(); err != nil {
 			return err
 		}
 	}
 	return thread.resume()
 }
 
-// Step a single instruction.
+// StepInstruction steps a single instruction.
 //
 // Executes exactly one instruction and then returns.
 // If the thread is at a breakpoint, we first clear it,
 // execute the instruction, and then replace the breakpoint.
 // Otherwise we simply execute the next instruction.
-func (thread *Thread) Step() (err error) {
+func (thread *Thread) StepInstruction() (err error) {
 	thread.running = true
 	thread.singleStepping = true
 	defer func() {

--- a/service/api/types.go
+++ b/service/api/types.go
@@ -184,8 +184,10 @@ type EvalScope struct {
 const (
 	// Continue resumes process execution.
 	Continue = "continue"
-	// Step continues for a single instruction, entering function calls.
+	// Step continues to next source line, entering function calls.
 	Step = "step"
+	// SingleStep continues for exactly 1 cpu instruction.
+	StepInstruction = "stepInstruction"
 	// Next continues to the next source line, not entering function calls.
 	Next = "next"
 	// SwitchThread switches the debugger's current thread context.

--- a/service/client.go
+++ b/service/client.go
@@ -25,6 +25,8 @@ type Client interface {
 	Next() (*api.DebuggerState, error)
 	// Step continues to the next source line, entering function calls.
 	Step() (*api.DebuggerState, error)
+	// SingleStep will step a single cpu instruction.
+	StepInstruction() (*api.DebuggerState, error)
 	// SwitchThread switches the current thread context.
 	SwitchThread(threadID int) (*api.DebuggerState, error)
 	// SwitchGoroutine switches the current goroutine (and the current thread as well)

--- a/service/debugger/debugger.go
+++ b/service/debugger/debugger.go
@@ -261,6 +261,9 @@ func (d *Debugger) Command(command *api.DebuggerCommand) (*api.DebuggerState, er
 	case api.Step:
 		log.Print("stepping")
 		err = d.process.Step()
+	case api.StepInstruction:
+		log.Print("single stepping")
+		err = d.process.StepInstruction()
 	case api.SwitchThread:
 		log.Printf("switching to thread %d", command.ThreadID)
 		err = d.process.SwitchThread(command.ThreadID)

--- a/service/rpc/client.go
+++ b/service/rpc/client.go
@@ -101,6 +101,12 @@ func (c *RPCClient) Step() (*api.DebuggerState, error) {
 	return state, err
 }
 
+func (c *RPCClient) StepInstruction() (*api.DebuggerState, error) {
+	state := new(api.DebuggerState)
+	err := c.call("Command", &api.DebuggerCommand{Name: api.StepInstruction}, state)
+	return state, err
+}
+
 func (c *RPCClient) SwitchThread(threadID int) (*api.DebuggerState, error) {
 	state := new(api.DebuggerState)
 	cmd := &api.DebuggerCommand{

--- a/terminal/command.go
+++ b/terminal/command.go
@@ -60,7 +60,8 @@ func DebugCommands(client service.Client) *Commands {
 		{aliases: []string{"trace", "t"}, cmdFn: tracepoint, helpMsg: "Set tracepoint, takes the same arguments as break."},
 		{aliases: []string{"restart", "r"}, cmdFn: restart, helpMsg: "Restart process."},
 		{aliases: []string{"continue", "c"}, cmdFn: cont, helpMsg: "Run until breakpoint or program termination."},
-		{aliases: []string{"step", "si"}, cmdFn: step, helpMsg: "Single step through program."},
+		{aliases: []string{"step", "s"}, cmdFn: step, helpMsg: "Single step through program."},
+		{aliases: []string{"step-instruction", "si"}, cmdFn: stepInstruction, helpMsg: "Single step a single cpu instruction."},
 		{aliases: []string{"next", "n"}, cmdFn: next, helpMsg: "Step over to next source line."},
 		{aliases: []string{"threads"}, cmdFn: threads, helpMsg: "Print out info for every traced thread."},
 		{aliases: []string{"thread", "tr"}, cmdFn: thread, helpMsg: "Switch to the specified thread."},
@@ -464,6 +465,15 @@ func cont(t *Term, args string) error {
 
 func step(t *Term, args string) error {
 	state, err := t.client.Step()
+	if err != nil {
+		return err
+	}
+	printcontext(t, state)
+	return nil
+}
+
+func stepInstruction(t *Term, args string) error {
+	state, err := t.client.StepInstruction()
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
This patch modifies the `step` command to step to the next source line,
stepping into any function encountered along the way.

Fixes #360