### PR TITLE
terminal: Next does not fill BreakpointInfo

### DIFF
--- a/_fixtures/math.go
+++ b/_fixtures/math.go
@@ -1,0 +1,10 @@
+package main
+
+import "math"
+
+var f = 1.5
+
+func main() {
+	_ = math.Floor(f)
+	_ = float64(int(f))
+}

--- a/terminal/command.go
+++ b/terminal/command.go
@@ -940,7 +940,7 @@ func printcontext(t *Term, state *api.DebuggerState) error {
 
 	printcontextThread(t, state.CurrentThread)
 
-	if state.CurrentThread.Breakpoint == nil || !state.CurrentThread.Breakpoint.Tracepoint {
+	if state.CurrentThread.Breakpoint == nil || !state.CurrentThread.Breakpoint.Tracepoint || state.CurrentThread.BreakpointInfo == nil {
 		return printfile(t, state.CurrentThread.File, state.CurrentThread.Line, true)
 	}
 	return nil
@@ -955,7 +955,7 @@ func printcontextThread(t *Term, th *api.Thread) {
 	}
 
 	args := ""
-	if th.Breakpoint.Tracepoint {
+	if th.Breakpoint.Tracepoint && th.BreakpointInfo != nil {
 		var arg []string
 		for _, ar := range th.BreakpointInfo.Arguments {
 			arg = append(arg, ar.SinglelineString())


### PR DESCRIPTION
Fixes #411

I've added a bit of test tooling in command_test.go. I tried using gexpect but it doesn't agree with peterh/liner. One issue was that gexpect doesn't intercept SIGWINCH which means peterh/liner will think the pty is not a terminal and quit immediately, but even after changing that (in peterh/liner) it still wouldn't work. 