### PR TITLE
service: Make Halt work during tracing

### DIFF
--- a/service/rpc1/client.go
+++ b/service/rpc1/client.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/derekparker/delve/service"
 	"github.com/derekparker/delve/service/api"
+	"sync"
 )
 
 // Client is a RPC service.Client.
@@ -15,6 +16,8 @@ type RPCClient struct {
 	addr       string
 	processPid int
 	client     *rpc.Client
+	haltMu     sync.Mutex
+	haltReq    bool
 }
 
 // Ensure the implementation satisfies the interface.
@@ -54,8 +57,18 @@ func (c *RPCClient) GetState() (*api.DebuggerState, error) {
 
 func (c *RPCClient) Continue() <-chan *api.DebuggerState {
 	ch := make(chan *api.DebuggerState)
+	c.haltMu.Lock()
+	c.haltReq = false
+	c.haltMu.Unlock()
 	go func() {
 		for {
+			c.haltMu.Lock()
+			if c.haltReq {
+				c.haltMu.Unlock()
+				close(ch)
+				return
+			}
+			c.haltMu.Unlock()
 			state := new(api.DebuggerState)
 			err := c.call("Command", &api.DebuggerCommand{Name: api.Continue}, state)
 			if err != nil {
@@ -129,6 +142,9 @@ func (c *RPCClient) SwitchGoroutine(goroutineID int) (*api.DebuggerState, error)
 
 func (c *RPCClient) Halt() (*api.DebuggerState, error) {
 	state := new(api.DebuggerState)
+	c.haltMu.Lock()
+	c.haltReq = true
+	c.haltMu.Unlock()
 	err := c.call("Command", &api.DebuggerCommand{Name: api.Halt}, state)
 	return state, err
 }

--- a/terminal/command.go
+++ b/terminal/command.go
@@ -434,12 +434,14 @@ func restart(t *Term, ctx callContext, args string) error {
 
 func cont(t *Term, ctx callContext, args string) error {
 	stateChan := t.client.Continue()
-	for state := range stateChan {
+	var state *api.DebuggerState
+	for state = range stateChan {
 		if state.Err != nil {
 			return state.Err
 		}
 		printcontext(t, state)
 	}
+	printfile(t, state.CurrentThread.File, state.CurrentThread.Line, true)
 	return nil
 }
 
@@ -449,6 +451,7 @@ func step(t *Term, ctx callContext, args string) error {
 		return err
 	}
 	printcontext(t, state)
+	printfile(t, state.CurrentThread.File, state.CurrentThread.Line, true)
 	return nil
 }
 
@@ -458,6 +461,7 @@ func stepInstruction(t *Term, ctx callContext, args string) error {
 		return err
 	}
 	printcontext(t, state)
+	printfile(t, state.CurrentThread.File, state.CurrentThread.Line, true)
 	return nil
 }
 
@@ -467,6 +471,7 @@ func next(t *Term, ctx callContext, args string) error {
 		return err
 	}
 	printcontext(t, state)
+	printfile(t, state.CurrentThread.File, state.CurrentThread.Line, true)
 	return nil
 }
 
@@ -789,6 +794,7 @@ func listCommand(t *Term, ctx callContext, args string) error {
 			return err
 		}
 		printcontext(t, state)
+		printfile(t, state.CurrentThread.File, state.CurrentThread.Line, true)
 		return nil
 	}
 
@@ -926,9 +932,6 @@ func printcontext(t *Term, state *api.DebuggerState) error {
 
 	printcontextThread(t, state.CurrentThread)
 
-	if state.CurrentThread.Breakpoint == nil || !state.CurrentThread.Breakpoint.Tracepoint || state.CurrentThread.BreakpointInfo == nil {
-		return printfile(t, state.CurrentThread.File, state.CurrentThread.Line, true)
-	}
 	return nil
 }
 


### PR DESCRIPTION
While tracing delve may spend most of its time outside of
proc.(*Process).Continue, which renders
service/rpc/client.(*Client).Halt ineffective.
This commit changes the implementation of
service/rpc/client.(*Client).Halt to make it capable of stopping traces.