### PR TITLE
terminal: helpful message in SIGINT handler

### DIFF
--- a/terminal/terminal.go
+++ b/terminal/terminal.go
@@ -72,6 +72,7 @@ func (t *Term) Run() (int, error) {
 	signal.Notify(ch, syscall.SIGINT)
 	go func() {
 		for range ch {
+			fmt.Printf("recieved SIGINT, stopping process (will not forward signal)")
 			_, err := t.client.Halt()
 			if err != nil {
 				fmt.Fprintf(os.Stderr, "%v", err)


### PR DESCRIPTION
Our handling of SIGINT is confusing to people that expect SIGINT to be
delivered to inferior when they press ^C (see #483 for example).
Let's make an effort to point out what's happening and how one can send
SIGINT to inferior.