### PR TITLE
terminal: show message if there are no vars/locals/args

### DIFF
--- a/terminal/command.go
+++ b/terminal/command.go
@@ -682,7 +682,7 @@ func args(t *Term, ctx callContext, filter string) ([]string, error) {
 	if err != nil {
 		return nil, err
 	}
-	return filterVariables(vars, filter), nil
+	return describeNoVars("args", filterVariables(vars, filter)), nil
 }
 
 func locals(t *Term, ctx callContext, filter string) ([]string, error) {
@@ -690,7 +690,7 @@ func locals(t *Term, ctx callContext, filter string) ([]string, error) {
 	if err != nil {
 		return nil, err
 	}
-	return filterVariables(locals, filter), nil
+	return describeNoVars("locals", filterVariables(locals, filter)), nil
 }
 
 func vars(t *Term, ctx callContext, filter string) ([]string, error) {
@@ -698,7 +698,7 @@ func vars(t *Term, ctx callContext, filter string) ([]string, error) {
 	if err != nil {
 		return nil, err
 	}
-	return filterVariables(vars, filter), nil
+	return describeNoVars("vars", filterVariables(vars, filter)), nil
 }
 
 func regs(t *Term, ctx callContext, args string) error {
@@ -1152,4 +1152,11 @@ func formatBreakpointLocation(bp *api.Breakpoint) string {
 		return fmt.Sprintf("%#v for %s() %s:%d", bp.Addr, bp.FunctionName, p, bp.Line)
 	}
 	return fmt.Sprintf("%#v for %s:%d", bp.Addr, p, bp.Line)
+}
+
+func describeNoVars(varType string, data []string) []string {
+	if len(data) == 0 {
+		return []string{fmt.Sprintf("(no %s)", varType)}
+	}
+	return data
 }

--- a/terminal/command_test.go
+++ b/terminal/command_test.go
@@ -269,7 +269,7 @@ func TestScopePrefix(t *testing.T) {
 			if fid < 0 {
 				t.Fatalf("Could not find frame for goroutine %d: %v", gid, stackOut)
 			}
-			term.AssertExec(fmt.Sprintf("goroutine %d frame %d locals", gid, fid), "")
+			term.AssertExec(fmt.Sprintf("goroutine %d frame %d locals", gid, fid), "(no locals)\n")
 			argsOut := strings.Split(term.MustExec(fmt.Sprintf("goroutine %d frame %d args", gid, fid)), "\n")
 			if len(argsOut) != 4 || argsOut[3] != "" {
 				t.Fatalf("Wrong number of arguments in goroutine %d frame %d: %v", gid, fid, argsOut)
@@ -345,5 +345,15 @@ func TestOnPrefix(t *testing.T) {
 				t.Fatalf("Goroutine %d not seen\n", i)
 			}
 		}
+	})
+}
+
+func TestNoVars(t *testing.T) {
+	withTestTerminal("locationsUpperCase", t, func(term *FakeTerminal) {
+		term.MustExec("b main.main")
+		term.MustExec("continue")
+		term.AssertExec("args", "(no args)\n")
+		term.AssertExec("locals", "(no locals)\n")
+		term.AssertExec("vars filterThatMatchesNothing", "(no vars)\n")
 	})
 }


### PR DESCRIPTION
When I started using delve, and I ran commands to look at variables, I became uneasy when there were no variables at that breakpoint:
```
(dlv) locals
(dlv)
```
```
(dlv) args
(dlv)
```
I couldn't tell if something went wrong or there were actually no locals or args at that point. This pull request makes the `vars`, `locals`, and `args` commands print messages when there is nothing to show:

```
(dlv) locals
(no locals)
(dlv)
```
```
(dlv) args
(no args)
(dlv)
```

This is completely about user experience and doesn't add any real functionality. I didn't add tests for `args` and `vars`, because I would like to get feedback on whether or not this seems like a good idea before investing the time to do so.