### PR TITLE
proc/variables: crash while reading unintialized variable

### DIFF
--- a/_fixtures/issue384.go
+++ b/_fixtures/issue384.go
@@ -1,0 +1,17 @@
+package main
+
+import (
+	"fmt"
+	"reflect"
+)
+
+func main() {
+	type S struct {
+		F string `species:"gopher" color:"blue"`
+	}
+
+	s := S{}
+	st := reflect.TypeOf(s)
+	field := st.Field(0)
+	fmt.Println(field.Tag.Get("color"), field.Tag.Get("species"))
+}

--- a/proc/proc_test.go
+++ b/proc/proc_test.go
@@ -1462,3 +1462,16 @@ func TestStepIntoFunction(t *testing.T) {
 		}
 	})
 }
+
+func TestIssue384(t *testing.T) {
+	// Crash related to reading uninitialized memory, introduced by the memory prefetching optimization
+	withTestProcess("issue384", t, func(p *Process, fixture protest.Fixture) {
+		start, _, err := p.goSymTable.LineToPC(fixture.Source, 13)
+		assertNoError(err, t, "LineToPC()")
+		_, err = p.SetBreakpoint(start)
+		assertNoError(err, t, "SetBreakpoint()")
+		assertNoError(p.Continue(), t, "Continue()")
+		_, err = evalVariable(p, "st")
+		assertNoError(err, t, "EvalVariable()")
+	})
+}

--- a/proc/variables.go
+++ b/proc/variables.go
@@ -3,6 +3,7 @@ package proc
 import (
 	"bytes"
 	"encoding/binary"
+	"errors"
 	"fmt"
 	"go/constant"
 	"go/parser"
@@ -925,6 +926,10 @@ func (v *Variable) loadSliceInfo(t *dwarf.SliceType) {
 
 func (v *Variable) loadArrayValues(recurseLevel int) {
 	if v.Unreadable != nil {
+		return
+	}
+	if v.Len < 0 {
+		v.Unreadable = errors.New("Negative array length")
 		return
 	}
 


### PR DESCRIPTION

Fixes #384 