### PR TITLE
[service/debugger] Case-insensitive paths on Windows

### DIFF
--- a/proc/proc.go
+++ b/proc/proc.go
@@ -160,8 +160,8 @@ func (dbp *Process) LoadInformation(path string) error {
 }
 
 // FindFileLocation returns the PC for a given file:line.
+// Assumes that `file` is normailzed to lower case and '/' on Windows.
 func (dbp *Process) FindFileLocation(fileName string, lineno int) (uint64, error) {
-	fileName = filepath.ToSlash(fileName)
 	pc, _, err := dbp.goSymTable.LineToPC(fileName, lineno)
 	if err != nil {
 		return 0, err

--- a/proc/test/support.go
+++ b/proc/test/support.go
@@ -7,8 +7,9 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
-	"testing"
 	"runtime"
+	"strings"
+	"testing"
 )
 
 // Fixture is a test binary.
@@ -64,7 +65,10 @@ func BuildFixture(name string) Fixture {
 
 	source, _ := filepath.Abs(path)
 	source = filepath.ToSlash(source)
-	
+	if runtime.GOOS == "windows" {
+		source = strings.ToLower(source)
+	}
+
 	Fixtures[name] = Fixture{Name: name, Path: tmpfile, Source: source}
 	return Fixtures[name]
 }

--- a/service/debugger/debugger.go
+++ b/service/debugger/debugger.go
@@ -149,7 +149,7 @@ func (d *Debugger) CreateBreakpoint(requestedBp *api.Breakpoint) (*api.Breakpoin
 	)
 	switch {
 	case len(requestedBp.File) > 0:
-		addr, err = d.process.FindFileLocation(requestedBp.File, requestedBp.Line)
+		addr, err = d.process.FindFileLocation(normalizePath(requestedBp.File), requestedBp.Line)
 	case len(requestedBp.FunctionName) > 0:
 		if requestedBp.Line >= 0 {
 			addr, err = d.process.FindFunctionLocation(requestedBp.FunctionName, false, requestedBp.Line)


### PR DESCRIPTION
Fixes #370.

The policy on path normalization after this change is roughly:

* `service/debugger` takes care of normalizing any path inputs from the user before using in comparisons
* `proc` package assumes normalized file names

This feels right, but other options might be available.  For example, normalization could be pushed all the way down into proc and any other code that handles paths.  Unfortunately `(*debug.gosym.Table).LineToPC` doesn't normalize it's input, so there would need to be a wrapper around that to do the normalization.
