### PR TITLE
Fixes for Issue #419

### DIFF
--- a/_fixtures/issue419.go
+++ b/_fixtures/issue419.go
@@ -1,0 +1,24 @@
+package main
+
+import (
+	"fmt"
+	"os"
+	"os/signal"
+)
+
+func main() {
+
+	fmt.Println("Start")
+
+	sc := make(chan os.Signal, 1)
+
+	//os.Interrupt, os.Kill
+	signal.Notify(sc, os.Interrupt, os.Kill)
+
+	quit := <-sc
+
+	fmt.Printf("Receive signal %s \n", quit.String())
+
+	fmt.Println("End")
+
+}

--- a/proc/proc_linux.go
+++ b/proc/proc_linux.go
@@ -317,7 +317,10 @@ func (dbp *Process) trapWait(pid int) (*Thread, error) {
 		}
 		if th != nil {
 			// TODO(dp) alert user about unexpected signals here.
-			if err := th.Continue(); err != nil {
+			if err := th.resumeWithSig(int(status.StopSignal())); err != nil {
+				if err == sys.ESRCH {
+					return nil, ProcessExitedError{Pid: dbp.Pid}
+				}
 				return nil, err
 			}
 		}

--- a/proc/proc_unix_test.go
+++ b/proc/proc_unix_test.go
@@ -1,0 +1,31 @@
+// +build linux darwin
+
+package proc
+
+import (
+	"testing"
+	"time"
+	"syscall"
+
+	protest "github.com/derekparker/delve/proc/test"
+)
+
+func TestIssue419(t *testing.T) {
+	// SIGINT directed at the inferior should be passed along not swallowed by delve
+	withTestProcess("issue419", t, func(p *Process, fixture protest.Fixture) {
+		go func() {
+			for {
+				if p.Running() {
+					time.Sleep(2 * time.Second)
+					err := syscall.Kill(p.Pid, syscall.SIGINT)
+					assertNoError(err, t, "syscall.Kill")
+					return
+				}
+			}
+		}()
+		err := p.Continue()
+		if _, exited := err.(ProcessExitedError); !exited {
+			t.Fatalf("Unexpected error after Continue(): %v\n", err)
+		}
+	})
+}

--- a/proc/threads_linux.go
+++ b/proc/threads_linux.go
@@ -33,9 +33,13 @@ func (t *Thread) stopped() bool {
 	return state == StatusTraceStop
 }
 
-func (t *Thread) resume() (err error) {
+func (t *Thread) resume() error {
+	return t.resumeWithSig(0)
+}
+
+func (t *Thread) resumeWithSig(sig int) (err error) {
 	t.running = true
-	t.dbp.execPtraceFunc(func() { err = PtraceCont(t.ID, 0) })
+	t.dbp.execPtraceFunc(func() { err = PtraceCont(t.ID, sig) })
 	return
 }
 

--- a/service/test/variables_test.go
+++ b/service/test/variables_test.go
@@ -7,8 +7,8 @@ import (
 	"testing"
 
 	"github.com/derekparker/delve/proc"
-	"github.com/derekparker/delve/service/api"
 	"github.com/derekparker/delve/service"
+	"github.com/derekparker/delve/service/api"
 
 	protest "github.com/derekparker/delve/proc/test"
 )
@@ -649,14 +649,14 @@ func TestUnsafePointer(t *testing.T) {
 
 func TestIssue406(t *testing.T) {
 	withTestClient("issue406", t, func(c service.Client) {
-		locs, err := c.FindLocation(api.EvalScope{ -1, 0 },"issue406.go:146")
+		locs, err := c.FindLocation(api.EvalScope{-1, 0}, "issue406.go:146")
 		assertNoError(err, t, "FindLocation()")
-		_, err = c.CreateBreakpoint(&api.Breakpoint{ Addr: locs[0].PC })
+		_, err = c.CreateBreakpoint(&api.Breakpoint{Addr: locs[0].PC})
 		assertNoError(err, t, "CreateBreakpoint()")
 		ch := c.Continue()
 		state := <-ch
 		assertNoError(state.Err, t, "Continue()")
-		v, err := c.EvalVariable(api.EvalScope{ -1, 0 }, "cfgtree")
+		v, err := c.EvalVariable(api.EvalScope{-1, 0}, "cfgtree")
 		assertNoError(err, t, "EvalVariable()")
 		vs := v.MultilineString("")
 		t.Logf("cfgtree formats to: %s\n", vs)


### PR DESCRIPTION
There were a couple of problems. The crash was caused (probably) by a race condition between `debugger.(*Debugger).State`, called by `rpc.(*Client).Halt`, and `proc.(*Process).Continue` both reading the type `runtime.g` simultaneously.
They both call `proc.(*Thread).GetG` which calls `debug/dwarf.(*Data).Type` which is not thread safe and can return incomplete values if called simultaneously by multiple threads.

The second problem is that this test example will never terminate when it is run under delve on linux, even if we send it a SIGTERM using `kill(1)` because we intercept and suppress all signals. I have changed `proc.(*Process).trapWait` to propagate any signal we don't handle ourselves to inferior, I don't know if we want to do this or not, it seems like something that could be useful and the OS X version already does it implicitly.