### PR TITLE
proc: Breakpoint to catch unrecovered panics

### DIFF
--- a/_fixtures/panic.go
+++ b/_fixtures/panic.go
@@ -1,0 +1,5 @@
+package main
+
+func main() {
+	panic("BOOM!")
+}

--- a/proc/proc.go
+++ b/proc/proc.go
@@ -741,6 +741,16 @@ func initializeDebugProcess(dbp *Process, path string, attach bool) (*Process, e
 	// the offset of g struct inside TLS
 	dbp.SelectedGoroutine, _ = dbp.CurrentThread.GetG()
 
+	panicpc, err := dbp.FindFunctionLocation("runtime.startpanic", true, 0)
+	if err == nil {
+		bp, err := dbp.SetBreakpoint(panicpc)
+		if err == nil {
+			bp.Name = "unrecovered-panic"
+			bp.ID = -1
+			dbp.breakpointIDCounter--
+		}
+	}
+
 	return dbp, nil
 }
 

--- a/service/debugger/debugger.go
+++ b/service/debugger/debugger.go
@@ -114,6 +114,9 @@ func (d *Debugger) Restart() error {
 		return fmt.Errorf("could not launch process: %s", err)
 	}
 	for _, oldBp := range d.breakpoints() {
+		if oldBp.ID < 0 {
+			continue
+		}
 		newBp, err := p.SetBreakpoint(oldBp.Addr)
 		if err != nil {
 			return err

--- a/service/test/integration_test.go
+++ b/service/test/integration_test.go
@@ -358,6 +358,18 @@ func TestClientServer_breakAtNonexistentPoint(t *testing.T) {
 	})
 }
 
+func countBreakpoints(t *testing.T, c service.Client) int {
+	bps, err := c.ListBreakpoints()
+	assertNoError(err, t, "ListBreakpoints()")
+	bpcount := 0
+	for _, bp := range bps {
+		if bp.ID >= 0 {
+			bpcount++
+		}
+	}
+	return bpcount
+}
+
 func TestClientServer_clearBreakpoint(t *testing.T) {
 	withTestClient("testprog", t, func(c service.Client) {
 		bp, err := c.CreateBreakpoint(&api.Breakpoint{FunctionName: "main.sleepytime", Line: 1})
@@ -365,8 +377,7 @@ func TestClientServer_clearBreakpoint(t *testing.T) {
 			t.Fatalf("Unexpected error: %v", err)
 		}
 
-		bps, err := c.ListBreakpoints()
-		if e, a := 1, len(bps); e != a {
+		if e, a := 1, countBreakpoints(t, c); e != a {
 			t.Fatalf("Expected breakpoint count %d, got %d", e, a)
 		}
 
@@ -379,8 +390,7 @@ func TestClientServer_clearBreakpoint(t *testing.T) {
 			t.Fatalf("Expected deleted breakpoint ID %v, got %v", bp.ID, deleted.ID)
 		}
 
-		bps, err = c.ListBreakpoints()
-		if e, a := 0, len(bps); e != a {
+		if e, a := 0, countBreakpoints(t, c); e != a {
 			t.Fatalf("Expected breakpoint count %d, got %d", e, a)
 		}
 	})

--- a/terminal/command.go
+++ b/terminal/command.go
@@ -515,6 +515,10 @@ func clearAll(t *Term, ctx callContext, args string) error {
 			}
 		}
 
+		if bp.ID < 0 {
+			continue
+		}
+
 		_, err := t.client.ClearBreakpoint(bp.ID)
 		if err != nil {
 			fmt.Printf("Couldn't delete %s at %s: %s\n", formatBreakpointName(bp, false), formatBreakpointLocation(bp), err)


### PR DESCRIPTION
Automatically sets a breakpoint on runtime.startpanic, the function
that gets called by runtime.dopanic when a panic is not recovered.

Implements #317