### PR TITLE
terminal/command: Fixed 'test' command

### DIFF
--- a/cmd/dlv/main.go
+++ b/cmd/dlv/main.go
@@ -256,6 +256,10 @@ starts and attaches to it, and enable you to immediately begin debugging your pr
 					return 1
 				}
 				debugname := "./" + base + ".test"
+				// On Windows, "go test" generates an executable with the ".exe" extension
+				if runtime.GOOS == "windows" {
+					debugname += ".exe"
+				}				
 				defer os.Remove(debugname)
 				processArgs := append([]string{debugname}, args...)
 


### PR DESCRIPTION
This change addresses a Windows-specifc issue with the 'test' command. On
Windows, 'go test' generate executables with a '.exe' filename extention,
but the current implementation attaches to a filename without the
extention.