### PR TITLE
Two bugs reported in issue #354

### DIFF
--- a/proc/mem.go
+++ b/proc/mem.go
@@ -35,6 +35,9 @@ func cacheMemory(mem memoryReadWriter, addr uintptr, size int) memoryReadWriter 
 	if !cacheEnabled {
 		return mem
 	}
+	if size <= 0 {
+		return mem
+	}
 	if cacheMem, isCache := mem.(*memCache); isCache {
 		if cacheMem.contains(addr, size) {
 			return mem

--- a/terminal/command.go
+++ b/terminal/command.go
@@ -819,6 +819,9 @@ func (c *Commands) sourceCommand(t *Term, args string) error {
 }
 
 func digits(n int) int {
+	if n <= 0 {
+		return 1
+	}
 	return int(math.Floor(math.Log10(float64(n)))) + 1
 }
 

--- a/terminal/command_test.go
+++ b/terminal/command_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/derekparker/delve/proc/test"
+	"github.com/derekparker/delve/service/api"
 )
 
 func TestCommandDefault(t *testing.T) {
@@ -97,4 +98,9 @@ func TestExecuteFile(t *testing.T) {
 	if breakCount != 1 || traceCount != 1 {
 		t.Fatalf("Wrong counts break: %d trace: %d\n", breakCount, traceCount)
 	}
+}
+
+func TestIssue354(t *testing.T) {
+	printStack([]api.Stackframe{ }, "")
+	printStack([]api.Stackframe{{api.Location{PC: 0, File: "irrelevant.go", Line: 10, Function: nil}, nil, nil}}, "")
 }


### PR DESCRIPTION
This pull request attempts to address the two bugs reported in Issue #354.

@antonikonovalov's bug is probably connected to reading uninitializer memory, I can't be sure because there aren't any exect instructions to reproduce it, but it seems pretty likely.

@OneOfOne's bug happens when the stack contains one frame or less.