### PR TITLE
proc: Step should skip function prologue 

### DIFF
--- a/_fixtures/callme.go
+++ b/_fixtures/callme.go
@@ -1,0 +1,27 @@
+package main
+
+import "fmt"
+
+func callme(i int) {
+	fmt.Println("got:", i)
+}
+
+const nBytes = 10
+var zeroarr [nBytes]byte
+
+func callme2() {
+	for i := 0; i < nBytes; i++ {
+		zeroarr[i] = '0'
+	}
+}
+
+func callme3() {
+	callme2()
+}
+
+func main() {
+	for i := 0; i < 5; i++ {
+		callme(i)
+	}
+	callme3()
+}

--- a/proc/disasm.go
+++ b/proc/disasm.go
@@ -31,10 +31,13 @@ func (thread *Thread) Disassemble(startPC, endPC uint64, currentGoroutine bool) 
 	r := make([]AsmInstruction, 0, len(mem)/15)
 	pc := startPC
 
-	regs, _ := thread.Registers()
 	var curpc uint64
-	if regs != nil {
-		curpc = regs.PC()
+	var regs Registers
+	if currentGoroutine {
+		regs, _ = thread.Registers()
+		if regs != nil {
+			curpc = regs.PC()
+		}
 	}
 
 	for len(mem) > 0 {

--- a/proc/disasm_amd64.go
+++ b/proc/disasm_amd64.go
@@ -6,6 +6,8 @@ import (
 	"rsc.io/x86/x86asm"
 )
 
+var maxInstructionLength uint64 = 15
+
 type ArchInst x86asm.Inst
 
 func asmDecode(mem []byte, pc uint64) (*ArchInst, error) {

--- a/proc/proc_test.go
+++ b/proc/proc_test.go
@@ -311,6 +311,7 @@ func testnext(program string, testcases []nextTest, initialLocation string, t *t
 
 func TestNextGeneral(t *testing.T) {
 	testcases := []nextTest{
+		{17, 19},
 		{19, 20},
 		{20, 23},
 		{23, 24},
@@ -331,6 +332,7 @@ func TestNextGeneral(t *testing.T) {
 
 func TestNextConcurrent(t *testing.T) {
 	testcases := []nextTest{
+		{8, 9},
 		{9, 10},
 		{10, 11},
 	}
@@ -371,6 +373,7 @@ func TestNextConcurrent(t *testing.T) {
 func TestNextConcurrentVariant2(t *testing.T) {
 	// Just like TestNextConcurrent but instead of removing the initial breakpoint we check that when it happens is for other goroutines
 	testcases := []nextTest{
+		{8, 9},
 		{9, 10},
 		{10, 11},
 	}
@@ -419,6 +422,7 @@ func TestNextConcurrentVariant2(t *testing.T) {
 
 func TestNextFunctionReturn(t *testing.T) {
 	testcases := []nextTest{
+		{13, 14},
 		{14, 15},
 		{15, 35},
 	}
@@ -427,6 +431,7 @@ func TestNextFunctionReturn(t *testing.T) {
 
 func TestNextFunctionReturnDefer(t *testing.T) {
 	testcases := []nextTest{
+		{5, 8},
 		{8, 9},
 		{9, 10},
 		{10, 7},
@@ -1537,5 +1542,12 @@ func TestIssue332_Part2(t *testing.T) {
 		if _, exited := err.(ProcessExitedError); !exited {
 			assertNoError(err, t, "final Continue()")
 		}
+	})
+}
+
+func TestIssue396(t *testing.T) {
+	withTestProcess("callme", t, func(p *Process, fixture protest.Fixture) {
+		_, err := p.FindFunctionLocation("main.init", true, -1)
+		assertNoError(err, t, "FindFunctionLocation()")
 	})
 }

--- a/proc/registers_windows_amd64.go
+++ b/proc/registers_windows_amd64.go
@@ -5,9 +5,9 @@ import "C"
 import (
 	"bytes"
 	"fmt"
+	"rsc.io/x86/x86asm"
 	"syscall"
 	"unsafe"
-	"rsc.io/x86/x86asm"
 )
 
 // Regs represents CPU registers on an AMD64 processor.

--- a/service/debugger/locations.go
+++ b/service/debugger/locations.go
@@ -268,7 +268,8 @@ func (loc *AddrLocationSpec) Find(d *Debugger, scope *proc.EvalScope, locStr str
 			addr, _ := constant.Uint64Val(v.Value)
 			return []api.Location{{PC: addr}}, nil
 		case reflect.Func:
-			pc, err := d.process.FunctionEntryToFirstLine(uint64(v.Base))
+			_, _, fn := d.process.PCToLine(uint64(v.Base))
+			pc, err := d.process.FirstPCAfterPrologue(fn, false)
 			if err != nil {
 				return nil, err
 			}


### PR DESCRIPTION
Builds on top of #413

Step disassembles the current instruction, if it is a CALL sets a
temp breakpoint inside the called function, after the prologue and
calls Continue.

Fixes #332