### PR TITLE
terminal: do not use escape codes on windows unless they are supported

### DIFF
--- a/terminal/terminal.go
+++ b/terminal/terminal.go
@@ -42,7 +42,7 @@ func New(client service.Client, conf *config.Config) *Term {
 		line:   liner.NewLiner(),
 		client: client,
 		cmds:   cmds,
-		dumb:   strings.ToLower(os.Getenv("TERM")) == "dumb",
+		dumb:   !supportsEscapeCodes(),
 	}
 }
 

--- a/terminal/terminal_other.go
+++ b/terminal/terminal_other.go
@@ -1,0 +1,13 @@
+// +build !windows
+
+package terminal
+
+import (
+	"os"
+	"strings"
+)
+
+// supportsEscapeCodes returns true if console handles escape codes.
+func supportsEscapeCodes() bool {
+	return strings.ToLower(os.Getenv("TERM")) != "dumb"
+}

--- a/terminal/terminal_windows.go
+++ b/terminal/terminal_windows.go
@@ -1,0 +1,31 @@
+package terminal
+
+import (
+	"os"
+	"strings"
+	"syscall"
+)
+
+// supportsEscapeCodes returns true if console handles escape codes.
+func supportsEscapeCodes() bool {
+	if strings.ToLower(os.Getenv("TERM")) == "dumb" {
+		return false
+	}
+	if strings.ToLower(os.Getenv("ConEmuANSI")) == "on" {
+		// The ConEmu terminal is installed. Use it.
+		return true
+	}
+
+	const ENABLE_VIRTUAL_TERMINAL_PROCESSING = 0x0004
+
+	h, err := syscall.GetStdHandle(syscall.STD_OUTPUT_HANDLE)
+	if err != nil {
+		return false
+	}
+	var m uint32
+	err = syscall.GetConsoleMode(h, &m)
+	if err != nil {
+		return false
+	}
+	return m&ENABLE_VIRTUAL_TERMINAL_PROCESSING != 0
+}


### PR DESCRIPTION
Fixes #436

@lukehoban for your review. Thank you.