### PR TITLE
tests: Add test for #149, fixed TestNextGeneral on tip

### DIFF
--- a/_fixtures/break.go
+++ b/_fixtures/break.go
@@ -1,0 +1,11 @@
+package main
+
+func main() {
+	i := 0
+	for {
+		i++
+		if i > 10 {
+			break
+		}
+	}
+}

--- a/proc/go_version.go
+++ b/proc/go_version.go
@@ -16,7 +16,7 @@ type GoVersion struct {
 	RC    int
 }
 
-func parseVersionString(ver string) (GoVersion, bool) {
+func ParseVersionString(ver string) (GoVersion, bool) {
 	var r GoVersion
 	var err1, err2, err3 error
 

--- a/proc/proc.go
+++ b/proc/proc.go
@@ -813,7 +813,7 @@ func (dbp *Process) getGoInformation() (ver GoVersion, isextld bool, err error) 
 		return
 	}
 
-	ver, ok := parseVersionString(constant.StringVal(vv.Value))
+	ver, ok := ParseVersionString(constant.StringVal(vv.Value))
 	if !ok {
 		err = fmt.Errorf("Could not parse version number: %v\n", vv.Value)
 		return

--- a/proc/proc_test.go
+++ b/proc/proc_test.go
@@ -308,23 +308,49 @@ func testnext(program string, testcases []nextTest, initialLocation string, t *t
 }
 
 func TestNextGeneral(t *testing.T) {
-	testcases := []nextTest{
-		{17, 19},
-		{19, 20},
-		{20, 23},
-		{23, 24},
-		{24, 26},
-		{26, 31},
-		{31, 23},
-		{23, 24},
-		{24, 26},
-		{26, 31},
-		{31, 23},
-		{23, 24},
-		{24, 26},
-		{26, 27},
-		{27, 34},
+	var testcases []nextTest
+
+	ver, _ := ParseVersionString(runtime.Version())
+
+	if ver.Major < 0 || ver.AfterOrEqual(GoVersion{1, 7, 0, 0, 0}) {
+		testcases = []nextTest{
+			{17, 19},
+			{19, 20},
+			{20, 23},
+			{23, 24},
+			{24, 26},
+			{26, 31},
+			{31, 23},
+			{23, 24},
+			{24, 26},
+			{26, 31},
+			{31, 23},
+			{23, 24},
+			{24, 26},
+			{26, 27},
+			{27, 28},
+			{28, 34},
+		}
+	} else {
+		testcases = []nextTest{
+			{17, 19},
+			{19, 20},
+			{20, 23},
+			{23, 24},
+			{24, 26},
+			{26, 31},
+			{31, 23},
+			{23, 24},
+			{24, 26},
+			{26, 31},
+			{31, 23},
+			{23, 24},
+			{24, 26},
+			{26, 27},
+			{27, 34},
+		}
 	}
+
 	testnext("testnextprog", testcases, "main.testnext", t)
 }
 
@@ -845,7 +871,7 @@ func TestContinueMulti(t *testing.T) {
 }
 
 func versionAfterOrEqual(t *testing.T, verStr string, ver GoVersion) {
-	pver, ok := parseVersionString(verStr)
+	pver, ok := ParseVersionString(verStr)
 	if !ok {
 		t.Fatalf("Could not parse version string <%s>", verStr)
 	}
@@ -861,7 +887,7 @@ func TestParseVersionString(t *testing.T) {
 	versionAfterOrEqual(t, "go1.4.2", GoVersion{1, 4, 2, 0, 0})
 	versionAfterOrEqual(t, "go1.5beta2", GoVersion{1, 5, -1, 2, 0})
 	versionAfterOrEqual(t, "go1.5rc2", GoVersion{1, 5, -1, 0, 2})
-	ver, ok := parseVersionString("devel +17efbfc Tue Jul 28 17:39:19 2015 +0000 linux/amd64")
+	ver, ok := ParseVersionString("devel +17efbfc Tue Jul 28 17:39:19 2015 +0000 linux/amd64")
 	if !ok {
 		t.Fatalf("Could not parse devel version string")
 	}
@@ -1595,5 +1621,17 @@ func TestPackageVariables(t *testing.T) {
 		if failed {
 			t.Fatalf("previous errors")
 		}
+	})
+}
+
+func TestIssue149(t *testing.T) {
+	ver, _ := ParseVersionString(runtime.Version())
+	if ver.Major	> 0 && !ver.AfterOrEqual(GoVersion{1, 7, 0, 0, 0}) {
+		return
+	}
+	// setting breakpoint on break statement
+	withTestProcess("break", t, func(p *Process, fixture protest.Fixture) {
+		_, err := p.FindFileLocation(fixture.Source, 8)
+		assertNoError(err, t, "FindFileLocation()")
 	})
 }

--- a/proc/proc_unix_test.go
+++ b/proc/proc_unix_test.go
@@ -3,9 +3,9 @@
 package proc
 
 import (
+	"syscall"
 	"testing"
 	"time"
-	"syscall"
 
 	protest "github.com/derekparker/delve/proc/test"
 )

--- a/service/test/integration_test.go
+++ b/service/test/integration_test.go
@@ -14,6 +14,7 @@ import (
 
 	protest "github.com/derekparker/delve/proc/test"
 
+	"github.com/derekparker/delve/proc"
 	"github.com/derekparker/delve/service"
 	"github.com/derekparker/delve/service/api"
 	"github.com/derekparker/delve/service/rpc"
@@ -253,23 +254,49 @@ func testnext(testcases []nextTest, initialLocation string, t *testing.T) {
 }
 
 func TestNextGeneral(t *testing.T) {
-	testcases := []nextTest{
-		{17, 19},
-		{19, 20},
-		{20, 23},
-		{23, 24},
-		{24, 26},
-		{26, 31},
-		{31, 23},
-		{23, 24},
-		{24, 26},
-		{26, 31},
-		{31, 23},
-		{23, 24},
-		{24, 26},
-		{26, 27},
-		{27, 34},
+	var testcases []nextTest
+
+	ver, _ := proc.ParseVersionString(runtime.Version())
+
+	if ver.Major < 0 || ver.AfterOrEqual(proc.GoVersion{1, 7, 0, 0, 0}) {
+		testcases = []nextTest{
+			{17, 19},
+			{19, 20},
+			{20, 23},
+			{23, 24},
+			{24, 26},
+			{26, 31},
+			{31, 23},
+			{23, 24},
+			{24, 26},
+			{26, 31},
+			{31, 23},
+			{23, 24},
+			{24, 26},
+			{26, 27},
+			{27, 28},
+			{28, 34},
+		}
+	} else {
+		testcases = []nextTest{
+			{17, 19},
+			{19, 20},
+			{20, 23},
+			{23, 24},
+			{24, 26},
+			{26, 31},
+			{31, 23},
+			{23, 24},
+			{24, 26},
+			{26, 31},
+			{31, 23},
+			{23, 24},
+			{24, 26},
+			{26, 27},
+			{27, 34},
+		}
 	}
+
 	testnext(testcases, "main.testnext", t)
 }
 


### PR DESCRIPTION
The go compiler changed and break statements no longer get compiled to
nothing when -N is passed:

https://go-review.googlesource.com/#/c/19848/
https://go-review.googlesource.com/#/c/19854/