### PR TITLE
proc: Caching type offsets

### DIFF
--- a/proc/proc_test.go
+++ b/proc/proc_test.go
@@ -1626,7 +1626,7 @@ func TestPackageVariables(t *testing.T) {
 
 func TestIssue149(t *testing.T) {
 	ver, _ := ParseVersionString(runtime.Version())
-	if ver.Major	> 0 && !ver.AfterOrEqual(GoVersion{1, 7, 0, 0, 0}) {
+	if ver.Major > 0 && !ver.AfterOrEqual(GoVersion{1, 7, 0, 0, 0}) {
 		return
 	}
 	// setting breakpoint on break statement


### PR DESCRIPTION
Caches the mapping of type names to offset in `debug_info` to speed up
variable evaluation.

```
BEFORE:
	BenchmarkArray-4         	     100	  13'238'441 ns/op	   0.62 MB/s
	BenchmarkArrayPointer-4  	     200	  10'044'093 ns/op	   0.87 MB/s
	BenchmarkMap-4           	    1000	   1'332'530 ns/op	   0.77 MB/s
	BenchmarkGoroutinesInfo-4	      10	 114'677'462 ns/op
	BenchmarkLocalVariables-4	    2000	   1'223'975 ns/op
AFTER:
	BenchmarkArray-4         	     200	   9'925'686 ns/op	   0.83 MB/s
	BenchmarkArrayPointer-4  	     100	  11'143'930 ns/op	   0.78 MB/s
	BenchmarkMap-4           	    2000	   1'302'520 ns/op	   0.79 MB/s
	BenchmarkGoroutinesInfo-4	      30	  35'079'549 ns/op
	BenchmarkLocalVariables-4	    1000	   1'137'299 ns/op
```

Note in particular the speedup of `BenchmarkGoroutinesInfo`, since
`proc.(*Variable).parseG` is a function we call a lot.