### PR TITLE
proc: Add filter for non-variable global symbols to PackageVariables

### DIFF
--- a/proc/proc_test.go
+++ b/proc/proc_test.go
@@ -1556,3 +1556,24 @@ func TestIssue396(t *testing.T) {
 		assertNoError(err, t, "FindFunctionLocation()")
 	})
 }
+
+func TestPackageVariables(t *testing.T) {
+	withTestProcess("testvariables", t, func(p *Process, fixture protest.Fixture) {
+		err := p.Continue()
+		assertNoError(err, t, "Continue()")
+		scope, err := p.CurrentThread.Scope()
+		assertNoError(err, t, "Scope()")
+		vars, err := scope.PackageVariables()
+		assertNoError(err, t, "PackageVariables()")
+		failed := false
+		for _, v := range vars {
+			if v.Unreadable != nil {
+				failed = true
+				t.Logf("Unreadable variable %s: %v", v.Name, v.Unreadable)
+			}
+		}
+		if failed {
+			t.Fatalf("previous errors")
+		}
+	})
+}

--- a/proc/variables.go
+++ b/proc/variables.go
@@ -541,9 +541,19 @@ func (scope *EvalScope) PackageVariables() ([]*Variable, error) {
 	var vars []*Variable
 	reader := scope.DwarfReader()
 
+	var utypoff dwarf.Offset
+	utypentry, err := reader.SeekToTypeNamed("<unspecified>")
+	if err == nil {
+		utypoff = utypentry.Offset
+	}
+
 	for entry, err := reader.NextPackageVariable(); entry != nil; entry, err = reader.NextPackageVariable() {
 		if err != nil {
 			return nil, err
+		}
+
+		if typoff, ok := entry.Val(dwarf.AttrType).(dwarf.Offset); !ok || typoff == utypoff {
+			continue
 		}
 
 		// Ignore errors trying to extract values


### PR DESCRIPTION
proc.(*EvalScope).PackageVariables shouldn't display unreadable global symbols that are not package variables (as indicated by their name).