### PR TITLE
Better support for type casts to anonymous types

### DIFF
--- a/_fixtures/testvariables2.go
+++ b/_fixtures/testvariables2.go
@@ -187,6 +187,16 @@ func main() {
 	b2 := B{A: A{42}, a: A{47}}
 	var sd D
 
+	var mapanonstruct1 map[string]struct{}
+	var anonstruct1 struct{ val constant.Value }
+	var anonstruct2 struct{ i, j int }
+	var anoniface1 interface {
+		SomeFunction(struct{ val constant.Value })
+		OtherFunction(i, j int)
+	}
+	var anonfunc func(a struct{ i int }, b interface{}, c struct{ val constant.Value })
+
+
 	for i := range benchparr {
 		benchparr[i] = &benchstruct{}
 	}
@@ -197,5 +207,5 @@ func main() {
 		fmt.Println(amb1)
 	}
 	runtime.Breakpoint()
-	fmt.Println(i1, i2, i3, p1, amb1, s1, s3, a1, p2, p3, s2, as1, str1, f1, fn1, fn2, nilslice, nilptr, ch1, chnil, m1, mnil, m2, m3, up1, i4, i5, i6, err1, err2, errnil, iface1, iface2, ifacenil, arr1, parr, cpx1, const1, iface3, iface4, recursive1, recursive1.x, iface5, iface2fn1, iface2fn2, bencharr, benchparr, mapinf, mainMenu, b, b2, sd)
+	fmt.Println(i1, i2, i3, p1, amb1, s1, s3, a1, p2, p3, s2, as1, str1, f1, fn1, fn2, nilslice, nilptr, ch1, chnil, m1, mnil, m2, m3, up1, i4, i5, i6, err1, err2, errnil, iface1, iface2, ifacenil, arr1, parr, cpx1, const1, iface3, iface4, recursive1, recursive1.x, iface5, iface2fn1, iface2fn2, bencharr, benchparr, mapinf, mainMenu, b, b2, sd, anonstruct1, anonstruct2, anoniface1, anonfunc, mapanonstruct1)
 }

--- a/dwarf/reader/reader.go
+++ b/dwarf/reader/reader.go
@@ -104,7 +104,7 @@ func (reader *Reader) AddrForMember(member string, initialInstructions []byte) (
 	}
 }
 
-var TypeNotFoundErr = errors.New("no type entry found")
+var TypeNotFoundErr = errors.New("no type entry found, use 'types' for a list of valid types")
 
 // SeekToType moves the reader to the type specified by the entry,
 // optionally resolving typedefs and pointer types. If the reader is set

--- a/proc/eval.go
+++ b/proc/eval.go
@@ -41,7 +41,13 @@ func (scope *EvalScope) evalAST(t ast.Expr) (*Variable, error) {
 			if err == nil {
 				return v, nil
 			}
-			if err != reader.TypeNotFoundErr {
+			_, isident := node.Fun.(*ast.Ident)
+			// we don't support function calls at the moment except for a few
+			// builtin functions so just return the type error here if the function
+			// isn't an identifier.
+			// More sophisticated logic will be required when function calls
+			// are implemented.
+			if err != reader.TypeNotFoundErr || !isident {
 				return v, err
 			}
 		}


### PR DESCRIPTION
This set of commits was prompted by Issue #426. Obviously we can't print the contents of an unsafe.Pointer (because we don't know what it contains), however one should be able to cast it to some other type and read it that way, in that case: `(*map[string]interface{})(0x...)`.

However that doesn't work because of the way `go/printer` formats the expression `map[string]interface{}`: `go/printer` doesn't put a space between `interface` and `{}`, but in debug_info the type appears as `map[string]interface {}`.

I took a look at other anonymous types and found other discrepancies. The first commit attempts to fix these discrepancies in the most common circumstances. It's not a perfect solution, it would probably be better to abandon `go/printer` and just write a serialization that matches the one used in debug_info but I couldn't find the part of the compiler that does this and I'd rather not guess.

The second commit introduces an alternate way to specify the type of a type casts, by putting the type in quotes, like: `(*"map[string]interface {}")(0x...)`, the type `map[string]interface {}` will be searched in `debug_info`, verbatim. This is also not particularly elegant but it can serve as a last resort (along with the `types` command in PR #433) for the user if we get the parsing/formatting wrong. I think lldb also takes this approach.
