### PR TITLE
Improvements to Variable printing

### DIFF
--- a/_fixtures/testvariables2.go
+++ b/_fixtures/testvariables2.go
@@ -40,6 +40,10 @@ type B struct {
 	ptr *A
 }
 
+type D struct {
+	u1, u2, u3, u4, u5, u6 uint32
+}
+
 func afunc(x int) int {
 	return x + 2
 }
@@ -181,6 +185,7 @@ func main() {
 	aas[0].aas = aas
 	b := B{A: A{-314}, C: &C{"hello"}, a: A{42}, ptr: &A{1337}}
 	b2 := B{A: A{42}, a: A{47}}
+	var sd D
 
 	for i := range benchparr {
 		benchparr[i] = &benchstruct{}
@@ -192,5 +197,5 @@ func main() {
 		fmt.Println(amb1)
 	}
 	runtime.Breakpoint()
-	fmt.Println(i1, i2, i3, p1, amb1, s1, s3, a1, p2, p3, s2, as1, str1, f1, fn1, fn2, nilslice, nilptr, ch1, chnil, m1, mnil, m2, m3, up1, i4, i5, i6, err1, err2, errnil, iface1, iface2, ifacenil, arr1, parr, cpx1, const1, iface3, iface4, recursive1, recursive1.x, iface5, iface2fn1, iface2fn2, bencharr, benchparr, mapinf, mainMenu, b, b2)
+	fmt.Println(i1, i2, i3, p1, amb1, s1, s3, a1, p2, p3, s2, as1, str1, f1, fn1, fn2, nilslice, nilptr, ch1, chnil, m1, mnil, m2, m3, up1, i4, i5, i6, err1, err2, errnil, iface1, iface2, ifacenil, arr1, parr, cpx1, const1, iface3, iface4, recursive1, recursive1.x, iface5, iface2fn1, iface2fn2, bencharr, benchparr, mapinf, mainMenu, b, b2, sd)
 }

--- a/cmd/dlv/cmds/commands.go
+++ b/cmd/dlv/cmds/commands.go
@@ -259,7 +259,7 @@ func traceCmd(cmd *cobra.Command, args []string) {
 			return 1
 		}
 		for i := range funcs {
-			_, err = client.CreateBreakpoint(&api.Breakpoint{FunctionName: funcs[i], Tracepoint: true, Line: -1, Stacktrace: traceStackDepth})
+			_, err = client.CreateBreakpoint(&api.Breakpoint{FunctionName: funcs[i], Tracepoint: true, Line: -1, Stacktrace: traceStackDepth, LoadArgs: &terminal.ShortLoadConfig})
 			if err != nil {
 				fmt.Fprintln(os.Stderr, err)
 				return 1

--- a/proc/breakpoints.go
+++ b/proc/breakpoints.go
@@ -28,6 +28,8 @@ type Breakpoint struct {
 	Goroutine     bool           // Retrieve goroutine information
 	Stacktrace    int            // Number of stack frames to retrieve
 	Variables     []string       // Variables to evaluate
+	LoadArgs      *LoadConfig
+	LoadLocals    *LoadConfig
 	HitCount      map[int]uint64 // Number of times a breakpoint has been reached in a certain goroutine
 	TotalHitCount uint64         // Number of times a breakpoint has been reached
 

--- a/proc/eval.go
+++ b/proc/eval.go
@@ -16,7 +16,7 @@ import (
 )
 
 // EvalExpression returns the value of the given expression.
-func (scope *EvalScope) EvalExpression(expr string) (*Variable, error) {
+func (scope *EvalScope) EvalExpression(expr string, cfg LoadConfig) (*Variable, error) {
 	t, err := parser.ParseExpr(expr)
 	if err != nil {
 		return nil, err
@@ -26,7 +26,7 @@ func (scope *EvalScope) EvalExpression(expr string) (*Variable, error) {
 	if err != nil {
 		return nil, err
 	}
-	ev.loadValue()
+	ev.loadValue(cfg)
 	if ev.Name == "" {
 		ev.Name = expr
 	}
@@ -116,7 +116,7 @@ func (scope *EvalScope) evalTypeCast(node *ast.CallExpr) (*Variable, error) {
 	if err != nil {
 		return nil, err
 	}
-	argv.loadValue()
+	argv.loadValue(loadSingleValue)
 	if argv.Unreadable != nil {
 		return nil, argv.Unreadable
 	}
@@ -280,7 +280,7 @@ func capBuiltin(args []*Variable, nodeargs []ast.Expr) (*Variable, error) {
 	case reflect.Slice:
 		return newConstant(constant.MakeInt64(arg.Cap), arg.mem), nil
 	case reflect.Chan:
-		arg.loadValue()
+		arg.loadValue(loadFullValue)
 		if arg.Unreadable != nil {
 			return nil, arg.Unreadable
 		}
@@ -313,7 +313,7 @@ func lenBuiltin(args []*Variable, nodeargs []ast.Expr) (*Variable, error) {
 		}
 		return newConstant(constant.MakeInt64(arg.Len), arg.mem), nil
 	case reflect.Chan:
-		arg.loadValue()
+		arg.loadValue(loadFullValue)
 		if arg.Unreadable != nil {
 			return nil, arg.Unreadable
 		}
@@ -343,8 +343,8 @@ func complexBuiltin(args []*Variable, nodeargs []ast.Expr) (*Variable, error) {
 	realev := args[0]
 	imagev := args[1]
 
-	realev.loadValue()
-	imagev.loadValue()
+	realev.loadValue(loadSingleValue)
+	imagev.loadValue(loadSingleValue)
 
 	if realev.Unreadable != nil {
 		return nil, realev.Unreadable
@@ -390,7 +390,7 @@ func imagBuiltin(args []*Variable, nodeargs []ast.Expr) (*Variable, error) {
 	}
 
 	arg := args[0]
-	arg.loadValue()
+	arg.loadValue(loadSingleValue)
 
 	if arg.Unreadable != nil {
 		return nil, arg.Unreadable
@@ -409,7 +409,7 @@ func realBuiltin(args []*Variable, nodeargs []ast.Expr) (*Variable, error) {
 	}
 
 	arg := args[0]
-	arg.loadValue()
+	arg.loadValue(loadSingleValue)
 
 	if arg.Unreadable != nil {
 		return nil, arg.Unreadable
@@ -473,7 +473,7 @@ func (scope *EvalScope) evalTypeAssert(node *ast.TypeAssertExpr) (*Variable, err
 	if xv.Kind != reflect.Interface {
 		return nil, fmt.Errorf("expression \"%s\" not an interface", exprToString(node.X))
 	}
-	xv.loadInterface(0, false)
+	xv.loadInterface(0, false, loadFullValue)
 	if xv.Unreadable != nil {
 		return nil, xv.Unreadable
 	}
@@ -520,7 +520,7 @@ func (scope *EvalScope) evalIndex(node *ast.IndexExpr) (*Variable, error) {
 		return xev.sliceAccess(int(n))
 
 	case reflect.Map:
-		idxev.loadValue()
+		idxev.loadValue(loadFullValue)
 		if idxev.Unreadable != nil {
 			return nil, idxev.Unreadable
 		}
@@ -579,7 +579,7 @@ func (scope *EvalScope) evalReslice(node *ast.SliceExpr) (*Variable, error) {
 			return nil, fmt.Errorf("second slice argument must be empty for maps")
 		}
 		xev.mapSkip += int(low)
-		xev.loadValue()
+		xev.loadValue(loadFullValue)
 		if xev.Unreadable != nil {
 			return nil, xev.Unreadable
 		}
@@ -678,7 +678,7 @@ func (scope *EvalScope) evalUnary(node *ast.UnaryExpr) (*Variable, error) {
 		return nil, err
 	}
 
-	xv.loadValue()
+	xv.loadValue(loadSingleValue)
 	if xv.Unreadable != nil {
 		return nil, xv.Unreadable
 	}
@@ -777,8 +777,8 @@ func (scope *EvalScope) evalBinary(node *ast.BinaryExpr) (*Variable, error) {
 		return nil, err
 	}
 
-	xv.loadValue()
-	yv.loadValue()
+	xv.loadValue(loadFullValue)
+	yv.loadValue(loadFullValue)
 
 	if xv.Unreadable != nil {
 		return nil, xv.Unreadable
@@ -946,7 +946,7 @@ func (v *Variable) asInt() (int64, error) {
 			return 0, fmt.Errorf("can not convert constant %s to int", v.Value)
 		}
 	} else {
-		v.loadValue()
+		v.loadValue(loadSingleValue)
 		if v.Unreadable != nil {
 			return 0, v.Unreadable
 		}
@@ -964,7 +964,7 @@ func (v *Variable) asUint() (uint64, error) {
 			return 0, fmt.Errorf("can not convert constant %s to uint", v.Value)
 		}
 	} else {
-		v.loadValue()
+		v.loadValue(loadSingleValue)
 		if v.Unreadable != nil {
 			return 0, v.Unreadable
 		}
@@ -1051,7 +1051,7 @@ func (v *Variable) mapAccess(idx *Variable) (*Variable, error) {
 	first := true
 	for it.next() {
 		key := it.key()
-		key.loadValue()
+		key.loadValue(loadFullValue)
 		if key.Unreadable != nil {
 			return nil, fmt.Errorf("can not access unreadable map: %v", key.Unreadable)
 		}

--- a/proc/eval.go
+++ b/proc/eval.go
@@ -27,6 +27,9 @@ func (scope *EvalScope) EvalExpression(expr string) (*Variable, error) {
 		return nil, err
 	}
 	ev.loadValue()
+	if ev.Name == "" {
+		ev.Name = expr
+	}
 	return ev, nil
 }
 

--- a/proc/proc.go
+++ b/proc/proc.go
@@ -805,7 +805,7 @@ func (dbp *Process) execPtraceFunc(fn func()) {
 }
 
 func (dbp *Process) getGoInformation() (ver GoVersion, isextld bool, err error) {
-	vv, err := dbp.EvalPackageVariable("runtime.buildVersion")
+	vv, err := dbp.EvalPackageVariable("runtime.buildVersion", LoadConfig{true, 0, 64, 0, 0})
 	if err != nil {
 		err = fmt.Errorf("Could not determine version number: %v\n", err)
 		return

--- a/proc/proc_test.go
+++ b/proc/proc_test.go
@@ -19,6 +19,8 @@ import (
 	protest "github.com/derekparker/delve/proc/test"
 )
 
+var normalLoadConfig = LoadConfig{true, 1, 64, 64, -1}
+
 func init() {
 	runtime.GOMAXPROCS(4)
 	os.Setenv("GOMAXPROCS", "4")
@@ -945,7 +947,7 @@ func evalVariable(p *Process, symbol string) (*Variable, error) {
 	if err != nil {
 		return nil, err
 	}
-	return scope.EvalVariable(symbol)
+	return scope.EvalVariable(symbol, normalLoadConfig)
 }
 
 func setVariable(p *Process, symbol, value string) error {
@@ -1070,7 +1072,7 @@ func TestFrameEvaluation(t *testing.T) {
 			scope, err := p.ConvertEvalScope(g.ID, frame)
 			assertNoError(err, t, "ConvertEvalScope()")
 			t.Logf("scope = %v", scope)
-			v, err := scope.EvalVariable("i")
+			v, err := scope.EvalVariable("i", normalLoadConfig)
 			t.Logf("v = %v", v)
 			if err != nil {
 				t.Logf("Goroutine %d: %v\n", g.ID, err)
@@ -1094,7 +1096,7 @@ func TestFrameEvaluation(t *testing.T) {
 		for i := 0; i <= 3; i++ {
 			scope, err := p.ConvertEvalScope(g.ID, i+1)
 			assertNoError(err, t, fmt.Sprintf("ConvertEvalScope() on frame %d", i+1))
-			v, err := scope.EvalVariable("n")
+			v, err := scope.EvalVariable("n", normalLoadConfig)
 			assertNoError(err, t, fmt.Sprintf("EvalVariable() on frame %d", i+1))
 			n, _ := constant.Int64Val(v.Value)
 			t.Logf("frame %d n %d\n", i+1, n)
@@ -1123,7 +1125,7 @@ func TestPointerSetting(t *testing.T) {
 		// change p1 to point to i2
 		scope, err := p.CurrentThread.Scope()
 		assertNoError(err, t, "Scope()")
-		i2addr, err := scope.EvalExpression("i2")
+		i2addr, err := scope.EvalExpression("i2", normalLoadConfig)
 		assertNoError(err, t, "EvalExpression()")
 		assertNoError(setVariable(p, "p1", fmt.Sprintf("(*int)(0x%x)", i2addr.Addr)), t, "SetVariable()")
 		pval(2)
@@ -1263,10 +1265,10 @@ func TestBreakpointCountsWithDetection(t *testing.T) {
 				}
 				scope, err := th.Scope()
 				assertNoError(err, t, "Scope()")
-				v, err := scope.EvalVariable("i")
+				v, err := scope.EvalVariable("i", normalLoadConfig)
 				assertNoError(err, t, "evalVariable")
 				i, _ := constant.Int64Val(v.Value)
-				v, err = scope.EvalVariable("id")
+				v, err = scope.EvalVariable("id", normalLoadConfig)
 				assertNoError(err, t, "evalVariable")
 				id, _ := constant.Int64Val(v.Value)
 				m[id] = i
@@ -1394,7 +1396,7 @@ func BenchmarkLocalVariables(b *testing.B) {
 		scope, err := p.CurrentThread.Scope()
 		assertNoError(err, b, "Scope()")
 		for i := 0; i < b.N; i++ {
-			_, err := scope.LocalVariables()
+			_, err := scope.LocalVariables(normalLoadConfig)
 			assertNoError(err, b, "LocalVariables()")
 		}
 	})
@@ -1619,7 +1621,7 @@ func TestPackageVariables(t *testing.T) {
 		assertNoError(err, t, "Continue()")
 		scope, err := p.CurrentThread.Scope()
 		assertNoError(err, t, "Scope()")
-		vars, err := scope.PackageVariables()
+		vars, err := scope.PackageVariables(normalLoadConfig)
 		assertNoError(err, t, "PackageVariables()")
 		failed := false
 		for _, v := range vars {

--- a/proc/variables.go
+++ b/proc/variables.go
@@ -19,9 +19,7 @@ import (
 )
 
 const (
-	maxVariableRecurse = 1  // How far to recurse when evaluating nested types.
-	maxArrayValues     = 64 // Max value for reading large arrays.
-	maxErrCount        = 3  // Max number of read errors to accept while evaluating slices, arrays and structs
+	maxErrCount = 3 // Max number of read errors to accept while evaluating slices, arrays and structs
 
 	maxArrayStridePrefetch = 1024 // Maximum size of array stride for which we will prefetch the array contents
 
@@ -67,6 +65,22 @@ type Variable struct {
 	loaded     bool
 	Unreadable error
 }
+
+type LoadConfig struct {
+	// FollowPointers requests pointers to be automatically dereferenced.
+	FollowPointers bool
+	// MaxVariableRecurse is how far to recurse when evaluating nested types.
+	MaxVariableRecurse int
+	// MaxStringLen is the maximum number of bytes read from a string
+	MaxStringLen int
+	// MaxArrayValues is the maximum number of elements read from an array, a slice or a map.
+	MaxArrayValues int
+	// MaxStructFields is the maximum number of fields read from a struct, -1 will read all fields.
+	MaxStructFields int
+}
+
+var loadSingleValue = LoadConfig{false, 0, 64, 0, 0}
+var loadFullValue = LoadConfig{true, 1, 64, 64, -1}
 
 // M represents a runtime M (OS thread) structure.
 type M struct {
@@ -356,7 +370,7 @@ func (gvar *Variable) parseG() (*G, error) {
 		}
 		return nil, NoGError{ tid: id }
 	}
-	gvar.loadValue()
+	gvar.loadValue(loadFullValue)
 	if gvar.Unreadable != nil {
 		return nil, gvar.Unreadable
 	}
@@ -394,7 +408,7 @@ func (v *Variable) toFieldNamed(name string) *Variable {
 	if err != nil {
 		return nil
 	}
-	v.loadValue()
+	v.loadValue(loadFullValue)
 	if v.Unreadable != nil {
 		return nil
 	}
@@ -436,8 +450,8 @@ func (g *G) Go() Location {
 }
 
 // EvalVariable returns the value of the given expression (backwards compatibility).
-func (scope *EvalScope) EvalVariable(name string) (*Variable, error) {
-	return scope.EvalExpression(name)
+func (scope *EvalScope) EvalVariable(name string, cfg LoadConfig) (*Variable, error) {
+	return scope.EvalExpression(name, cfg)
 }
 
 // SetVariable sets the value of the named variable
@@ -470,7 +484,7 @@ func (scope *EvalScope) SetVariable(name, value string) error {
 		return err
 	}
 
-	yv.loadValue()
+	yv.loadValue(loadSingleValue)
 
 	if err := yv.isType(xv.RealType, xv.Kind); err != nil {
 		return err
@@ -483,13 +497,13 @@ func (scope *EvalScope) SetVariable(name, value string) error {
 	return xv.setValue(yv)
 }
 
-func (scope *EvalScope) extractVariableFromEntry(entry *dwarf.Entry) (*Variable, error) {
+func (scope *EvalScope) extractVariableFromEntry(entry *dwarf.Entry, cfg LoadConfig) (*Variable, error) {
 	rdr := scope.DwarfReader()
 	v, err := scope.extractVarInfoFromEntry(entry, rdr)
 	if err != nil {
 		return nil, err
 	}
-	v.loadValue()
+	v.loadValue(cfg)
 	return v, nil
 }
 
@@ -519,17 +533,17 @@ func (scope *EvalScope) extractVarInfo(varName string) (*Variable, error) {
 }
 
 // LocalVariables returns all local variables from the current function scope.
-func (scope *EvalScope) LocalVariables() ([]*Variable, error) {
-	return scope.variablesByTag(dwarf.TagVariable)
+func (scope *EvalScope) LocalVariables(cfg LoadConfig) ([]*Variable, error) {
+	return scope.variablesByTag(dwarf.TagVariable, cfg)
 }
 
 // FunctionArguments returns the name, value, and type of all current function arguments.
-func (scope *EvalScope) FunctionArguments() ([]*Variable, error) {
-	return scope.variablesByTag(dwarf.TagFormalParameter)
+func (scope *EvalScope) FunctionArguments(cfg LoadConfig) ([]*Variable, error) {
+	return scope.variablesByTag(dwarf.TagFormalParameter, cfg)
 }
 
 // PackageVariables returns the name, value, and type of all package variables in the application.
-func (scope *EvalScope) PackageVariables() ([]*Variable, error) {
+func (scope *EvalScope) PackageVariables(cfg LoadConfig) ([]*Variable, error) {
 	var vars []*Variable
 	reader := scope.DwarfReader()
 
@@ -549,7 +563,7 @@ func (scope *EvalScope) PackageVariables() ([]*Variable, error) {
 		}
 
 		// Ignore errors trying to extract values
-		val, err := scope.extractVariableFromEntry(entry)
+		val, err := scope.extractVariableFromEntry(entry, cfg)
 		if err != nil {
 			continue
 		}
@@ -561,14 +575,14 @@ func (scope *EvalScope) PackageVariables() ([]*Variable, error) {
 
 // EvalPackageVariable will evaluate the package level variable
 // specified by 'name'.
-func (dbp *Process) EvalPackageVariable(name string) (*Variable, error) {
+func (dbp *Process) EvalPackageVariable(name string, cfg LoadConfig) (*Variable, error) {
 	scope := &EvalScope{Thread: dbp.CurrentThread, PC: 0, CFA: 0}
 
 	v, err := scope.packageVarAddr(name)
 	if err != nil {
 		return nil, err
 	}
-	v.loadValue()
+	v.loadValue(cfg)
 	return v, nil
 }
 
@@ -709,11 +723,11 @@ func (v *Variable) maybeDereference() *Variable {
 }
 
 // Extracts the value of the variable at the given address.
-func (v *Variable) loadValue() {
-	v.loadValueInternal(0)
+func (v *Variable) loadValue(cfg LoadConfig) {
+	v.loadValueInternal(0, cfg)
 }
 
-func (v *Variable) loadValueInternal(recurseLevel int) {
+func (v *Variable) loadValueInternal(recurseLevel int, cfg LoadConfig) {
 	if v.Unreadable != nil || v.loaded || (v.Addr == 0 && v.Base == 0) {
 		return
 	}
@@ -723,30 +737,34 @@ func (v *Variable) loadValueInternal(recurseLevel int) {
 	case reflect.Ptr, reflect.UnsafePointer:
 		v.Len = 1
 		v.Children = []Variable{*v.maybeDereference()}
-		// Don't increase the recursion level when dereferencing pointers
-		v.Children[0].loadValueInternal(recurseLevel)
+		if cfg.FollowPointers {
+			// Don't increase the recursion level when dereferencing pointers
+			v.Children[0].loadValueInternal(recurseLevel, cfg)
+		} else {
+			v.Children[0].OnlyAddr = true
+		}
 
 	case reflect.Chan:
 		sv := v.clone()
 		sv.RealType = resolveTypedef(&(sv.RealType.(*dwarf.ChanType).TypedefType))
 		sv = sv.maybeDereference()
-		sv.loadValueInternal(recurseLevel)
+		sv.loadValueInternal(0, loadFullValue)
 		v.Children = sv.Children
 		v.Len = sv.Len
 		v.Base = sv.Addr
 
 	case reflect.Map:
-		if recurseLevel <= maxVariableRecurse {
-			v.loadMap(recurseLevel)
+		if recurseLevel <= cfg.MaxVariableRecurse {
+			v.loadMap(recurseLevel, cfg)
 		}
 
 	case reflect.String:
 		var val string
-		val, v.Unreadable = readStringValue(v.mem, v.Base, v.Len)
+		val, v.Unreadable = readStringValue(v.mem, v.Base, v.Len, cfg)
 		v.Value = constant.MakeString(val)
 
 	case reflect.Slice, reflect.Array:
-		v.loadArrayValues(recurseLevel)
+		v.loadArrayValues(recurseLevel, cfg)
 
 	case reflect.Struct:
 		v.mem = cacheMemory(v.mem, v.Addr, int(v.RealType.Size()))
@@ -754,18 +772,21 @@ func (v *Variable) loadValueInternal(recurseLevel int) {
 		v.Len = int64(len(t.Field))
 		// Recursively call extractValue to grab
 		// the value of all the members of the struct.
-		if recurseLevel <= maxVariableRecurse {
+		if recurseLevel <= cfg.MaxVariableRecurse {
 			v.Children = make([]Variable, 0, len(t.Field))
 			for i, field := range t.Field {
+				if cfg.MaxStructFields >= 0 && len(v.Children) >= cfg.MaxStructFields {
+					break
+				}
 				f, _ := v.toField(field)
 				v.Children = append(v.Children, *f)
 				v.Children[i].Name = field.Name
-				v.Children[i].loadValueInternal(recurseLevel + 1)
+				v.Children[i].loadValueInternal(recurseLevel+1, cfg)
 			}
 		}
 
 	case reflect.Interface:
-		v.loadInterface(recurseLevel, true)
+		v.loadInterface(recurseLevel, true, cfg)
 
 	case reflect.Complex64, reflect.Complex128:
 		v.readComplex(v.RealType.(*dwarf.ComplexType).ByteSize)
@@ -854,10 +875,10 @@ func readStringInfo(mem memoryReadWriter, arch Arch, addr uintptr) (uintptr, int
 	return addr, strlen, nil
 }
 
-func readStringValue(mem memoryReadWriter, addr uintptr, strlen int64) (string, error) {
+func readStringValue(mem memoryReadWriter, addr uintptr, strlen int64, cfg LoadConfig) (string, error) {
 	count := strlen
-	if count > maxArrayValues {
-		count = maxArrayValues
+	if count > int64(cfg.MaxStringLen) {
+		count = int64(cfg.MaxStringLen)
 	}
 
 	val, err := mem.readMemory(addr, int(count))
@@ -868,16 +889,6 @@ func readStringValue(mem memoryReadWriter, addr uintptr, strlen int64) (string, 
 	retstr := *(*string)(unsafe.Pointer(&val))
 
 	return retstr, nil
-}
-
-func readString(mem memoryReadWriter, arch Arch, addr uintptr) (string, int64, error) {
-	addr, strlen, err := readStringInfo(mem, arch, addr)
-	if err != nil {
-		return "", 0, err
-	}
-
-	retstr, err := readStringValue(mem, addr, strlen)
-	return retstr, strlen, err
 }
 
 func (v *Variable) loadSliceInfo(t *dwarf.SliceType) {
@@ -901,14 +912,14 @@ func (v *Variable) loadSliceInfo(t *dwarf.SliceType) {
 			}
 		case "len":
 			lstrAddr, _ := v.toField(f)
-			lstrAddr.loadValue()
+			lstrAddr.loadValue(loadSingleValue)
 			err = lstrAddr.Unreadable
 			if err == nil {
 				v.Len, _ = constant.Int64Val(lstrAddr.Value)
 			}
 		case "cap":
 			cstrAddr, _ := v.toField(f)
-			cstrAddr.loadValue()
+			cstrAddr.loadValue(loadSingleValue)
 			err = cstrAddr.Unreadable
 			if err == nil {
 				v.Cap, _ = constant.Int64Val(cstrAddr.Value)
@@ -928,7 +939,7 @@ func (v *Variable) loadSliceInfo(t *dwarf.SliceType) {
 	return
 }
 
-func (v *Variable) loadArrayValues(recurseLevel int) {
+func (v *Variable) loadArrayValues(recurseLevel int, cfg LoadConfig) {
 	if v.Unreadable != nil {
 		return
 	}
@@ -939,8 +950,8 @@ func (v *Variable) loadArrayValues(recurseLevel int) {
 
 	count := v.Len
 	// Cap number of elements
-	if count > maxArrayValues {
-		count = maxArrayValues
+	if count > int64(cfg.MaxArrayValues) {
+		count = int64(cfg.MaxArrayValues)
 	}
 
 	if v.stride < maxArrayStridePrefetch {
@@ -951,7 +962,7 @@ func (v *Variable) loadArrayValues(recurseLevel int) {
 
 	for i := int64(0); i < count; i++ {
 		fieldvar := v.newVariable("", uintptr(int64(v.Base)+(i*v.stride)), v.fieldType)
-		fieldvar.loadValueInternal(recurseLevel + 1)
+		fieldvar.loadValueInternal(recurseLevel+1, cfg)
 
 		if fieldvar.Unreadable != nil {
 			errcount++
@@ -980,8 +991,8 @@ func (v *Variable) readComplex(size int64) {
 
 	realvar := v.newVariable("real", v.Addr, ftyp)
 	imagvar := v.newVariable("imaginary", v.Addr+uintptr(fs), ftyp)
-	realvar.loadValue()
-	imagvar.loadValue()
+	realvar.loadValue(loadSingleValue)
+	imagvar.loadValue(loadSingleValue)
 	v.Value = constant.BinaryOp(realvar.Value, token.ADD, constant.MakeImag(imagvar.Value))
 }
 
@@ -1132,7 +1143,7 @@ func (v *Variable) readFunctionPtr() {
 	v.Value = constant.MakeString(fn.Name)
 }
 
-func (v *Variable) loadMap(recurseLevel int) {
+func (v *Variable) loadMap(recurseLevel int, cfg LoadConfig) {
 	it := v.mapIterator()
 	if it == nil {
 		return
@@ -1148,13 +1159,13 @@ func (v *Variable) loadMap(recurseLevel int) {
 	count := 0
 	errcount := 0
 	for it.next() {
-		if count >= maxArrayValues {
+		if count >= cfg.MaxArrayValues {
 			break
 		}
 		key := it.key()
 		val := it.value()
-		key.loadValueInternal(recurseLevel + 1)
-		val.loadValueInternal(recurseLevel + 1)
+		key.loadValueInternal(recurseLevel+1, cfg)
+		val.loadValueInternal(recurseLevel+1, cfg)
 		if key.Unreadable != nil || val.Unreadable != nil {
 			errcount++
 		}
@@ -1382,7 +1393,7 @@ func mapEvacuated(b *Variable) bool {
 	return true
 }
 
-func (v *Variable) loadInterface(recurseLevel int, loadData bool) {
+func (v *Variable) loadInterface(recurseLevel int, loadData bool, cfg LoadConfig) {
 	var typestring, data *Variable
 	isnil := false
 
@@ -1432,7 +1443,7 @@ func (v *Variable) loadInterface(recurseLevel int, loadData bool) {
 		data = data.maybeDereference()
 		v.Children = []Variable{*data}
 		if loadData {
-			v.Children[0].loadValueInternal(recurseLevel)
+			v.Children[0].loadValueInternal(recurseLevel, cfg)
 		}
 		return
 	}
@@ -1441,7 +1452,7 @@ func (v *Variable) loadInterface(recurseLevel int, loadData bool) {
 		v.Unreadable = fmt.Errorf("invalid interface type")
 		return
 	}
-	typestring.loadValue()
+	typestring.loadValue(LoadConfig{false, 0, 512, 0, 0})
 	if typestring.Unreadable != nil {
 		v.Unreadable = fmt.Errorf("invalid interface type: %v", typestring.Unreadable)
 		return
@@ -1469,13 +1480,15 @@ func (v *Variable) loadInterface(recurseLevel int, loadData bool) {
 
 	v.Children = []Variable{*data}
 	if loadData {
-		v.Children[0].loadValueInternal(recurseLevel)
+		v.Children[0].loadValueInternal(recurseLevel, cfg)
+	} else {
+		v.Children[0].OnlyAddr = true
 	}
 	return
 }
 
 // Fetches all variables of a specific type in the current function scope
-func (scope *EvalScope) variablesByTag(tag dwarf.Tag) ([]*Variable, error) {
+func (scope *EvalScope) variablesByTag(tag dwarf.Tag, cfg LoadConfig) ([]*Variable, error) {
 	reader := scope.DwarfReader()
 
 	_, err := reader.SeekToFunction(scope.PC)
@@ -1490,7 +1503,7 @@ func (scope *EvalScope) variablesByTag(tag dwarf.Tag) ([]*Variable, error) {
 		}
 
 		if entry.Tag == tag {
-			val, err := scope.extractVariableFromEntry(entry)
+			val, err := scope.extractVariableFromEntry(entry, cfg)
 			if err != nil {
 				// skip variables that we can't parse yet
 				continue

--- a/proc/variables.go
+++ b/proc/variables.go
@@ -250,6 +250,7 @@ func newConstant(val constant.Value, mem memoryReadWriter) *Variable {
 }
 
 var nilVariable = &Variable{
+	Name:     "nil",
 	Addr:     0,
 	Base:     0,
 	Kind:     reflect.Ptr,

--- a/service/api/conversions.go
+++ b/service/api/conversions.go
@@ -27,6 +27,8 @@ func ConvertBreakpoint(bp *proc.Breakpoint) *Breakpoint {
 		Stacktrace:    bp.Stacktrace,
 		Goroutine:     bp.Goroutine,
 		Variables:     bp.Variables,
+		LoadArgs:      LoadConfigFromProc(bp.LoadArgs),
+		LoadLocals:    LoadConfigFromProc(bp.LoadLocals),
 		TotalHitCount: bp.TotalHitCount,
 	}
 
@@ -215,5 +217,31 @@ func ConvertAsmInstruction(inst proc.AsmInstruction, text string) AsmInstruction
 		Bytes:      inst.Bytes,
 		Breakpoint: inst.Breakpoint,
 		AtPC:       inst.AtPC,
+	}
+}
+
+func LoadConfigToProc(cfg *LoadConfig) *proc.LoadConfig {
+	if cfg == nil {
+		return nil
+	}
+	return &proc.LoadConfig{
+		cfg.FollowPointers,
+		cfg.MaxVariableRecurse,
+		cfg.MaxStringLen,
+		cfg.MaxArrayValues,
+		cfg.MaxStructFields,
+	}
+}
+
+func LoadConfigFromProc(cfg *proc.LoadConfig) *LoadConfig {
+	if cfg == nil {
+		return nil
+	}
+	return &LoadConfig{
+		cfg.FollowPointers,
+		cfg.MaxVariableRecurse,
+		cfg.MaxStringLen,
+		cfg.MaxArrayValues,
+		cfg.MaxStructFields,
 	}
 }

--- a/service/api/types.go
+++ b/service/api/types.go
@@ -51,8 +51,12 @@ type Breakpoint struct {
 	Goroutine bool `json:"goroutine"`
 	// number of stack frames to retrieve
 	Stacktrace int `json:"stacktrace"`
-	// variables to evaluate
+	// expressions to evaluate
 	Variables []string `json:"variables,omitempty"`
+	// LoadArgs requests loading function arguments when the breakpoint is hit
+	LoadArgs *LoadConfig
+	// LoadLocals requests loading function locals when the breakpoint is hit
+	LoadLocals *LoadConfig
 	// number of times a breakpoint has been reached in a certain goroutine
 	HitCount map[string]uint64 `json:"hitCount"`
 	// number of times a breakpoint has been reached
@@ -166,6 +170,20 @@ type Variable struct {
 	Unreadable string `json:"unreadable"`
 }
 
+// LoadConfig describes how to load values from target's memory
+type LoadConfig struct {
+	// FollowPointers requests pointers to be automatically dereferenced.
+	FollowPointers bool
+	// MaxVariableRecurse is how far to recurse when evaluating nested types.
+	MaxVariableRecurse int
+	// MaxStringLen is the maximum number of bytes read from a string
+	MaxStringLen int
+	// MaxArrayValues is the maximum number of elements read from an array, a slice or a map.
+	MaxArrayValues int
+	// MaxStructFields is the maximum number of fields read from a struct, -1 will read all fields.
+	MaxStructFields int
+}
+
 // Goroutine represents the information relevant to Delve from the runtime's
 // internal G structure.
 type Goroutine struct {
@@ -197,6 +215,7 @@ type BreakpointInfo struct {
 	Goroutine  *Goroutine   `json:"goroutine,omitempty"`
 	Variables  []Variable   `json:"variables,omitempty"`
 	Arguments  []Variable   `json:"arguments,omitempty"`
+	Locals     []Variable   `json:"locals,omitempty"`
 }
 
 type EvalScope struct {

--- a/service/api/types.go
+++ b/service/api/types.go
@@ -129,10 +129,6 @@ type Function struct {
 	Value  uint64 `json:"value"`
 	Type   byte   `json:"type"`
 	GoType uint64 `json:"goType"`
-	// Args are the function arguments in a thread context.
-	Args []Variable `json:"args"`
-	// Locals are the thread local variables.
-	Locals []Variable `json:"locals"`
 }
 
 // Variable describes a variable.

--- a/service/client.go
+++ b/service/client.go
@@ -56,9 +56,9 @@ type Client interface {
 	GetThread(id int) (*api.Thread, error)
 
 	// ListPackageVariables lists all package variables in the context of the current thread.
-	ListPackageVariables(filter string) ([]api.Variable, error)
+	ListPackageVariables(filter string, cfg api.LoadConfig) ([]api.Variable, error)
 	// EvalVariable returns a variable in the context of the current thread.
-	EvalVariable(scope api.EvalScope, symbol string) (*api.Variable, error)
+	EvalVariable(scope api.EvalScope, symbol string, cfg api.LoadConfig) (*api.Variable, error)
 
 	// SetVariable sets the value of a variable
 	SetVariable(scope api.EvalScope, symbol, value string) error
@@ -70,9 +70,9 @@ type Client interface {
 	// ListTypes lists all types in the process matching filter.
 	ListTypes(filter string) ([]string, error)
 	// ListLocals lists all local variables in scope.
-	ListLocalVariables(scope api.EvalScope) ([]api.Variable, error)
+	ListLocalVariables(scope api.EvalScope, cfg api.LoadConfig) ([]api.Variable, error)
 	// ListFunctionArgs lists all arguments to the current function.
-	ListFunctionArgs(scope api.EvalScope) ([]api.Variable, error)
+	ListFunctionArgs(scope api.EvalScope, cfg api.LoadConfig) ([]api.Variable, error)
 	// ListRegisters lists registers and their values.
 	ListRegisters() (string, error)
 
@@ -80,7 +80,7 @@ type Client interface {
 	ListGoroutines() ([]*api.Goroutine, error)
 
 	// Returns stacktrace
-	Stacktrace(int, int, bool) ([]api.Stackframe, error)
+	Stacktrace(int, int, *api.LoadConfig) ([]api.Stackframe, error)
 
 	// Returns whether we attached to a running process or not
 	AttachedToExistingProcess() bool

--- a/service/debugger/locations.go
+++ b/service/debugger/locations.go
@@ -256,7 +256,7 @@ func (loc *AddrLocationSpec) Find(d *Debugger, scope *proc.EvalScope, locStr str
 		}
 		return []api.Location{{PC: uint64(addr)}}, nil
 	} else {
-		v, err := scope.EvalExpression(loc.AddrExpr)
+		v, err := scope.EvalExpression(loc.AddrExpr, proc.LoadConfig{true, 0, 0, 0, 0})
 		if err != nil {
 			return nil, err
 		}

--- a/service/rpc1/client.go
+++ b/service/rpc1/client.go
@@ -6,7 +6,6 @@ import (
 	"net/rpc"
 	"net/rpc/jsonrpc"
 
-	"github.com/derekparker/delve/service"
 	"github.com/derekparker/delve/service/api"
 )
 
@@ -16,9 +15,6 @@ type RPCClient struct {
 	processPid int
 	client     *rpc.Client
 }
-
-// Ensure the implementation satisfies the interface.
-var _ service.Client = &RPCClient{}
 
 // NewClient creates a new RPCClient.
 func NewClient(addr string) *RPCClient {

--- a/service/rpc2/client.go
+++ b/service/rpc2/client.go
@@ -190,9 +190,9 @@ func (c *RPCClient) GetThread(id int) (*api.Thread, error) {
 	return out.Thread, err
 }
 
-func (c *RPCClient) EvalVariable(scope api.EvalScope, expr string) (*api.Variable, error) {
+func (c *RPCClient) EvalVariable(scope api.EvalScope, expr string, cfg api.LoadConfig) (*api.Variable, error) {
 	var out EvalOut
-	err := c.call("Eval", EvalIn{scope, expr}, &out)
+	err := c.call("Eval", EvalIn{scope, expr, &cfg}, &out)
 	return out.Variable, err
 }
 
@@ -219,15 +219,15 @@ func (c *RPCClient) ListTypes(filter string) ([]string, error) {
 	return types.Types, err
 }
 
-func (c *RPCClient) ListPackageVariables(filter string) ([]api.Variable, error) {
+func (c *RPCClient) ListPackageVariables(filter string, cfg api.LoadConfig) ([]api.Variable, error) {
 	var out ListPackageVarsOut
-	err := c.call("ListPackageVars", ListPackageVarsIn{filter}, &out)
+	err := c.call("ListPackageVars", ListPackageVarsIn{filter, cfg}, &out)
 	return out.Variables, err
 }
 
-func (c *RPCClient) ListLocalVariables(scope api.EvalScope) ([]api.Variable, error) {
+func (c *RPCClient) ListLocalVariables(scope api.EvalScope, cfg api.LoadConfig) ([]api.Variable, error) {
 	var out ListLocalVarsOut
-	err := c.call("ListLocalVars", ListLocalVarsIn{scope}, &out)
+	err := c.call("ListLocalVars", ListLocalVarsIn{scope, cfg}, &out)
 	return out.Variables, err
 }
 
@@ -237,9 +237,9 @@ func (c *RPCClient) ListRegisters() (string, error) {
 	return out.Registers, err
 }
 
-func (c *RPCClient) ListFunctionArgs(scope api.EvalScope) ([]api.Variable, error) {
+func (c *RPCClient) ListFunctionArgs(scope api.EvalScope, cfg api.LoadConfig) ([]api.Variable, error) {
 	var out ListFunctionArgsOut
-	err := c.call("ListFunctionArgs", ListFunctionArgsIn{scope}, &out)
+	err := c.call("ListFunctionArgs", ListFunctionArgsIn{scope, cfg}, &out)
 	return out.Args, err
 }
 
@@ -249,9 +249,9 @@ func (c *RPCClient) ListGoroutines() ([]*api.Goroutine, error) {
 	return out.Goroutines, err
 }
 
-func (c *RPCClient) Stacktrace(goroutineId, depth int, full bool) ([]api.Stackframe, error) {
+func (c *RPCClient) Stacktrace(goroutineId, depth int, cfg *api.LoadConfig) ([]api.Stackframe, error) {
 	var out StacktraceOut
-	err := c.call("Stacktrace", StacktraceIn{goroutineId, depth, full}, &out)
+	err := c.call("Stacktrace", StacktraceIn{goroutineId, depth, false, cfg}, &out)
 	return out.Locations, err
 }
 

--- a/service/test/integration2_test.go
+++ b/service/test/integration2_test.go
@@ -1075,3 +1075,21 @@ func TestIssue406(t *testing.T) {
 		t.Logf("cfgtree formats to: %s\n", vs)
 	})
 }
+
+func TestEvalExprName(t *testing.T) {
+	withTestClient2("testvariables2", t, func(c service.Client) {
+		state := <-c.Continue()
+		assertNoError(state.Err, t, "Continue()")
+
+		var1, err := c.EvalVariable(api.EvalScope{-1, 0}, "i1+1")
+		assertNoError(err, t, "EvalVariable")
+
+		const name = "i1+1"
+
+		t.Logf("i1+1 → %#v", var1)
+
+		if var1.Name != name {
+			t.Fatalf("Wrong variable name %q, expected %q", var1.Name, name)
+		}
+	})
+}

--- a/service/test/variables_test.go
+++ b/service/test/variables_test.go
@@ -12,11 +12,14 @@ import (
 	protest "github.com/derekparker/delve/proc/test"
 )
 
+var pnormalLoadConfig = proc.LoadConfig{true, 1, 64, 64, -1}
+var pshortLoadConfig = proc.LoadConfig{false, 0, 64, 0, 3}
+
 type varTest struct {
 	name         string
 	preserveName bool
 	value        string
-	setTo        string
+	alternate    string
 	varType      string
 	err          error
 }
@@ -49,21 +52,17 @@ func assertVariable(t *testing.T, variable *proc.Variable, expected varTest) {
 	}
 }
 
-func evalVariable(p *proc.Process, symbol string) (*proc.Variable, error) {
+func evalVariable(p *proc.Process, symbol string, cfg proc.LoadConfig) (*proc.Variable, error) {
 	scope, err := p.CurrentThread.Scope()
 	if err != nil {
 		return nil, err
 	}
-	return scope.EvalVariable(symbol)
+	return scope.EvalVariable(symbol, cfg)
 }
 
-func (tc *varTest) settable() bool {
-	return tc.setTo != ""
-}
-
-func (tc *varTest) afterSet() varTest {
+func (tc *varTest) alternateVarTest() varTest {
 	r := *tc
-	r.value = r.setTo
+	r.value = r.alternate
 	return r
 }
 
@@ -142,7 +141,7 @@ func TestVariableEvaluation(t *testing.T) {
 		assertNoError(err, t, "Continue() returned an error")
 
 		for _, tc := range testcases {
-			variable, err := evalVariable(p, tc.name)
+			variable, err := evalVariable(p, tc.name, pnormalLoadConfig)
 			if tc.err == nil {
 				assertNoError(err, t, "EvalVariable() returned an error")
 				assertVariable(t, variable, tc)
@@ -155,16 +154,82 @@ func TestVariableEvaluation(t *testing.T) {
 				}
 			}
 
-			if tc.settable() {
-				assertNoError(setVariable(p, tc.name, tc.setTo), t, "SetVariable()")
-				variable, err = evalVariable(p, tc.name)
+			if tc.alternate != "" {
+				assertNoError(setVariable(p, tc.name, tc.alternate), t, "SetVariable()")
+				variable, err = evalVariable(p, tc.name, pnormalLoadConfig)
 				assertNoError(err, t, "EvalVariable()")
-				assertVariable(t, variable, tc.afterSet())
+				assertVariable(t, variable, tc.alternateVarTest())
 
 				assertNoError(setVariable(p, tc.name, tc.value), t, "SetVariable()")
-				variable, err := evalVariable(p, tc.name)
+				variable, err := evalVariable(p, tc.name, pnormalLoadConfig)
 				assertNoError(err, t, "EvalVariable()")
 				assertVariable(t, variable, tc)
+			}
+		}
+	})
+}
+
+func TestVariableEvaluationShort(t *testing.T) {
+	testcases := []varTest{
+		{"a1", true, "\"foofoofoofoofoofoo\"", "", "string", nil},
+		{"a11", true, "[3]main.FooBar [...]", "", "[3]main.FooBar", nil},
+		{"a12", true, "[]main.FooBar len: 2, cap: 2, [...]", "", "[]main.FooBar", nil},
+		{"a13", true, "[]*main.FooBar len: 3, cap: 3, [...]", "", "[]*main.FooBar", nil},
+		{"a2", true, "6", "", "int", nil},
+		{"a3", true, "7.23", "", "float64", nil},
+		{"a4", true, "[2]int [...]", "", "[2]int", nil},
+		{"a5", true, "[]int len: 5, cap: 5, [...]", "", "[]int", nil},
+		{"a6", true, "main.FooBar {Baz: 8, Bur: \"word\"}", "", "main.FooBar", nil},
+		{"a7", true, "(*main.FooBar)(0x…", "", "*main.FooBar", nil},
+		{"a8", true, "main.FooBar2 {Bur: 10, Baz: \"feh\"}", "", "main.FooBar2", nil},
+		{"a9", true, "*main.FooBar nil", "", "*main.FooBar", nil},
+		{"baz", true, "\"bazburzum\"", "", "string", nil},
+		{"neg", true, "-1", "", "int", nil},
+		{"f32", true, "1.2", "", "float32", nil},
+		{"c64", true, "(1 + 2i)", "", "complex64", nil},
+		{"c128", true, "(2 + 3i)", "", "complex128", nil},
+		{"a6.Baz", true, "8", "", "int", nil},
+		{"a7.Baz", true, "5", "", "int", nil},
+		{"a8.Baz", true, "\"feh\"", "", "string", nil},
+		{"a9.Baz", true, "nil", "", "int", fmt.Errorf("a9 is nil")},
+		{"a9.NonExistent", true, "nil", "", "int", fmt.Errorf("a9 has no member NonExistent")},
+		{"a8", true, "main.FooBar2 {Bur: 10, Baz: \"feh\"}", "", "main.FooBar2", nil}, // reread variable after member
+		{"i32", true, "[2]int32 [...]", "", "[2]int32", nil},
+		{"b1", true, "true", "false", "bool", nil},
+		{"b2", true, "false", "true", "bool", nil},
+		{"i8", true, "1", "2", "int8", nil},
+		{"u16", true, "65535", "0", "uint16", nil},
+		{"u32", true, "4294967295", "1", "uint32", nil},
+		{"u64", true, "18446744073709551615", "2", "uint64", nil},
+		{"u8", true, "255", "3", "uint8", nil},
+		{"up", true, "5", "4", "uintptr", nil},
+		{"f", true, "main.barfoo", "", "func()", nil},
+		{"ba", true, "[]int len: 200, cap: 200, [...]", "", "[]int", nil},
+		{"ms", true, "main.Nest {Level: 0, Nest: (*main.Nest)(0x…", "", "main.Nest", nil},
+		{"ms.Nest.Nest", true, "(*main.Nest)(0x…", "", "*main.Nest", nil},
+		{"ms.Nest.Nest.Nest.Nest.Nest", true, "*main.Nest nil", "", "*main.Nest", nil},
+		{"ms.Nest.Nest.Nest.Nest.Nest.Nest", true, "", "", "*main.Nest", fmt.Errorf("ms.Nest.Nest.Nest.Nest.Nest is nil")},
+		{"main.p1", true, "10", "", "int", nil},
+		{"p1", true, "10", "", "int", nil},
+		{"NonExistent", true, "", "", "", fmt.Errorf("could not find symbol value for NonExistent")},
+	}
+
+	withTestProcess("testvariables", t, func(p *proc.Process, fixture protest.Fixture) {
+		err := p.Continue()
+		assertNoError(err, t, "Continue() returned an error")
+
+		for _, tc := range testcases {
+			variable, err := evalVariable(p, tc.name, pshortLoadConfig)
+			if tc.err == nil {
+				assertNoError(err, t, "EvalVariable() returned an error")
+				assertVariable(t, variable, tc)
+			} else {
+				if err == nil {
+					t.Fatalf("Expected error %s, got no error: %s\n", tc.err.Error(), api.ConvertVar(variable).SinglelineString())
+				}
+				if tc.err.Error() != err.Error() {
+					t.Fatalf("Unexpected error. Expected %s got %s", tc.err.Error(), err.Error())
+				}
 			}
 		}
 	})
@@ -209,7 +274,7 @@ func TestMultilineVariableEvaluation(t *testing.T) {
 		assertNoError(err, t, "Continue() returned an error")
 
 		for _, tc := range testcases {
-			variable, err := evalVariable(p, tc.name)
+			variable, err := evalVariable(p, tc.name, pnormalLoadConfig)
 			assertNoError(err, t, "EvalVariable() returned an error")
 			if ms := api.ConvertVar(variable).MultilineString(""); !matchStringOrPrefix(ms, tc.value) {
 				t.Fatalf("Expected %s got %s (variable %s)\n", tc.value, ms, variable.Name)
@@ -237,7 +302,7 @@ func (s varArray) Less(i, j int) bool {
 
 func TestLocalVariables(t *testing.T) {
 	testcases := []struct {
-		fn     func(*proc.EvalScope) ([]*proc.Variable, error)
+		fn     func(*proc.EvalScope, proc.LoadConfig) ([]*proc.Variable, error)
 		output []varTest
 	}{
 		{(*proc.EvalScope).LocalVariables,
@@ -284,7 +349,7 @@ func TestLocalVariables(t *testing.T) {
 		for _, tc := range testcases {
 			scope, err := p.CurrentThread.Scope()
 			assertNoError(err, t, "AsScope()")
-			vars, err := tc.fn(scope)
+			vars, err := tc.fn(scope, pnormalLoadConfig)
 			assertNoError(err, t, "LocalVariables() returned an error")
 
 			sort.Sort(varArray(vars))
@@ -303,21 +368,24 @@ func TestLocalVariables(t *testing.T) {
 func TestEmbeddedStruct(t *testing.T) {
 	withTestProcess("testvariables2", t, func(p *proc.Process, fixture protest.Fixture) {
 		testcases := []varTest{
-			{"b.val", true, "-314", "", "int", nil},
-			{"b.A.val", true, "-314", "", "int", nil},
-			{"b.a.val", true, "42", "", "int", nil},
-			{"b.ptr.val", true, "1337", "", "int", nil},
-			{"b.C.s", true, "\"hello\"", "", "string", nil},
-			{"b.s", true, "\"hello\"", "", "string", nil},
-			{"b2", true, "main.B {main.A: struct main.A {val: 42}, *main.C: *struct main.C nil, a: main.A {val: 47}, ptr: *main.A nil}", "", "main.B", nil},
+			{"b.val", true, "-314", "-314", "int", nil},
+			{"b.A.val", true, "-314", "-314", "int", nil},
+			{"b.a.val", true, "42", "42", "int", nil},
+			{"b.ptr.val", true, "1337", "1337", "int", nil},
+			{"b.C.s", true, "\"hello\"", "\"hello\"", "string", nil},
+			{"b.s", true, "\"hello\"", "\"hello\"", "string", nil},
+			{"b2", true, "main.B {main.A: struct main.A {val: 42}, *main.C: *struct main.C nil, a: main.A {val: 47}, ptr: *main.A nil}", "main.B {main.A: (*struct main.A)(0x…", "main.B", nil},
 		}
 		assertNoError(p.Continue(), t, "Continue()")
 
 		for _, tc := range testcases {
-			variable, err := evalVariable(p, tc.name)
+			variable, err := evalVariable(p, tc.name, pnormalLoadConfig)
 			if tc.err == nil {
-				assertNoError(err, t, "EvalVariable() returned an error")
+				assertNoError(err, t, fmt.Sprintf("EvalVariable(%s) returned an error", tc.name))
 				assertVariable(t, variable, tc)
+				variable, err = evalVariable(p, tc.name, pshortLoadConfig)
+				assertNoError(err, t, fmt.Sprintf("EvalVariable(%s, pshortLoadConfig) returned an error", tc.name))
+				assertVariable(t, variable, tc.alternateVarTest())
 			} else {
 				if tc.err.Error() != err.Error() {
 					t.Fatalf("Unexpected error. Expected %s got %s", tc.err.Error(), err.Error())
@@ -334,7 +402,7 @@ func TestComplexSetting(t *testing.T) {
 
 		h := func(setExpr, value string) {
 			assertNoError(setVariable(p, "c128", setExpr), t, "SetVariable()")
-			variable, err := evalVariable(p, "c128")
+			variable, err := evalVariable(p, "c128", pnormalLoadConfig)
 			assertNoError(err, t, "EvalVariable()")
 			if s := api.ConvertVar(variable).SinglelineString(); s != value {
 				t.Fatalf("Wrong value of c128: \"%s\", expected \"%s\" after setting it to \"%s\"", s, value, setExpr)
@@ -351,171 +419,171 @@ func TestComplexSetting(t *testing.T) {
 func TestEvalExpression(t *testing.T) {
 	testcases := []varTest{
 		// slice/array/string subscript
-		{"s1[0]", false, "\"one\"", "", "string", nil},
-		{"s1[1]", false, "\"two\"", "", "string", nil},
-		{"s1[2]", false, "\"three\"", "", "string", nil},
-		{"s1[3]", false, "\"four\"", "", "string", nil},
-		{"s1[4]", false, "\"five\"", "", "string", nil},
+		{"s1[0]", false, "\"one\"", "\"one\"", "string", nil},
+		{"s1[1]", false, "\"two\"", "\"two\"", "string", nil},
+		{"s1[2]", false, "\"three\"", "\"three\"", "string", nil},
+		{"s1[3]", false, "\"four\"", "\"four\"", "string", nil},
+		{"s1[4]", false, "\"five\"", "\"five\"", "string", nil},
 		{"s1[5]", false, "", "", "string", fmt.Errorf("index out of bounds")},
-		{"a1[0]", false, "\"one\"", "", "string", nil},
-		{"a1[1]", false, "\"two\"", "", "string", nil},
-		{"a1[2]", false, "\"three\"", "", "string", nil},
-		{"a1[3]", false, "\"four\"", "", "string", nil},
-		{"a1[4]", false, "\"five\"", "", "string", nil},
+		{"a1[0]", false, "\"one\"", "\"one\"", "string", nil},
+		{"a1[1]", false, "\"two\"", "\"two\"", "string", nil},
+		{"a1[2]", false, "\"three\"", "\"three\"", "string", nil},
+		{"a1[3]", false, "\"four\"", "\"four\"", "string", nil},
+		{"a1[4]", false, "\"five\"", "\"five\"", "string", nil},
 		{"a1[5]", false, "", "", "string", fmt.Errorf("index out of bounds")},
-		{"str1[0]", false, "48", "", "byte", nil},
-		{"str1[1]", false, "49", "", "byte", nil},
-		{"str1[2]", false, "50", "", "byte", nil},
-		{"str1[10]", false, "48", "", "byte", nil},
+		{"str1[0]", false, "48", "48", "byte", nil},
+		{"str1[1]", false, "49", "49", "byte", nil},
+		{"str1[2]", false, "50", "50", "byte", nil},
+		{"str1[10]", false, "48", "48", "byte", nil},
 		{"str1[11]", false, "", "", "byte", fmt.Errorf("index out of bounds")},
 
 		// slice/array/string reslicing
-		{"a1[2:4]", false, "[]string len: 2, cap: 2, [\"three\",\"four\"]", "", "[]string", nil},
-		{"s1[2:4]", false, "[]string len: 2, cap: 2, [\"three\",\"four\"]", "", "[]string", nil},
-		{"str1[2:4]", false, "\"23\"", "", "string", nil},
-		{"str1[0:11]", false, "\"01234567890\"", "", "string", nil},
-		{"str1[:3]", false, "\"012\"", "", "string", nil},
-		{"str1[3:]", false, "\"34567890\"", "", "string", nil},
+		{"a1[2:4]", false, "[]string len: 2, cap: 2, [\"three\",\"four\"]", "[]string len: 2, cap: 2, [...]", "[]string", nil},
+		{"s1[2:4]", false, "[]string len: 2, cap: 2, [\"three\",\"four\"]", "[]string len: 2, cap: 2, [...]", "[]string", nil},
+		{"str1[2:4]", false, "\"23\"", "\"23\"", "string", nil},
+		{"str1[0:11]", false, "\"01234567890\"", "\"01234567890\"", "string", nil},
+		{"str1[:3]", false, "\"012\"", "\"012\"", "string", nil},
+		{"str1[3:]", false, "\"34567890\"", "\"34567890\"", "string", nil},
 		{"str1[0:12]", false, "", "", "string", fmt.Errorf("index out of bounds")},
 		{"str1[5:3]", false, "", "", "string", fmt.Errorf("index out of bounds")},
 
 		// pointers
-		{"*p2", false, "5", "", "int", nil},
-		{"p2", true, "*5", "", "*int", nil},
-		{"p3", true, "*int nil", "", "*int", nil},
+		{"*p2", false, "5", "5", "int", nil},
+		{"p2", true, "*5", "(*int)(0x…", "*int", nil},
+		{"p3", true, "*int nil", "*int nil", "*int", nil},
 		{"*p3", false, "", "", "int", fmt.Errorf("nil pointer dereference")},
 
 		// channels
-		{"ch1", true, "chan int 0/2", "", "chan int", nil},
-		{"chnil", true, "chan int nil", "", "chan int", nil},
+		{"ch1", true, "chan int 0/2", "chan int 0/2", "chan int", nil},
+		{"chnil", true, "chan int nil", "chan int nil", "chan int", nil},
 		{"ch1+1", false, "", "", "", fmt.Errorf("can not convert 1 constant to chan int")},
 
 		// maps
-		{"m1[\"Malone\"]", false, "struct main.astruct {A: 2, B: 3}", "", "struct main.astruct", nil},
-		{"m2[1].B", false, "11", "", "int", nil},
-		{"m2[c1.sa[2].B-4].A", false, "10", "", "int", nil},
-		{"m2[*p1].B", false, "11", "", "int", nil},
-		{"m3[as1]", false, "42", "", "int", nil},
+		{"m1[\"Malone\"]", false, "struct main.astruct {A: 2, B: 3}", "struct main.astruct {A: 2, B: 3}", "struct main.astruct", nil},
+		{"m2[1].B", false, "11", "11", "int", nil},
+		{"m2[c1.sa[2].B-4].A", false, "10", "10", "int", nil},
+		{"m2[*p1].B", false, "11", "11", "int", nil},
+		{"m3[as1]", false, "42", "42", "int", nil},
 		{"mnil[\"Malone\"]", false, "", "", "", fmt.Errorf("key not found")},
 		{"m1[80:]", false, "", "", "", fmt.Errorf("map index out of bounds")},
 
 		// interfaces
-		{"err1", true, "error(*struct main.astruct) *{A: 1, B: 2}", "", "error", nil},
-		{"err2", true, "error(*struct main.bstruct) *{a: main.astruct {A: 1, B: 2}}", "", "error", nil},
-		{"errnil", true, "error nil", "", "error", nil},
-		{"iface1", true, "interface {}(*struct main.astruct) *{A: 1, B: 2}", "", "interface {}", nil},
-		{"iface2", true, "interface {}(*string) *\"test\"", "", "interface {}", nil},
-		{"iface3", true, "interface {}(*map[string]go/constant.Value) *[]", "", "interface {}", nil},
-		{"iface4", true, "interface {}(*[]go/constant.Value) *[*4]", "", "interface {}", nil},
-		{"ifacenil", true, "interface {} nil", "", "interface {}", nil},
-		{"err1 == err2", false, "false", "", "", nil},
+		{"err1", true, "error(*struct main.astruct) *{A: 1, B: 2}", "error(*struct main.astruct) 0x…", "error", nil},
+		{"err2", true, "error(*struct main.bstruct) *{a: main.astruct {A: 1, B: 2}}", "error(*struct main.bstruct) 0x…", "error", nil},
+		{"errnil", true, "error nil", "error nil", "error", nil},
+		{"iface1", true, "interface {}(*struct main.astruct) *{A: 1, B: 2}", "interface {}(*struct main.astruct) 0x…", "interface {}", nil},
+		{"iface2", true, "interface {}(*string) *\"test\"", "interface {}(*string) 0x…", "interface {}", nil},
+		{"iface3", true, "interface {}(*map[string]go/constant.Value) *[]", "interface {}(*map[string]go/constant.Value) 0x…", "interface {}", nil},
+		{"iface4", true, "interface {}(*[]go/constant.Value) *[*4]", "interface {}(*[]go/constant.Value) 0x…", "interface {}", nil},
+		{"ifacenil", true, "interface {} nil", "interface {} nil", "interface {}", nil},
+		{"err1 == err2", false, "false", "false", "", nil},
 		{"err1 == iface1", false, "", "", "", fmt.Errorf("mismatched types \"error\" and \"interface {}\"")},
-		{"errnil == nil", false, "false", "", "", nil},
-		{"nil == errnil", false, "false", "", "", nil},
-		{"err1.(*main.astruct)", false, "*struct main.astruct {A: 1, B: 2}", "", "*struct main.astruct", nil},
+		{"errnil == nil", false, "false", "false", "", nil},
+		{"nil == errnil", false, "false", "false", "", nil},
+		{"err1.(*main.astruct)", false, "*struct main.astruct {A: 1, B: 2}", "(*struct main.astruct)(0x…", "*struct main.astruct", nil},
 		{"err1.(*main.bstruct)", false, "", "", "", fmt.Errorf("interface conversion: error is *struct main.astruct, not *struct main.bstruct")},
 		{"errnil.(*main.astruct)", false, "", "", "", fmt.Errorf("interface conversion: error is nil, not *main.astruct")},
-		{"const1", true, "go/constant.Value(*go/constant.int64Val) *3", "", "go/constant.Value", nil},
+		{"const1", true, "go/constant.Value(*go/constant.int64Val) *3", "go/constant.Value(*go/constant.int64Val) 0x…", "go/constant.Value", nil},
 
 		// combined expressions
-		{"c1.pb.a.A", true, "1", "", "int", nil},
-		{"c1.sa[1].B", false, "3", "", "int", nil},
-		{"s2[5].B", false, "12", "", "int", nil},
-		{"s2[c1.sa[2].B].A", false, "11", "", "int", nil},
-		{"s2[*p2].B", false, "12", "", "int", nil},
+		{"c1.pb.a.A", true, "1", "1", "int", nil},
+		{"c1.sa[1].B", false, "3", "3", "int", nil},
+		{"s2[5].B", false, "12", "12", "int", nil},
+		{"s2[c1.sa[2].B].A", false, "11", "11", "int", nil},
+		{"s2[*p2].B", false, "12", "12", "int", nil},
 
 		// constants
-		{"1.1", false, "1.1", "", "", nil},
-		{"10", false, "10", "", "", nil},
-		{"1 + 2i", false, "(1 + 2i)", "", "", nil},
-		{"true", false, "true", "", "", nil},
-		{"\"test\"", false, "\"test\"", "", "", nil},
+		{"1.1", false, "1.1", "1.1", "", nil},
+		{"10", false, "10", "10", "", nil},
+		{"1 + 2i", false, "(1 + 2i)", "(1 + 2i)", "", nil},
+		{"true", false, "true", "true", "", nil},
+		{"\"test\"", false, "\"test\"", "\"test\"", "", nil},
 
 		// binary operators
-		{"i2 + i3", false, "5", "", "int", nil},
-		{"i2 - i3", false, "-1", "", "int", nil},
-		{"i3 - i2", false, "1", "", "int", nil},
-		{"i2 * i3", false, "6", "", "int", nil},
-		{"i2/i3", false, "0", "", "int", nil},
-		{"f1/2.0", false, "1.5", "", "float64", nil},
-		{"i2 << 2", false, "8", "", "int", nil},
+		{"i2 + i3", false, "5", "5", "int", nil},
+		{"i2 - i3", false, "-1", "-1", "int", nil},
+		{"i3 - i2", false, "1", "1", "int", nil},
+		{"i2 * i3", false, "6", "6", "int", nil},
+		{"i2/i3", false, "0", "0", "int", nil},
+		{"f1/2.0", false, "1.5", "1.5", "float64", nil},
+		{"i2 << 2", false, "8", "8", "int", nil},
 
 		// unary operators
-		{"-i2", false, "-2", "", "int", nil},
-		{"+i2", false, "2", "", "int", nil},
-		{"^i2", false, "-3", "", "int", nil},
+		{"-i2", false, "-2", "-2", "int", nil},
+		{"+i2", false, "2", "2", "int", nil},
+		{"^i2", false, "-3", "-3", "int", nil},
 
 		// comparison operators
-		{"i2 == i3", false, "false", "", "", nil},
-		{"i2 == 2", false, "true", "", "", nil},
-		{"i2 == 2", false, "true", "", "", nil},
-		{"i2 == 3", false, "false", "", "", nil},
-		{"i2 != i3", false, "true", "", "", nil},
-		{"i2 < i3", false, "true", "", "", nil},
-		{"i2 <= i3", false, "true", "", "", nil},
-		{"i2 > i3", false, "false", "", "", nil},
-		{"i2 >= i3", false, "false", "", "", nil},
-		{"i2 >= 2", false, "true", "", "", nil},
-		{"str1 == \"01234567890\"", false, "true", "", "", nil},
-		{"str1 < \"01234567890\"", false, "false", "", "", nil},
-		{"str1 < \"11234567890\"", false, "true", "", "", nil},
-		{"str1 > \"00234567890\"", false, "true", "", "", nil},
-		{"str1 == str1", false, "true", "", "", nil},
-		{"c1.pb.a == *(c1.sa[0])", false, "true", "", "", nil},
-		{"c1.pb.a != *(c1.sa[0])", false, "false", "", "", nil},
-		{"c1.pb.a == *(c1.sa[1])", false, "false", "", "", nil},
-		{"c1.pb.a != *(c1.sa[1])", false, "true", "", "", nil},
+		{"i2 == i3", false, "false", "false", "", nil},
+		{"i2 == 2", false, "true", "true", "", nil},
+		{"i2 == 2", false, "true", "true", "", nil},
+		{"i2 == 3", false, "false", "false", "", nil},
+		{"i2 != i3", false, "true", "true", "", nil},
+		{"i2 < i3", false, "true", "true", "", nil},
+		{"i2 <= i3", false, "true", "true", "", nil},
+		{"i2 > i3", false, "false", "false", "", nil},
+		{"i2 >= i3", false, "false", "false", "", nil},
+		{"i2 >= 2", false, "true", "true", "", nil},
+		{"str1 == \"01234567890\"", false, "true", "true", "", nil},
+		{"str1 < \"01234567890\"", false, "false", "false", "", nil},
+		{"str1 < \"11234567890\"", false, "true", "true", "", nil},
+		{"str1 > \"00234567890\"", false, "true", "true", "", nil},
+		{"str1 == str1", false, "true", "true", "", nil},
+		{"c1.pb.a == *(c1.sa[0])", false, "true", "true", "", nil},
+		{"c1.pb.a != *(c1.sa[0])", false, "false", "false", "", nil},
+		{"c1.pb.a == *(c1.sa[1])", false, "false", "false", "", nil},
+		{"c1.pb.a != *(c1.sa[1])", false, "true", "true", "", nil},
 
 		// builtins
-		{"cap(parr)", false, "4", "", "", nil},
-		{"len(parr)", false, "4", "", "", nil},
+		{"cap(parr)", false, "4", "4", "", nil},
+		{"len(parr)", false, "4", "4", "", nil},
 		{"cap(p1)", false, "", "", "", fmt.Errorf("invalid argument p1 (type *int) for cap")},
 		{"len(p1)", false, "", "", "", fmt.Errorf("invalid argument p1 (type *int) for len")},
-		{"cap(a1)", false, "5", "", "", nil},
-		{"len(a1)", false, "5", "", "", nil},
-		{"cap(s3)", false, "6", "", "", nil},
-		{"len(s3)", false, "0", "", "", nil},
-		{"cap(nilslice)", false, "0", "", "", nil},
-		{"len(nilslice)", false, "0", "", "", nil},
-		{"cap(ch1)", false, "2", "", "", nil},
-		{"len(ch1)", false, "0", "", "", nil},
-		{"cap(chnil)", false, "0", "", "", nil},
-		{"len(chnil)", false, "0", "", "", nil},
-		{"len(m1)", false, "41", "", "", nil},
-		{"len(mnil)", false, "0", "", "", nil},
-		{"imag(cpx1)", false, "2", "", "", nil},
-		{"real(cpx1)", false, "1", "", "", nil},
-		{"imag(3i)", false, "3", "", "", nil},
-		{"real(4)", false, "4", "", "", nil},
+		{"cap(a1)", false, "5", "5", "", nil},
+		{"len(a1)", false, "5", "5", "", nil},
+		{"cap(s3)", false, "6", "6", "", nil},
+		{"len(s3)", false, "0", "0", "", nil},
+		{"cap(nilslice)", false, "0", "0", "", nil},
+		{"len(nilslice)", false, "0", "0", "", nil},
+		{"cap(ch1)", false, "2", "2", "", nil},
+		{"len(ch1)", false, "0", "0", "", nil},
+		{"cap(chnil)", false, "0", "0", "", nil},
+		{"len(chnil)", false, "0", "0", "", nil},
+		{"len(m1)", false, "41", "41", "", nil},
+		{"len(mnil)", false, "0", "0", "", nil},
+		{"imag(cpx1)", false, "2", "2", "", nil},
+		{"real(cpx1)", false, "1", "1", "", nil},
+		{"imag(3i)", false, "3", "3", "", nil},
+		{"real(4)", false, "4", "4", "", nil},
 
 		// nil
-		{"nil", false, "nil", "", "", nil},
+		{"nil", false, "nil", "nil", "", nil},
 		{"nil+1", false, "", "", "", fmt.Errorf("operator + can not be applied to \"nil\"")},
-		{"fn1", false, "main.afunc", "", "main.functype", nil},
-		{"fn2", false, "nil", "", "main.functype", nil},
-		{"nilslice", false, "[]int len: 0, cap: 0, []", "", "[]int", nil},
+		{"fn1", false, "main.afunc", "main.afunc", "main.functype", nil},
+		{"fn2", false, "nil", "nil", "main.functype", nil},
+		{"nilslice", false, "[]int len: 0, cap: 0, []", "[]int len: 0, cap: 0, []", "[]int", nil},
 		{"fn1 == fn2", false, "", "", "", fmt.Errorf("can not compare func variables")},
-		{"fn1 == nil", false, "false", "", "", nil},
-		{"fn1 != nil", false, "true", "", "", nil},
-		{"fn2 == nil", false, "true", "", "", nil},
-		{"fn2 != nil", false, "false", "", "", nil},
-		{"c1.sa == nil", false, "false", "", "", nil},
-		{"c1.sa != nil", false, "true", "", "", nil},
-		{"c1.sa[0] == nil", false, "false", "", "", nil},
-		{"c1.sa[0] != nil", false, "true", "", "", nil},
-		{"nilslice == nil", false, "true", "", "", nil},
-		{"nil == nilslice", false, "true", "", "", nil},
-		{"nilslice != nil", false, "false", "", "", nil},
-		{"nilptr == nil", false, "true", "", "", nil},
-		{"nilptr != nil", false, "false", "", "", nil},
-		{"p1 == nil", false, "false", "", "", nil},
-		{"p1 != nil", false, "true", "", "", nil},
-		{"ch1 == nil", false, "false", "", "", nil},
-		{"chnil == nil", false, "true", "", "", nil},
+		{"fn1 == nil", false, "false", "false", "", nil},
+		{"fn1 != nil", false, "true", "true", "", nil},
+		{"fn2 == nil", false, "true", "true", "", nil},
+		{"fn2 != nil", false, "false", "false", "", nil},
+		{"c1.sa == nil", false, "false", "false", "", nil},
+		{"c1.sa != nil", false, "true", "true", "", nil},
+		{"c1.sa[0] == nil", false, "false", "false", "", nil},
+		{"c1.sa[0] != nil", false, "true", "true", "", nil},
+		{"nilslice == nil", false, "true", "true", "", nil},
+		{"nil == nilslice", false, "true", "true", "", nil},
+		{"nilslice != nil", false, "false", "false", "", nil},
+		{"nilptr == nil", false, "true", "true", "", nil},
+		{"nilptr != nil", false, "false", "false", "", nil},
+		{"p1 == nil", false, "false", "false", "", nil},
+		{"p1 != nil", false, "true", "true", "", nil},
+		{"ch1 == nil", false, "false", "false", "", nil},
+		{"chnil == nil", false, "true", "true", "", nil},
 		{"ch1 == chnil", false, "", "", "", fmt.Errorf("can not compare chan variables")},
-		{"m1 == nil", false, "false", "", "", nil},
+		{"m1 == nil", false, "false", "false", "", nil},
 		{"mnil == m1", false, "", "", "", fmt.Errorf("can not compare map variables")},
-		{"mnil == nil", false, "true", "", "", nil},
+		{"mnil == nil", false, "true", "true", "", nil},
 		{"nil == 2", false, "", "", "", fmt.Errorf("can not compare int to nil")},
 		{"2 == nil", false, "", "", "", fmt.Errorf("can not compare int to nil")},
 
@@ -540,28 +608,32 @@ func TestEvalExpression(t *testing.T) {
 		{"(map[string]main.astruct)(0x4000)", false, "", "", "", fmt.Errorf("can not convert \"0x4000\" to map[string]main.astruct")},
 
 		// typecasts
-		{"uint(i2)", false, "2", "", "uint", nil},
-		{"int8(i2)", false, "2", "", "int8", nil},
-		{"int(f1)", false, "3", "", "int", nil},
-		{"complex128(f1)", false, "(3 + 0i)", "", "complex128", nil},
-		{"uint8(i4)", false, "32", "", "uint8", nil},
-		{"uint8(i5)", false, "253", "", "uint8", nil},
-		{"int8(i5)", false, "-3", "", "int8", nil},
-		{"int8(i6)", false, "12", "", "int8", nil},
+		{"uint(i2)", false, "2", "2", "uint", nil},
+		{"int8(i2)", false, "2", "2", "int8", nil},
+		{"int(f1)", false, "3", "3", "int", nil},
+		{"complex128(f1)", false, "(3 + 0i)", "(3 + 0i)", "complex128", nil},
+		{"uint8(i4)", false, "32", "32", "uint8", nil},
+		{"uint8(i5)", false, "253", "253", "uint8", nil},
+		{"int8(i5)", false, "-3", "-3", "int8", nil},
+		{"int8(i6)", false, "12", "12", "int8", nil},
 
 		// misc
-		{"i1", true, "1", "", "int", nil},
-		{"mainMenu", true, `main.Menu len: 3, cap: 3, [{Name: "home", Route: "/", Active: 1},{Name: "About", Route: "/about", Active: 1},{Name: "Login", Route: "/login", Active: 1}]`, "", "main.Menu", nil},
-		{"mainMenu[0]", false, `main.Item {Name: "home", Route: "/", Active: 1}`, "", "main.Item", nil},
+		{"i1", true, "1", "1", "int", nil},
+		{"mainMenu", true, `main.Menu len: 3, cap: 3, [{Name: "home", Route: "/", Active: 1},{Name: "About", Route: "/about", Active: 1},{Name: "Login", Route: "/login", Active: 1}]`, `main.Menu len: 3, cap: 3, [...]`, "main.Menu", nil},
+		{"mainMenu[0]", false, `main.Item {Name: "home", Route: "/", Active: 1}`, `main.Item {Name: "home", Route: "/", Active: 1}`, "main.Item", nil},
+		{"sd", false, "main.D {u1: 0, u2: 0, u3: 0, u4: 0, u5: 0, u6: 0}", "main.D {u1: 0, u2: 0, u3: 0,...+3 more}", "main.D", nil},
 	}
 
 	withTestProcess("testvariables2", t, func(p *proc.Process, fixture protest.Fixture) {
 		assertNoError(p.Continue(), t, "Continue() returned an error")
 		for _, tc := range testcases {
-			variable, err := evalVariable(p, tc.name)
+			variable, err := evalVariable(p, tc.name, pnormalLoadConfig)
 			if tc.err == nil {
 				assertNoError(err, t, fmt.Sprintf("EvalExpression(%s) returned an error", tc.name))
 				assertVariable(t, variable, tc)
+				variable, err := evalVariable(p, tc.name, pshortLoadConfig)
+				assertNoError(err, t, fmt.Sprintf("EvalExpression(%s, pshortLoadConfig) returned an error", tc.name))
+				assertVariable(t, variable, tc.alternateVarTest())
 			} else {
 				if err == nil {
 					t.Fatalf("Expected error %s, got no error (%s)", tc.err.Error(), tc.name)
@@ -570,6 +642,7 @@ func TestEvalExpression(t *testing.T) {
 					t.Fatalf("Unexpected error. Expected %s got %s", tc.err.Error(), err.Error())
 				}
 			}
+
 		}
 	})
 }
@@ -577,7 +650,7 @@ func TestEvalExpression(t *testing.T) {
 func TestEvalAddrAndCast(t *testing.T) {
 	withTestProcess("testvariables2", t, func(p *proc.Process, fixture protest.Fixture) {
 		assertNoError(p.Continue(), t, "Continue() returned an error")
-		c1addr, err := evalVariable(p, "&c1")
+		c1addr, err := evalVariable(p, "&c1", pnormalLoadConfig)
 		assertNoError(err, t, "EvalExpression(&c1)")
 		c1addrstr := api.ConvertVar(c1addr).SinglelineString()
 		t.Logf("&c1 → %s", c1addrstr)
@@ -585,7 +658,7 @@ func TestEvalAddrAndCast(t *testing.T) {
 			t.Fatalf("Invalid value of EvalExpression(&c1) \"%s\"", c1addrstr)
 		}
 
-		aaddr, err := evalVariable(p, "&(c1.pb.a)")
+		aaddr, err := evalVariable(p, "&(c1.pb.a)", pnormalLoadConfig)
 		assertNoError(err, t, "EvalExpression(&(c1.pb.a))")
 		aaddrstr := api.ConvertVar(aaddr).SinglelineString()
 		t.Logf("&(c1.pb.a) → %s", aaddrstr)
@@ -593,7 +666,7 @@ func TestEvalAddrAndCast(t *testing.T) {
 			t.Fatalf("invalid value of EvalExpression(&(c1.pb.a)) \"%s\"", aaddrstr)
 		}
 
-		a, err := evalVariable(p, "*"+aaddrstr)
+		a, err := evalVariable(p, "*"+aaddrstr, pnormalLoadConfig)
 		assertNoError(err, t, fmt.Sprintf("EvalExpression(*%s)", aaddrstr))
 		t.Logf("*%s → %s", aaddrstr, api.ConvertVar(a).SinglelineString())
 		assertVariable(t, a, varTest{aaddrstr, false, "struct main.astruct {A: 1, B: 2}", "", "struct main.astruct", nil})
@@ -603,7 +676,7 @@ func TestEvalAddrAndCast(t *testing.T) {
 func TestMapEvaluation(t *testing.T) {
 	withTestProcess("testvariables2", t, func(p *proc.Process, fixture protest.Fixture) {
 		assertNoError(p.Continue(), t, "Continue() returned an error")
-		m1v, err := evalVariable(p, "m1")
+		m1v, err := evalVariable(p, "m1", pnormalLoadConfig)
 		assertNoError(err, t, "EvalVariable()")
 		m1 := api.ConvertVar(m1v)
 		t.Logf("m1 = %v", m1.MultilineString(""))
@@ -626,7 +699,7 @@ func TestMapEvaluation(t *testing.T) {
 			t.Fatalf("Could not find Malone")
 		}
 
-		m1sliced, err := evalVariable(p, "m1[10:]")
+		m1sliced, err := evalVariable(p, "m1[10:]", pnormalLoadConfig)
 		assertNoError(err, t, "EvalVariable(m1[10:])")
 		if len(m1sliced.Children)/2 != int(m1.Len-10) {
 			t.Fatalf("Wrong number of children (after slicing): %d", len(m1sliced.Children)/2)
@@ -637,7 +710,7 @@ func TestMapEvaluation(t *testing.T) {
 func TestUnsafePointer(t *testing.T) {
 	withTestProcess("testvariables2", t, func(p *proc.Process, fixture protest.Fixture) {
 		assertNoError(p.Continue(), t, "Continue() returned an error")
-		up1v, err := evalVariable(p, "up1")
+		up1v, err := evalVariable(p, "up1", pnormalLoadConfig)
 		assertNoError(err, t, "EvalVariable(up1)")
 		up1 := api.ConvertVar(up1v)
 		if ss := up1.SinglelineString(); !strings.HasPrefix(ss, "unsafe.Pointer(") {

--- a/service/test/variables_test.go
+++ b/service/test/variables_test.go
@@ -536,7 +536,7 @@ func TestEvalExpression(t *testing.T) {
 		{"&nil", false, "", "", "", fmt.Errorf("can not take address of \"nil\"")},
 		{"nil[0]", false, "", "", "", fmt.Errorf("expression \"nil\" (nil) does not support indexing")},
 		{"nil[2:10]", false, "", "", "", fmt.Errorf("can not slice \"nil\" (type nil)")},
-		{"nil.member", false, "", "", "", fmt.Errorf("type nil is not a struct")},
+		{"nil.member", false, "", "", "", fmt.Errorf("nil (type nil) is not a struct")},
 		{"(map[string]main.astruct)(0x4000)", false, "", "", "", fmt.Errorf("can not convert \"0x4000\" to map[string]main.astruct")},
 
 		// typecasts

--- a/terminal/command_test.go
+++ b/terminal/command_test.go
@@ -357,3 +357,44 @@ func TestNoVars(t *testing.T) {
 		term.AssertExec("vars filterThatMatchesNothing", "(no vars)\n")
 	})
 }
+
+func TestOnPrefixLocals(t *testing.T) {
+	const prefix = "\ti: "
+	withTestTerminal("goroutinestackprog", t, func(term *FakeTerminal) {
+		term.MustExec("b agobp main.agoroutine")
+		term.MustExec("on agobp args -v")
+
+		seen := make([]bool, 10)
+
+		for {
+			outstr, err := term.Exec("continue")
+			if err != nil {
+				if strings.Index(err.Error(), "exited") < 0 {
+					t.Fatalf("Unexpected error executing 'continue': %v", err)
+				}
+				break
+			}
+			out := strings.Split(outstr, "\n")
+
+			for i := range out {
+				if !strings.HasPrefix(out[i], "\ti: ") {
+					continue
+				}
+				id, err := strconv.Atoi(out[i][len(prefix):])
+				if err != nil {
+					continue
+				}
+				if seen[id] {
+					t.Fatalf("Goroutine %d seen twice\n", id)
+				}
+				seen[id] = true
+			}
+		}
+
+		for i := range seen {
+			if !seen[i] {
+				t.Fatalf("Goroutine %d not seen\n", i)
+			}
+		}
+	})
+}


### PR DESCRIPTION
Most of these changes were proposed on the mailing list.

[dlv output before the changes](https://gist.githubusercontent.com/aarzilli/8a78798bb359d2aa5c08/raw/b88f679252b91437615526bd6d50f832c35fbe92/before)
[dlv output after the changes](https://gist.githubusercontent.com/aarzilli/3503eff5b25952befff9/raw/5c5296c0a02263f8973d20b5da1447bcaf100b57/after)

Commit messages for the changeset:

service/api: Removed unused fields of service/api.Function
proc/eval: Set return variable name to input expression
all: fine-grained control of loadValue for better variable printing
Makes proc.(*Variable).loadValue loading parameters configurable
through one extra argument of type LoadConfig.
This interface is also exposed through the API so clients can control
how much of a variable delve should read.

BREAKS API COMPATIBILITY:

- CreateBreakpoint, AmendBreakpoint
    Breakpoint struct has two new members LoadLocals and LoadArgs that
    control if and how delve should load local variables and arguments
    when the breakpoint is hit
- State objects for breakpoints no longer automatically fill
    BreakpointInfo.Arguments
- Stacktrace (second argument is a LoadConfig not a boolean)
    Second argument is a *LoadConfig not a boolean. Pass nil to not
    load local variables and arguments.
- ListPackageVars, ListLocalVars, ListFunctionArgs, EvalSymbol
    All gain one extra LoadConfig argument.
