### PR TITLE
proc: bugfix: Truncate stacktrace when FDE of a frame can not be found

### DIFF
--- a/dwarf/frame/entries.go
+++ b/dwarf/frame/entries.go
@@ -65,6 +65,14 @@ func NewFrameIndex() FrameDescriptionEntries {
 	return make(FrameDescriptionEntries, 0, 1000)
 }
 
+type NoFDEForPCError struct {
+	PC uint64
+}
+
+func (err *NoFDEForPCError) Error() string {
+	return fmt.Sprintf("could not find FDE for PC %#v", err.PC)
+}
+
 // Returns the Frame Description Entry for the given PC.
 func (fdes FrameDescriptionEntries) FDEForPC(pc uint64) (*FrameDescriptionEntry, error) {
 	idx := sort.Search(len(fdes), func(i int) bool {
@@ -77,7 +85,7 @@ func (fdes FrameDescriptionEntries) FDEForPC(pc uint64) (*FrameDescriptionEntry,
 		return true
 	})
 	if idx == len(fdes) {
-		return nil, fmt.Errorf("could not find FDE for PC %#v", pc)
+		return nil, &NoFDEForPCError{pc}
 	}
 	return fdes[idx], nil
 }

--- a/proc/proc.go
+++ b/proc/proc.go
@@ -876,7 +876,7 @@ func (dbp *Process) ConvertEvalScope(gid, frame int) (*EvalScope, error) {
 		out.Thread = g.thread
 	}
 
-	locs, err := dbp.GoroutineStacktrace(g, frame)
+	locs, err := g.Stacktrace(frame)
 	if err != nil {
 		return nil, err
 	}

--- a/proc/proc_test.go
+++ b/proc/proc_test.go
@@ -758,7 +758,7 @@ func TestStacktraceGoroutine(t *testing.T) {
 		mainCount := 0
 
 		for i, g := range gs {
-			locations, err := p.GoroutineStacktrace(g, 40)
+			locations, err := g.Stacktrace(40)
 			assertNoError(err, t, "GoroutineStacktrace()")
 
 			if stackMatch(mainStack, locations, false) {
@@ -1053,7 +1053,7 @@ func TestFrameEvaluation(t *testing.T) {
 		found := make([]bool, 10)
 		for _, g := range gs {
 			frame := -1
-			frames, err := p.GoroutineStacktrace(g, 10)
+			frames, err := g.Stacktrace(10)
 			assertNoError(err, t, "GoroutineStacktrace()")
 			for i := range frames {
 				if frames[i].Call.Fn != nil && frames[i].Call.Fn.Name == "main.agoroutine" {

--- a/proc/stack.go
+++ b/proc/stack.go
@@ -4,6 +4,7 @@ import (
 	"encoding/binary"
 	"errors"
 	"fmt"
+	"github.com/derekparker/delve/dwarf/frame"
 )
 
 // NoReturnAddr is returned when return address
@@ -101,6 +102,12 @@ func (it *StackIterator) Next() bool {
 	}
 	it.frame, it.err = it.dbp.frameInfo(it.pc, it.sp, it.top)
 	if it.err != nil {
+		if _, nofde := it.err.(*frame.NoFDEForPCError); nofde && !it.top {
+			it.frame = Stackframe{ Current: Location{ PC: it.pc, File: "?", Line: -1  }, Call: Location{ PC: it.pc, File: "?", Line: -1 }, CFA: 0, Ret: 0 }
+			it.atend = true
+			it.err = nil
+			return true
+		}
 		return false
 	}
 

--- a/proc/stack.go
+++ b/proc/stack.go
@@ -127,6 +127,9 @@ func (it *stackIterator) Next() bool {
 	}
 
 	if it.frame.Current.Fn == nil {
+		if it.top {
+			it.err = fmt.Errorf("PC not associated to any function")
+		}
 		return false
 	}
 

--- a/proc/stack.go
+++ b/proc/stack.go
@@ -135,7 +135,7 @@ func (it *stackIterator) Next() bool {
 		return true
 	}
 	// Look for "top of stack" functions.
-	if it.frame.Current.Fn.Name == "runtime.goexit" || it.frame.Current.Fn.Name == "runtime.rt0_go" {
+	if it.frame.Current.Fn.Name == "runtime.goexit" || it.frame.Current.Fn.Name == "runtime.rt0_go" || it.frame.Current.Fn.Name == "runtime.mcall" {
 		it.atend = true
 		return true
 	}

--- a/proc/threads.go
+++ b/proc/threads.go
@@ -3,6 +3,7 @@ package proc
 import (
 	"debug/gosym"
 	"encoding/binary"
+	"errors"
 	"fmt"
 	"path/filepath"
 	"reflect"
@@ -352,6 +353,9 @@ func (thread *Thread) Scope() (*EvalScope, error) {
 	locations, err := thread.Stacktrace(0)
 	if err != nil {
 		return nil, err
+	}
+	if len(locations) < 1 {
+		return nil, errors.New("could not decode first frame")
 	}
 	return locations[0].Scope(thread), nil
 }

--- a/proc/variables.go
+++ b/proc/variables.go
@@ -429,9 +429,11 @@ func (g *G) UserCurrent() Location {
 	it := newStackIterator(g.dbp, pc, sp)
 	for it.Next() {
 		frame := it.Frame()
-		name := frame.Call.Fn.Name
-		if (strings.Index(name, ".") >= 0) && (!strings.HasPrefix(name, "runtime.") || isExportedRuntime(name)) {
-			return frame.Call
+		if frame.Call.Fn != nil {
+			name := frame.Call.Fn.Name
+			if (strings.Index(name, ".") >= 0) && (!strings.HasPrefix(name, "runtime.") || isExportedRuntime(name)) {
+				return frame.Call
+			}
 		}
 	}
 	return g.CurrentLoc

--- a/proc/variables.go
+++ b/proc/variables.go
@@ -317,7 +317,7 @@ func (g *G) ChanRecvBlocked() bool {
 
 // chanRecvReturnAddr returns the address of the return from a channel read.
 func (g *G) chanRecvReturnAddr(dbp *Process) (uint64, error) {
-	locs, err := dbp.GoroutineStacktrace(g, 4)
+	locs, err := g.Stacktrace(4)
 	if err != nil {
 		return 0, err
 	}
@@ -418,15 +418,10 @@ func isExportedRuntime(name string) bool {
 // UserCurrent returns the location the users code is at,
 // or was at before entering a runtime function.
 func (g *G) UserCurrent() Location {
-	pc, sp := g.PC, g.SP
-	if g.thread != nil {
-		regs, err := g.thread.Registers()
-		if err != nil {
-			return g.CurrentLoc
-		}
-		pc, sp = regs.PC(), regs.SP()
+	it, err := g.stackIterator()
+	if err != nil {
+		return g.CurrentLoc
 	}
-	it := newStackIterator(g.dbp, pc, sp)
 	for it.Next() {
 		frame := it.Frame()
 		if frame.Call.Fn != nil {

--- a/service/debugger/debugger.go
+++ b/service/debugger/debugger.go
@@ -691,7 +691,7 @@ func (d *Debugger) Stacktrace(goroutineID, depth int, full bool) ([]api.Stackfra
 	if g == nil {
 		rawlocs, err = d.process.CurrentThread.Stacktrace(depth)
 	} else {
-		rawlocs, err = d.process.GoroutineStacktrace(g, depth)
+		rawlocs, err = g.Stacktrace(depth)
 	}
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
Instead of returning an error when FDE of a frame can not be found,
just truncate the stack trace.

Fixes #462

I also did a bit of refactoring of the stacktrace code:

- made GoroutineStacktrace a method of struct G
- made stacktrace a method of StackIterator
- renamed StackIterator to stackIterator
- factored out logic to obtain a stackIterator from a goroutine that's
used by both (*G).Stacktrace and by (*G).UserCurrent


