### PR TITLE
Pass commandline to the Windows syscall when creating the process.

### DIFF
--- a/_fixtures/testargs.go
+++ b/_fixtures/testargs.go
@@ -1,0 +1,16 @@
+package main
+
+import (
+	"fmt"
+	"os"
+)
+
+func main() {
+	fmt.Println("Hello, args world!")
+	if os.Args[1] != "test" {
+		panic("os.args[1] is not test!")
+	}
+	if os.Args[2] != "-passFlag" {
+		panic("os.args[2] is not test!")
+	}
+}

--- a/proc/proc_test.go
+++ b/proc/proc_test.go
@@ -1689,7 +1689,7 @@ func TestCmdLineArgs(t *testing.T) {
 
 	}, []string{"test", "-passFlag"})
 	withTestProcessArgs("testargs", t, func(p *Process, fixture protest.Fixture) {
-		err := p.Continue()
+		p.Continue()
 		bp := p.CurrentBreakpoint()
 		if bp == nil || bp.Name != "unrecovered-panic" {
 			t.Fatalf("not on unrecovered-panic breakpoint: %v", p.CurrentBreakpoint)

--- a/proc/proc_test.go
+++ b/proc/proc_test.go
@@ -1689,18 +1689,14 @@ func TestCmdLineArgs(t *testing.T) {
 
 	}, []string{"test", "-passFlag"})
 	withTestProcessArgs("testargs", t, func(p *Process, fixture protest.Fixture) {
-		err = p.Continue()
+		err := p.Continue()
 		bp := p.CurrentBreakpoint()
 		if bp == nil || bp.Name != "unrecovered-panic" {
 			t.Fatalf("not on unrecovered-panic breakpoint: %v", p.CurrentBreakpoint)
 		}
-		exit, exited := err.(ProcessExitedError)
-		if !exited {
-			t.Fatalf("Process did not exit!", err)
-		} else {
-			if exit.Status != 0 {
-				t.Fatalf("process exited with invalid status", exit.Status)
-			}
+		_, exited := err.(ProcessExitedError)
+		if exited {
+			t.Fatalf("Process exited unexpectedly!", err)
 		}
 	}, []string{"txest", "-pxassFlag"})
 }

--- a/proc/proc_test.go
+++ b/proc/proc_test.go
@@ -1694,10 +1694,6 @@ func TestCmdLineArgs(t *testing.T) {
 		if bp == nil || bp.Name != "unrecovered-panic" {
 			t.Fatalf("not on unrecovered-panic breakpoint: %v", p.CurrentBreakpoint)
 		}
-		_, exited := err.(ProcessExitedError)
-		if exited {
-			t.Fatalf("Process exited unexpectedly!", err)
-		}
 	}, []string{"txest", "-pxassFlag"})
 }
 

--- a/proc/proc_test.go
+++ b/proc/proc_test.go
@@ -43,6 +43,21 @@ func withTestProcess(name string, t testing.TB, fn func(p *Process, fixture prot
 	fn(p, fixture)
 }
 
+func withTestProcessArgs(name string, t testing.TB, fn func(p *Process, fixture protest.Fixture), Args []string) {
+	fixture := protest.BuildFixture(name)
+	p, err := Launch(append([]string{fixture.Path}, Args...))
+	if err != nil {
+		t.Fatal("Launch():", err)
+	}
+
+	defer func() {
+		p.Halt()
+		p.Kill()
+	}()
+
+	fn(p, fixture)
+}
+
 func getRegisters(p *Process, t *testing.T) Registers {
 	regs, err := p.Registers()
 	if err != nil {
@@ -1654,6 +1669,40 @@ func TestPanicBreakpoint(t *testing.T) {
 			t.Fatalf("not on unrecovered-panic breakpoint: %v", p.CurrentBreakpoint)
 		}
 	})
+}
+
+func TestCmdLineArgs(t *testing.T) {
+	withTestProcessArgs("testargs", t, func(p *Process, fixture protest.Fixture) {
+		err := p.Continue()
+		bp := p.CurrentBreakpoint()
+		if bp != nil && bp.Name == "unrecovered-panic" {
+			t.Fatalf("testing args failed on unrecovered-panic breakpoint: %v", p.CurrentBreakpoint)
+		}
+		exit, exited := err.(ProcessExitedError)
+		if !exited {
+			t.Fatalf("Process did not exit!", err)
+		} else {
+			if exit.Status != 0 {
+				t.Fatalf("process exited with invalid status", exit.Status)
+			}
+		}
+
+	}, []string{"test", "-passFlag"})
+	withTestProcessArgs("testargs", t, func(p *Process, fixture protest.Fixture) {
+		err = p.Continue()
+		bp := p.CurrentBreakpoint()
+		if bp == nil || bp.Name != "unrecovered-panic" {
+			t.Fatalf("not on unrecovered-panic breakpoint: %v", p.CurrentBreakpoint)
+		}
+		exit, exited := err.(ProcessExitedError)
+		if !exited {
+			t.Fatalf("Process did not exit!", err)
+		} else {
+			if exit.Status != 0 {
+				t.Fatalf("process exited with invalid status", exit.Status)
+			}
+		}
+	}, []string{"txest", "-pxassFlag"})
 }
 
 func TestIssue462(t *testing.T) {

--- a/proc/proc_windows.go
+++ b/proc/proc_windows.go
@@ -71,7 +71,7 @@ func Launch(cmd []string) (*Process, error) {
 	si.StdOutput = sys.Handle(fd[1])
 	si.StdErr = sys.Handle(fd[2])
 	pi := new(sys.ProcessInformation)
-	cmdline, _ := syscall.UTF16PtrFromString(strings.Join(cmd, " "))
+	cmdline, _ := syscall.UTF16PtrFromString(strings.Join(append([]string{argv0Go}, cmd[1:]...), " "))
 	err = sys.CreateProcess(argv0, cmdline, nil, nil, true, DEBUGONLYTHISPROCESS, nil, nil, si, pi)
 	if err != nil {
 		return nil, err

--- a/proc/proc_windows.go
+++ b/proc/proc_windows.go
@@ -9,6 +9,7 @@ import (
 	"os/exec"
 	"path/filepath"
 	"runtime"
+	"strings"
 	"sync"
 	"syscall"
 	"unsafe"
@@ -70,7 +71,8 @@ func Launch(cmd []string) (*Process, error) {
 	si.StdOutput = sys.Handle(fd[1])
 	si.StdErr = sys.Handle(fd[2])
 	pi := new(sys.ProcessInformation)
-	err = sys.CreateProcess(argv0, nil, nil, nil, true, DEBUGONLYTHISPROCESS, nil, nil, si, pi)
+	cmdline, _ := syscall.UTF16PtrFromString(strings.Join(cmd, " "))
+	err = sys.CreateProcess(argv0, cmdline, nil, nil, true, DEBUGONLYTHISPROCESS, nil, nil, si, pi)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Currently, Delve will not pass command-line arguments while on Windows and at least with a cursory glance I saw no reference to any other given argument except the filename being handled - so, I'm not sure if it ever worked? 

Anyhow, the fix is really simple, let me know if you'd prefer some other way of handling it.

ref; [MSDN](https://msdn.microsoft.com/en-us/library/windows/desktop/ms682425(v=vs.85).aspx) on the Windows syscall in question.

Also included are some very basic sanity tests that validate that args are getting passed correctly.