### PR TITLE
service/rpc: clean irrelevant net/rpc error messages

### DIFF
--- a/service/test/integration_test.go
+++ b/service/test/integration_test.go
@@ -122,7 +122,7 @@ func TestRestart_attachPid(t *testing.T) {
 		Listener:  nil,
 		AttachPid: 999,
 	}, false)
-	if err := server.Restart(nil, nil); err == nil {
+	if err := server.Restart(); err == nil {
 		t.Fatal("expected error on restart after attaching to pid but got none")
 	}
 }


### PR DESCRIPTION
Note that this change is purely cosmetic, I tried to do it with the least possible amount of diff noise I could get away with.

Fixes #378 