### PR TITLE
Changed word from singular to plural form to better fit context.

### DIFF
--- a/Documentation/usage/dlv.md
+++ b/Documentation/usage/dlv.md
@@ -16,7 +16,7 @@ The goal of this tool is to provide a simple yet powerful interface for debuggin
 ### Options
 
 ```
-      --accept-multiclient[=false]: Allows a headless server to accept multiple client connection. Note that the server API is not reentrant and clients will have to coordinate
+      --accept-multiclient[=false]: Allows a headless server to accept multiple client connections. Note that the server API is not reentrant and clients will have to coordinate
       --build-flags="": Build flags, to be passed to the compiler.
       --headless[=false]: Run debug server only, in headless mode.
       --init="": Init file, executed by the terminal client.

--- a/Documentation/usage/dlv_attach.md
+++ b/Documentation/usage/dlv_attach.md
@@ -14,7 +14,7 @@ dlv attach pid
 ### Options inherited from parent commands
 
 ```
-      --accept-multiclient[=false]: Allows a headless server to accept multiple client connection. Note that the server API is not reentrant and clients will have to coordinate
+      --accept-multiclient[=false]: Allows a headless server to accept multiple client connections. Note that the server API is not reentrant and clients will have to coordinate
       --build-flags="": Build flags, to be passed to the compiler.
       --headless[=false]: Run debug server only, in headless mode.
       --init="": Init file, executed by the terminal client.

--- a/Documentation/usage/dlv_connect.md
+++ b/Documentation/usage/dlv_connect.md
@@ -14,7 +14,7 @@ dlv connect addr
 ### Options inherited from parent commands
 
 ```
-      --accept-multiclient[=false]: Allows a headless server to accept multiple client connection. Note that the server API is not reentrant and clients will have to coordinate
+      --accept-multiclient[=false]: Allows a headless server to accept multiple client connections. Note that the server API is not reentrant and clients will have to coordinate
       --build-flags="": Build flags, to be passed to the compiler.
       --headless[=false]: Run debug server only, in headless mode.
       --init="": Init file, executed by the terminal client.

--- a/Documentation/usage/dlv_debug.md
+++ b/Documentation/usage/dlv_debug.md
@@ -15,7 +15,7 @@ dlv debug [package]
 ### Options inherited from parent commands
 
 ```
-      --accept-multiclient[=false]: Allows a headless server to accept multiple client connection. Note that the server API is not reentrant and clients will have to coordinate
+      --accept-multiclient[=false]: Allows a headless server to accept multiple client connections. Note that the server API is not reentrant and clients will have to coordinate
       --build-flags="": Build flags, to be passed to the compiler.
       --headless[=false]: Run debug server only, in headless mode.
       --init="": Init file, executed by the terminal client.

--- a/Documentation/usage/dlv_exec.md
+++ b/Documentation/usage/dlv_exec.md
@@ -14,7 +14,7 @@ dlv exec [./path/to/binary]
 ### Options inherited from parent commands
 
 ```
-      --accept-multiclient[=false]: Allows a headless server to accept multiple client connection. Note that the server API is not reentrant and clients will have to coordinate
+      --accept-multiclient[=false]: Allows a headless server to accept multiple client connections. Note that the server API is not reentrant and clients will have to coordinate
       --build-flags="": Build flags, to be passed to the compiler.
       --headless[=false]: Run debug server only, in headless mode.
       --init="": Init file, executed by the terminal client.

--- a/Documentation/usage/dlv_run.md
+++ b/Documentation/usage/dlv_run.md
@@ -14,7 +14,7 @@ dlv run
 ### Options inherited from parent commands
 
 ```
-      --accept-multiclient[=false]: Allows a headless server to accept multiple client connection. Note that the server API is not reentrant and clients will have to coordinate
+      --accept-multiclient[=false]: Allows a headless server to accept multiple client connections. Note that the server API is not reentrant and clients will have to coordinate
       --build-flags="": Build flags, to be passed to the compiler.
       --headless[=false]: Run debug server only, in headless mode.
       --init="": Init file, executed by the terminal client.

--- a/Documentation/usage/dlv_test.md
+++ b/Documentation/usage/dlv_test.md
@@ -14,7 +14,7 @@ dlv test [package]
 ### Options inherited from parent commands
 
 ```
-      --accept-multiclient[=false]: Allows a headless server to accept multiple client connection. Note that the server API is not reentrant and clients will have to coordinate
+      --accept-multiclient[=false]: Allows a headless server to accept multiple client connections. Note that the server API is not reentrant and clients will have to coordinate
       --build-flags="": Build flags, to be passed to the compiler.
       --headless[=false]: Run debug server only, in headless mode.
       --init="": Init file, executed by the terminal client.

--- a/Documentation/usage/dlv_trace.md
+++ b/Documentation/usage/dlv_trace.md
@@ -21,7 +21,7 @@ dlv trace [package] regexp
 ### Options inherited from parent commands
 
 ```
-      --accept-multiclient[=false]: Allows a headless server to accept multiple client connection. Note that the server API is not reentrant and clients will have to coordinate
+      --accept-multiclient[=false]: Allows a headless server to accept multiple client connections. Note that the server API is not reentrant and clients will have to coordinate
       --build-flags="": Build flags, to be passed to the compiler.
       --headless[=false]: Run debug server only, in headless mode.
       --init="": Init file, executed by the terminal client.

--- a/Documentation/usage/dlv_version.md
+++ b/Documentation/usage/dlv_version.md
@@ -14,7 +14,7 @@ dlv version
 ### Options inherited from parent commands
 
 ```
-      --accept-multiclient[=false]: Allows a headless server to accept multiple client connection. Note that the server API is not reentrant and clients will have to coordinate
+      --accept-multiclient[=false]: Allows a headless server to accept multiple client connections. Note that the server API is not reentrant and clients will have to coordinate
       --build-flags="": Build flags, to be passed to the compiler.
       --headless[=false]: Run debug server only, in headless mode.
       --init="": Init file, executed by the terminal client.

--- a/cmd/dlv/cmds/commands.go
+++ b/cmd/dlv/cmds/commands.go
@@ -77,7 +77,7 @@ func New() *cobra.Command {
 	RootCommand.PersistentFlags().StringVarP(&Addr, "listen", "l", "localhost:0", "Debugging server listen address.")
 	RootCommand.PersistentFlags().BoolVarP(&Log, "log", "", false, "Enable debugging server logging.")
 	RootCommand.PersistentFlags().BoolVarP(&Headless, "headless", "", false, "Run debug server only, in headless mode.")
-	RootCommand.PersistentFlags().BoolVarP(&AcceptMulti, "accept-multiclient", "", false, "Allows a headless server to accept multiple client connection. Note that the server API is not reentrant and clients will have to coordinate")
+	RootCommand.PersistentFlags().BoolVarP(&AcceptMulti, "accept-multiclient", "", false, "Allows a headless server to accept multiple client connections. Note that the server API is not reentrant and clients will have to coordinate")
 	RootCommand.PersistentFlags().StringVar(&InitFile, "init", "", "Init file, executed by the terminal client.")
 	RootCommand.PersistentFlags().StringVar(&BuildFlags, "build-flags", buildFlagsDefault, "Build flags, to be passed to the compiler.")
 


### PR DESCRIPTION
This is a very minor correction, but seems the same mistake just happened to propagate, thanks likely to Copy&Paste.