### PR TITLE
proc: replace cgo with syscalls on windows

### DIFF
--- a/proc/syscall_windows.go
+++ b/proc/syscall_windows.go
@@ -22,8 +22,53 @@ type _THREAD_BASIC_INFORMATION struct {
 	BasePriority   int32
 }
 
+type _CREATE_PROCESS_DEBUG_INFO struct {
+	File                syscall.Handle
+	Process             syscall.Handle
+	Thread              syscall.Handle
+	BaseOfImage         uintptr
+	DebugInfoFileOffset uint32
+	DebugInfoSize       uint32
+	ThreadLocalBase     uintptr
+	StartAddress        uintptr
+	ImageName           uintptr
+	Unicode             uint16
+}
+
+type _CREATE_THREAD_DEBUG_INFO struct {
+	Thread          syscall.Handle
+	ThreadLocalBase uintptr
+	StartAddress    uintptr
+}
+
+type _EXIT_PROCESS_DEBUG_INFO struct {
+	ExitCode uint32
+}
+
+type _LOAD_DLL_DEBUG_INFO struct {
+	File                syscall.Handle
+	BaseOfDll           uintptr
+	DebugInfoFileOffset uint32
+	DebugInfoSize       uint32
+	ImageName           uintptr
+	Unicode             uint16
+}
+
 const (
 	_ThreadBasicInformation = 0
+
+	_DBG_CONTINUE              = 0x00010002
+	_DBG_EXCEPTION_NOT_HANDLED = 0x80010001
+
+	_EXCEPTION_DEBUG_EVENT      = 1
+	_CREATE_THREAD_DEBUG_EVENT  = 2
+	_CREATE_PROCESS_DEBUG_EVENT = 3
+	_EXIT_THREAD_DEBUG_EVENT    = 4
+	_EXIT_PROCESS_DEBUG_EVENT   = 5
+	_LOAD_DLL_DEBUG_EVENT       = 6
+	_UNLOAD_DLL_DEBUG_EVENT     = 7
+	_OUTPUT_DEBUG_STRING_EVENT  = 8
+	_RIP_EVENT                  = 9
 )
 
 func _NT_SUCCESS(x _NTSTATUS) bool {
@@ -31,3 +76,12 @@ func _NT_SUCCESS(x _NTSTATUS) bool {
 }
 
 //sys	_NtQueryInformationThread(threadHandle syscall.Handle, infoclass int32, info uintptr, infolen uint32, retlen *uint32) (status _NTSTATUS) = ntdll.NtQueryInformationThread
+//sys	_GetThreadContext(thread syscall.Handle, context *_CONTEXT) (err error) = kernel32.GetThreadContext
+//sys	_SetThreadContext(thread syscall.Handle, context *_CONTEXT) (err error) = kernel32.SetThreadContext
+//sys	_SuspendThread(threadid syscall.Handle) (prevsuspcount uint32, err error) [failretval==0xffffffff] = kernel32.SuspendThread
+//sys	_ResumeThread(threadid syscall.Handle) (prevsuspcount uint32, err error) [failretval==0xffffffff] = kernel32.ResumeThread
+//sys	_ContinueDebugEvent(processid uint32, threadid uint32, continuestatus uint32) (err error) = kernel32.ContinueDebugEvent
+//sys	_WriteProcessMemory(process syscall.Handle, baseaddr uintptr, buffer *byte, size uintptr, byteswritten *uintptr) (err error) = kernel32.WriteProcessMemory
+//sys	_ReadProcessMemory(process syscall.Handle, baseaddr uintptr, buffer *byte, size uintptr, bytesread *uintptr) (err error) = kernel32.ReadProcessMemory
+//sys	_DebugBreakProcess(process syscall.Handle) (err error) = kernel32.DebugBreakProcess
+//sys	_WaitForDebugEvent(debugevent *_DEBUG_EVENT, milliseconds uint32) (err error) = kernel32.WaitForDebugEvent

--- a/proc/syscall_windows_amd64.go
+++ b/proc/syscall_windows_amd64.go
@@ -1,0 +1,95 @@
+package proc
+
+import "unsafe"
+
+const (
+	_CONTEXT_AMD64               = 0x100000
+	_CONTEXT_CONTROL             = (_CONTEXT_AMD64 | 0x1)
+	_CONTEXT_INTEGER             = (_CONTEXT_AMD64 | 0x2)
+	_CONTEXT_SEGMENTS            = (_CONTEXT_AMD64 | 0x4)
+	_CONTEXT_FLOATING_POINT      = (_CONTEXT_AMD64 | 0x8)
+	_CONTEXT_DEBUG_REGISTERS     = (_CONTEXT_AMD64 | 0x10)
+	_CONTEXT_FULL                = (_CONTEXT_CONTROL | _CONTEXT_INTEGER | _CONTEXT_FLOATING_POINT)
+	_CONTEXT_ALL                 = (_CONTEXT_CONTROL | _CONTEXT_INTEGER | _CONTEXT_SEGMENTS | _CONTEXT_FLOATING_POINT | _CONTEXT_DEBUG_REGISTERS)
+	_CONTEXT_EXCEPTION_ACTIVE    = 0x8000000
+	_CONTEXT_SERVICE_ACTIVE      = 0x10000000
+	_CONTEXT_EXCEPTION_REQUEST   = 0x40000000
+	_CONTEXT_EXCEPTION_REPORTING = 0x80000000
+)
+
+type _M128A struct {
+	Low  uint64
+	High int64
+}
+
+type _CONTEXT struct {
+	P1Home uint64
+	P2Home uint64
+	P3Home uint64
+	P4Home uint64
+	P5Home uint64
+	P6Home uint64
+
+	ContextFlags uint32
+	MxCsr        uint32
+
+	SegCs  uint16
+	SegDs  uint16
+	SegEs  uint16
+	SegFs  uint16
+	SegGs  uint16
+	SegSs  uint16
+	EFlags uint32
+
+	Dr0 uint64
+	Dr1 uint64
+	Dr2 uint64
+	Dr3 uint64
+	Dr6 uint64
+	Dr7 uint64
+
+	Rax uint64
+	Rcx uint64
+	Rdx uint64
+	Rbx uint64
+	Rsp uint64
+	Rbp uint64
+	Rsi uint64
+	Rdi uint64
+	R8  uint64
+	R9  uint64
+	R10 uint64
+	R11 uint64
+	R12 uint64
+	R13 uint64
+	R14 uint64
+	R15 uint64
+
+	Rip uint64
+
+	FltSave [512]byte
+
+	VectorRegister [26]_M128A
+	VectorControl  uint64
+
+	DebugControl         uint64
+	LastBranchToRip      uint64
+	LastBranchFromRip    uint64
+	LastExceptionToRip   uint64
+	LastExceptionFromRip uint64
+}
+
+// newCONTEXT allocates Windows CONTEXT structure aligned to 16 bytes.
+func newCONTEXT() *_CONTEXT {
+	var c *_CONTEXT
+	buf := make([]byte, unsafe.Sizeof(*c)+15)
+	return (*_CONTEXT)(unsafe.Pointer((uintptr(unsafe.Pointer(&buf[15]))) &^ 15))
+}
+
+type _DEBUG_EVENT struct {
+	DebugEventCode uint32
+	ProcessId      uint32
+	ThreadId       uint32
+	_              uint32 // to align Union properly
+	U              [160]byte
+}

--- a/proc/zsyscall_windows.go
+++ b/proc/zsyscall_windows.go
@@ -8,13 +8,133 @@ import "syscall"
 var _ unsafe.Pointer
 
 var (
-	modntdll = syscall.NewLazyDLL("ntdll.dll")
+	modntdll    = syscall.NewLazyDLL("ntdll.dll")
+	modkernel32 = syscall.NewLazyDLL("kernel32.dll")
 
 	procNtQueryInformationThread = modntdll.NewProc("NtQueryInformationThread")
+	procGetThreadContext         = modkernel32.NewProc("GetThreadContext")
+	procSetThreadContext         = modkernel32.NewProc("SetThreadContext")
+	procSuspendThread            = modkernel32.NewProc("SuspendThread")
+	procResumeThread             = modkernel32.NewProc("ResumeThread")
+	procContinueDebugEvent       = modkernel32.NewProc("ContinueDebugEvent")
+	procWriteProcessMemory       = modkernel32.NewProc("WriteProcessMemory")
+	procReadProcessMemory        = modkernel32.NewProc("ReadProcessMemory")
+	procDebugBreakProcess        = modkernel32.NewProc("DebugBreakProcess")
+	procWaitForDebugEvent        = modkernel32.NewProc("WaitForDebugEvent")
 )
 
 func _NtQueryInformationThread(threadHandle syscall.Handle, infoclass int32, info uintptr, infolen uint32, retlen *uint32) (status _NTSTATUS) {
 	r0, _, _ := syscall.Syscall6(procNtQueryInformationThread.Addr(), 5, uintptr(threadHandle), uintptr(infoclass), uintptr(info), uintptr(infolen), uintptr(unsafe.Pointer(retlen)), 0)
 	status = _NTSTATUS(r0)
+	return
+}
+
+func _GetThreadContext(thread syscall.Handle, context *_CONTEXT) (err error) {
+	r1, _, e1 := syscall.Syscall(procGetThreadContext.Addr(), 2, uintptr(thread), uintptr(unsafe.Pointer(context)), 0)
+	if r1 == 0 {
+		if e1 != 0 {
+			err = error(e1)
+		} else {
+			err = syscall.EINVAL
+		}
+	}
+	return
+}
+
+func _SetThreadContext(thread syscall.Handle, context *_CONTEXT) (err error) {
+	r1, _, e1 := syscall.Syscall(procSetThreadContext.Addr(), 2, uintptr(thread), uintptr(unsafe.Pointer(context)), 0)
+	if r1 == 0 {
+		if e1 != 0 {
+			err = error(e1)
+		} else {
+			err = syscall.EINVAL
+		}
+	}
+	return
+}
+
+func _SuspendThread(threadid syscall.Handle) (prevsuspcount uint32, err error) {
+	r0, _, e1 := syscall.Syscall(procSuspendThread.Addr(), 1, uintptr(threadid), 0, 0)
+	prevsuspcount = uint32(r0)
+	if prevsuspcount == 0xffffffff {
+		if e1 != 0 {
+			err = error(e1)
+		} else {
+			err = syscall.EINVAL
+		}
+	}
+	return
+}
+
+func _ResumeThread(threadid syscall.Handle) (prevsuspcount uint32, err error) {
+	r0, _, e1 := syscall.Syscall(procResumeThread.Addr(), 1, uintptr(threadid), 0, 0)
+	prevsuspcount = uint32(r0)
+	if prevsuspcount == 0xffffffff {
+		if e1 != 0 {
+			err = error(e1)
+		} else {
+			err = syscall.EINVAL
+		}
+	}
+	return
+}
+
+func _ContinueDebugEvent(processid uint32, threadid uint32, continuestatus uint32) (err error) {
+	r1, _, e1 := syscall.Syscall(procContinueDebugEvent.Addr(), 3, uintptr(processid), uintptr(threadid), uintptr(continuestatus))
+	if r1 == 0 {
+		if e1 != 0 {
+			err = error(e1)
+		} else {
+			err = syscall.EINVAL
+		}
+	}
+	return
+}
+
+func _WriteProcessMemory(process syscall.Handle, baseaddr uintptr, buffer *byte, size uintptr, byteswritten *uintptr) (err error) {
+	r1, _, e1 := syscall.Syscall6(procWriteProcessMemory.Addr(), 5, uintptr(process), uintptr(baseaddr), uintptr(unsafe.Pointer(buffer)), uintptr(size), uintptr(unsafe.Pointer(byteswritten)), 0)
+	if r1 == 0 {
+		if e1 != 0 {
+			err = error(e1)
+		} else {
+			err = syscall.EINVAL
+		}
+	}
+	return
+}
+
+func _ReadProcessMemory(process syscall.Handle, baseaddr uintptr, buffer *byte, size uintptr, bytesread *uintptr) (err error) {
+	r1, _, e1 := syscall.Syscall6(procReadProcessMemory.Addr(), 5, uintptr(process), uintptr(baseaddr), uintptr(unsafe.Pointer(buffer)), uintptr(size), uintptr(unsafe.Pointer(bytesread)), 0)
+	if r1 == 0 {
+		if e1 != 0 {
+			err = error(e1)
+		} else {
+			err = syscall.EINVAL
+		}
+	}
+	return
+}
+
+func _DebugBreakProcess(process syscall.Handle) (err error) {
+	r1, _, e1 := syscall.Syscall(procDebugBreakProcess.Addr(), 1, uintptr(process), 0, 0)
+	if r1 == 0 {
+		if e1 != 0 {
+			err = error(e1)
+		} else {
+			err = syscall.EINVAL
+		}
+	}
+	return
+}
+
+func _WaitForDebugEvent(debugevent *_DEBUG_EVENT, milliseconds uint32) (err error) {
+	r1, _, e1 := syscall.Syscall(procWaitForDebugEvent.Addr(), 2, uintptr(unsafe.Pointer(debugevent)), uintptr(milliseconds), 0)
+	if r1 == 0 {
+		if e1 != 0 {
+			err = error(e1)
+		} else {
+			err = syscall.EINVAL
+		}
+	}
 	return
 }


### PR DESCRIPTION
Unrelated to conversion, I have also changed (*Thread).readMemory
to return only first count bytes of memory just as advised
by ReadProcessMemory.

Fixes #409

@lukehoban for your review. Thank you.
Sorry about the size of this change. I tried to make it as small as possible.