### PR TITLE
proc: bugs setting next breakpoints

### DIFF
--- a/_fixtures/issue332.go
+++ b/_fixtures/issue332.go
@@ -1,0 +1,15 @@
+package main
+
+import "fmt"
+
+func main() {
+	m := make([]string, 1, 25)
+	fmt.Println(m) // [ ]
+	changeMe(m)
+	fmt.Println(m) // [Todd]
+}
+
+func changeMe(z []string) {
+	z[0] = "Todd"
+	fmt.Println(z) // [Todd]
+}

--- a/proc/threads.go
+++ b/proc/threads.go
@@ -164,7 +164,7 @@ func (ge GoroutineExitingError) Error() string {
 // Set breakpoints at every line, and the return address. Also look for
 // a deferred function and set a breakpoint there too.
 func (thread *Thread) next(curpc uint64, fde *frame.FrameDescriptionEntry, file string, line int) error {
-	pcs := thread.dbp.lineInfo.AllPCsBetween(fde.Begin(), fde.End(), file)
+	pcs := thread.dbp.lineInfo.AllPCsBetween(fde.Begin(), fde.End()-1, file)
 
 	g, err := thread.GetG()
 	if err != nil {

--- a/proc/variables.go
+++ b/proc/variables.go
@@ -311,7 +311,7 @@ func (scope *EvalScope) PtrSize() int {
 // ChanRecvBlocked returns whether the goroutine is blocked on
 // a channel read operation.
 func (g *G) ChanRecvBlocked() bool {
-	return g.WaitReason == chanRecv
+	return (g.thread == nil) && (g.WaitReason == chanRecv)
 }
 
 // chanRecvReturnAddr returns the address of the return from a channel read.

--- a/terminal/command.go
+++ b/terminal/command.go
@@ -882,7 +882,7 @@ func printcontextThread(t *Term, th *api.Thread) {
 	fn := th.Function
 
 	if th.Breakpoint == nil {
-		fmt.Printf("> %s() %s:%d\n", fn.Name, ShortenFilePath(th.File), th.Line)
+		fmt.Printf("> %s() %s:%d (PC: %#v)\n", fn.Name, ShortenFilePath(th.File), th.Line, th.PC)
 		return
 	}
 
@@ -896,21 +896,23 @@ func printcontextThread(t *Term, th *api.Thread) {
 	}
 
 	if hitCount, ok := th.Breakpoint.HitCount[strconv.Itoa(th.GoroutineID)]; ok {
-		fmt.Printf("> %s(%s) %s:%d (hits goroutine(%d):%d total:%d)\n",
+		fmt.Printf("> %s(%s) %s:%d (hits goroutine(%d):%d total:%d) (PC: %#v)\n",
 			fn.Name,
 			args,
 			ShortenFilePath(th.File),
 			th.Line,
 			th.GoroutineID,
 			hitCount,
-			th.Breakpoint.TotalHitCount)
+			th.Breakpoint.TotalHitCount,
+			th.PC)
 	} else {
-		fmt.Printf("> %s(%s) %s:%d (hits total:%d)\n",
+		fmt.Printf("> %s(%s) %s:%d (hits total:%d) (PC: %#v)\n",
 			fn.Name,
 			args,
 			ShortenFilePath(th.File),
 			th.Line,
-			th.Breakpoint.TotalHitCount)
+			th.Breakpoint.TotalHitCount,
+			th.PC)
 	}
 
 	if th.BreakpointInfo != nil {


### PR DESCRIPTION
These bugs were found while investigating Issue #332:

1. A running goroutine is by definition not parked waiting for a
chan recv
2. The FDE end address is intended to be exclusive, the code
interpreted as inclusive and sometimes ended up setting a breakpoint
on a function other than the current one.

This however does not fix Issue #332 itself. The problem there is that the FDE information is wrong inside some parts of the prologue for some functions (not all functions and not all parts of the prologue). I have added a test (disabled) for this problem.

The fix for issue #332 is to check if the current instruction is a `CALL` and if it is set a temp breakpoint after the function's prologue and call `proc.(*Process).Continue`.
We would need to implement Issue #368 to do this.

In addition I would also return an error when a breakpoint is set on a function prologue using the `<filename>:<lineno>` syntax, given that in addition to being generally confusing, this problem with FDE means it could break delve.