### PR TITLE
test mode doesn't work on Windows

### DIFF
--- a/cmd/dlv/main.go
+++ b/cmd/dlv/main.go
@@ -256,6 +256,10 @@ starts and attaches to it, and enable you to immediately begin debugging your pr
 					return 1
 				}
 				debugname := "./" + base + ".test"
+				// On Windows, "go test" generates an executable with the ".exe" extension
+				if runtime.GOOS == "windows" {
+					debugname += ".exe"
+				}				
 				defer os.Remove(debugname)
 				processArgs := append([]string{debugname}, args...)
 


### PR DESCRIPTION
Delve is attaching to the wrong executable name on Windows. On Windows, "go test" generates an executable with the ".exe" extension.