### PR TITLE
Make next, step, step-instruction work on parked goroutines, implemented stepout

### DIFF
--- a/_fixtures/defercall.go
+++ b/_fixtures/defercall.go
@@ -1,0 +1,29 @@
+package main
+
+var n = 0
+
+func sampleFunction() {
+	n++
+}
+
+func callAndDeferReturn() {
+	defer sampleFunction()
+	sampleFunction()
+	n++
+}
+
+func callAndPanic2() {
+	defer sampleFunction()
+	sampleFunction()
+	panic("panicking")
+}
+
+func callAndPanic() {
+	defer recover()
+	callAndPanic2()
+}
+
+func main() {
+	callAndDeferReturn()
+	callAndPanic()
+}

--- a/proc/proc.go
+++ b/proc/proc.go
@@ -509,7 +509,8 @@ func (dbp *Process) StepInstruction() (err error) {
 		return errors.New("cannot single step: no selected goroutine")
 	}
 	if dbp.SelectedGoroutine.thread == nil {
-		return fmt.Errorf("cannot single step: no thread associated with goroutine %d", dbp.SelectedGoroutine.ID)
+		// Step called on parked goroutine
+		return dbp.stepToPC(dbp.SelectedGoroutine.PC)
 	}
 	return dbp.run(dbp.SelectedGoroutine.thread.StepInstruction)
 }

--- a/proc/proc_test.go
+++ b/proc/proc_test.go
@@ -1825,3 +1825,47 @@ func TestStepParked(t *testing.T) {
 		}
 	})
 }
+
+func TestStepOut(t *testing.T) {
+	withTestProcess("testnextprog", t, func(p *Process, fixture protest.Fixture) {
+		bp, err := setFunctionBreakpoint(p, "main.helloworld")
+		assertNoError(err, t, "SetBreakpoint()")
+		assertNoError(p.Continue(), t, "Continue()")
+		p.ClearBreakpoint(bp.Addr)
+
+		f, lno := currentLineNumber(p, t)
+		if lno != 13 {
+			t.Fatalf("wrong line number %s:%d, expected %d", f, lno, 13)
+		}
+
+		assertNoError(p.StepOut(), t, "StepOut()")
+
+		f, lno = currentLineNumber(p, t)
+		if lno != 35 {
+			t.Fatalf("wrong line number %s:%d, expected %d", f, lno, 34)
+		}
+	})
+}
+
+func TestStepOutDefer(t *testing.T) {
+	withTestProcess("testnextdefer", t, func(p *Process, fixture protest.Fixture) {
+		pc, err := p.FindFileLocation(fixture.Source, 9)
+		assertNoError(err, t, "FindFileLocation()")
+		bp, err := p.SetBreakpoint(pc)
+		assertNoError(err, t, "SetBreakpoint()")
+		assertNoError(p.Continue(), t, "Continue()")
+		p.ClearBreakpoint(bp.Addr)
+
+		f, lno := currentLineNumber(p, t)
+		if lno != 9 {
+			t.Fatalf("worng line number %s:%d, expected %d", f, lno, 5)
+		}
+
+		assertNoError(p.StepOut(), t, "StepOut()")
+
+		f, lno = currentLineNumber(p, t)
+		if lno != 6 {
+			t.Fatalf("wrong line number %s:%d, expected %d", f, lno, 6)
+		}
+	})
+}

--- a/service/api/conversions.go
+++ b/service/api/conversions.go
@@ -38,7 +38,9 @@ func ConvertBreakpoint(bp *proc.Breakpoint) *Breakpoint {
 	}
 
 	var buf bytes.Buffer
-	printer.Fprint(&buf, token.NewFileSet(), bp.Cond)
+	if bp.Cond != nil {
+		printer.Fprint(&buf, token.NewFileSet(), bp.Cond.Expr)
+	}
 	b.Cond = buf.String()
 
 	return b

--- a/service/api/types.go
+++ b/service/api/types.go
@@ -233,6 +233,8 @@ const (
 	Continue = "continue"
 	// Step continues to next source line, entering function calls.
 	Step = "step"
+	// StepOut continues to the return address of the current function
+	StepOut = "stepOut"
 	// SingleStep continues for exactly 1 cpu instruction.
 	StepInstruction = "stepInstruction"
 	// Next continues to the next source line, not entering function calls.

--- a/service/client.go
+++ b/service/client.go
@@ -25,6 +25,9 @@ type Client interface {
 	Next() (*api.DebuggerState, error)
 	// Step continues to the next source line, entering function calls.
 	Step() (*api.DebuggerState, error)
+	// StepOut continues to the return address of the current function
+	StepOut() (*api.DebuggerState, error)
+
 	// SingleStep will step a single cpu instruction.
 	StepInstruction() (*api.DebuggerState, error)
 	// SwitchThread switches the current thread context.

--- a/service/debugger/debugger.go
+++ b/service/debugger/debugger.go
@@ -415,6 +415,9 @@ func (d *Debugger) Command(command *api.DebuggerCommand) (*api.DebuggerState, er
 	case api.StepInstruction:
 		log.Print("single stepping")
 		err = d.process.StepInstruction()
+	case api.StepOut:
+		log.Print("step out")
+		err = d.process.StepOut()
 	case api.SwitchThread:
 		log.Printf("switching to thread %d", command.ThreadID)
 		err = d.process.SwitchThread(command.ThreadID)

--- a/service/debugger/debugger.go
+++ b/service/debugger/debugger.go
@@ -4,6 +4,7 @@ import (
 	"debug/gosym"
 	"errors"
 	"fmt"
+	"go/ast"
 	"go/parser"
 	"log"
 	"path/filepath"
@@ -264,7 +265,11 @@ func copyBreakpointInfo(bp *proc.Breakpoint, requested *api.Breakpoint) (err err
 	bp.LoadLocals = api.LoadConfigToProc(requested.LoadLocals)
 	bp.Cond = nil
 	if requested.Cond != "" {
-		bp.Cond, err = parser.ParseExpr(requested.Cond)
+		var expr ast.Expr
+		expr, err = parser.ParseExpr(requested.Cond)
+		if expr != nil {
+			bp.Cond = &proc.BreakpointCondition{Expr: expr}
+		}
 	}
 	return err
 }

--- a/service/rpc2/client.go
+++ b/service/rpc2/client.go
@@ -104,6 +104,12 @@ func (c *RPCClient) Step() (*api.DebuggerState, error) {
 	return &out.State, err
 }
 
+func (c *RPCClient) StepOut() (*api.DebuggerState, error) {
+	var out CommandOut
+	err := c.call("Command", &api.DebuggerCommand{ Name: api.StepOut}, &out)
+	return &out.State, err
+}
+
 func (c *RPCClient) StepInstruction() (*api.DebuggerState, error) {
 	var out CommandOut
 	err := c.call("Command", api.DebuggerCommand{Name: api.StepInstruction}, &out)

--- a/service/test/integration2_test.go
+++ b/service/test/integration2_test.go
@@ -196,6 +196,23 @@ func TestClientServer_step(t *testing.T) {
 	})
 }
 
+func TestClientServer_stepout(t *testing.T) {
+	withTestClient2("testnextprog", t, func(c service.Client) {
+		_, err := c.CreateBreakpoint(&api.Breakpoint{FunctionName: "main.helloworld", Line: -1})
+		assertNoError(err, t, "CreateBreakpoint()")
+		stateBefore := <-c.Continue()
+		assertNoError(stateBefore.Err, t, "Continue()")
+		if stateBefore.CurrentThread.Line != 13 {
+			t.Fatalf("wrong line number %s:%d, expected %d", stateBefore.CurrentThread.File, stateBefore.CurrentThread.Line, 13)
+		}
+		stateAfter, err := c.StepOut()
+		assertNoError(err, t, "StepOut()")
+		if stateAfter.CurrentThread.Line != 35 {
+			t.Fatalf("wrong line number %s:%d, expected %d", stateAfter.CurrentThread.File, stateAfter.CurrentThread.Line, 13)
+		}
+	})
+}
+
 func testnext2(testcases []nextTest, initialLocation string, t *testing.T) {
 	withTestClient2("testnextprog", t, func(c service.Client) {
 		bp, err := c.CreateBreakpoint(&api.Breakpoint{FunctionName: initialLocation, Line: -1})
@@ -275,7 +292,7 @@ func TestNextGeneral(t *testing.T) {
 		}
 	}
 
-	testnext(testcases, "main.testnext", t)
+	testnext2(testcases, "main.testnext", t)
 }
 
 func TestNextFunctionReturn(t *testing.T) {
@@ -284,7 +301,7 @@ func TestNextFunctionReturn(t *testing.T) {
 		{14, 15},
 		{15, 35},
 	}
-	testnext(testcases, "main.helloworld", t)
+	testnext2(testcases, "main.helloworld", t)
 }
 
 func TestClientServer_breakpointInMainThread(t *testing.T) {

--- a/terminal/command.go
+++ b/terminal/command.go
@@ -102,6 +102,7 @@ See also: "help on", "help cond" and "help clear"`},
 		{aliases: []string{"step", "s"}, allowedPrefixes: scopePrefix, cmdFn: step, helpMsg: "Single step through program."},
 		{aliases: []string{"step-instruction", "si"}, allowedPrefixes: scopePrefix, cmdFn: stepInstruction, helpMsg: "Single step a single cpu instruction."},
 		{aliases: []string{"next", "n"}, allowedPrefixes: scopePrefix, cmdFn: next, helpMsg: "Step over to next source line."},
+		{aliases: []string{"stepout"}, allowedPrefixes: scopePrefix, cmdFn: stepout, helpMsg: "Step out of the current function."},
 		{aliases: []string{"threads"}, cmdFn: threads, helpMsg: "Print out info for every traced thread."},
 		{aliases: []string{"thread", "tr"}, cmdFn: thread, helpMsg: `Switch to the specified thread.
 
@@ -652,6 +653,18 @@ func next(t *Term, ctx callContext, args string) error {
 	}
 	printcontext(t, state)
 	return continueUntilCompleteNext(t, state, "next")
+}
+
+func stepout(t *Term, ctx callContext, args string) error {
+	if err := scopePrefixSwitch(t, ctx); err != nil {
+		return err
+	}
+	state, err := t.client.StepOut()
+	if err != nil {
+		return err
+	}
+	printcontext(t, state)
+	return continueUntilCompleteNext(t, state, "stepout")
 }
 
 func clear(t *Term, ctx callContext, args string) error {

--- a/terminal/command.go
+++ b/terminal/command.go
@@ -99,7 +99,7 @@ A tracepoint is a breakpoint that does not stop the execution of the program, in
 See also: "help on", "help cond" and "help clear"`},
 		{aliases: []string{"restart", "r"}, cmdFn: restart, helpMsg: "Restart process."},
 		{aliases: []string{"continue", "c"}, cmdFn: cont, helpMsg: "Run until breakpoint or program termination."},
-		{aliases: []string{"step", "s"}, cmdFn: step, helpMsg: "Single step through program."},
+		{aliases: []string{"step", "s"}, allowedPrefixes: scopePrefix, cmdFn: step, helpMsg: "Single step through program."},
 		{aliases: []string{"step-instruction", "si"}, cmdFn: stepInstruction, helpMsg: "Single step a single cpu instruction."},
 		{aliases: []string{"next", "n"}, allowedPrefixes: scopePrefix, cmdFn: next, helpMsg: "Step over to next source line."},
 		{aliases: []string{"threads"}, cmdFn: threads, helpMsg: "Print out info for every traced thread."},
@@ -601,7 +601,26 @@ func continueUntilCompleteNext(t *Term, state *api.DebuggerState, op string) err
 	}
 }
 
+func scopePrefixSwitch(t *Term, ctx callContext) error {
+	if ctx.Prefix != scopePrefix {
+		return nil
+	}
+	if ctx.Scope.Frame != 0 {
+		return errors.New("frame prefix not accepted")
+	}
+	if ctx.Scope.GoroutineID > 0 {
+		_, err := t.client.SwitchGoroutine(ctx.Scope.GoroutineID)
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
 func step(t *Term, ctx callContext, args string) error {
+	if err := scopePrefixSwitch(t, ctx); err != nil {
+		return err
+	}
 	state, err := t.client.Step()
 	if err != nil {
 		return err
@@ -621,16 +640,8 @@ func stepInstruction(t *Term, ctx callContext, args string) error {
 }
 
 func next(t *Term, ctx callContext, args string) error {
-	if ctx.Prefix == scopePrefix {
-		if ctx.Scope.Frame != 0 {
-			return errors.New("can not prefix next with frame")
-		}
-		if ctx.Scope.GoroutineID > 0 {
-			_, err := t.client.SwitchGoroutine(ctx.Scope.GoroutineID)
-			if err != nil {
-				return err
-			}
-		}
+	if err := scopePrefixSwitch(t, ctx); err != nil {
+		return err
 	}
 	state, err := t.client.Next()
 	if err != nil {

--- a/terminal/command.go
+++ b/terminal/command.go
@@ -100,7 +100,7 @@ See also: "help on", "help cond" and "help clear"`},
 		{aliases: []string{"restart", "r"}, cmdFn: restart, helpMsg: "Restart process."},
 		{aliases: []string{"continue", "c"}, cmdFn: cont, helpMsg: "Run until breakpoint or program termination."},
 		{aliases: []string{"step", "s"}, allowedPrefixes: scopePrefix, cmdFn: step, helpMsg: "Single step through program."},
-		{aliases: []string{"step-instruction", "si"}, cmdFn: stepInstruction, helpMsg: "Single step a single cpu instruction."},
+		{aliases: []string{"step-instruction", "si"}, allowedPrefixes: scopePrefix, cmdFn: stepInstruction, helpMsg: "Single step a single cpu instruction."},
 		{aliases: []string{"next", "n"}, allowedPrefixes: scopePrefix, cmdFn: next, helpMsg: "Step over to next source line."},
 		{aliases: []string{"threads"}, cmdFn: threads, helpMsg: "Print out info for every traced thread."},
 		{aliases: []string{"thread", "tr"}, cmdFn: thread, helpMsg: `Switch to the specified thread.
@@ -630,6 +630,9 @@ func step(t *Term, ctx callContext, args string) error {
 }
 
 func stepInstruction(t *Term, ctx callContext, args string) error {
+	if err := scopePrefixSwitch(t, ctx); err != nil {
+		return err
+	}
 	state, err := t.client.StepInstruction()
 	if err != nil {
 		return err

--- a/terminal/command.go
+++ b/terminal/command.go
@@ -101,7 +101,7 @@ See also: "help on", "help cond" and "help clear"`},
 		{aliases: []string{"continue", "c"}, cmdFn: cont, helpMsg: "Run until breakpoint or program termination."},
 		{aliases: []string{"step", "s"}, cmdFn: step, helpMsg: "Single step through program."},
 		{aliases: []string{"step-instruction", "si"}, cmdFn: stepInstruction, helpMsg: "Single step a single cpu instruction."},
-		{aliases: []string{"next", "n"}, cmdFn: next, helpMsg: "Step over to next source line."},
+		{aliases: []string{"next", "n"}, allowedPrefixes: scopePrefix, cmdFn: next, helpMsg: "Step over to next source line."},
 		{aliases: []string{"threads"}, cmdFn: threads, helpMsg: "Print out info for every traced thread."},
 		{aliases: []string{"thread", "tr"}, cmdFn: thread, helpMsg: `Switch to the specified thread.
 
@@ -621,6 +621,17 @@ func stepInstruction(t *Term, ctx callContext, args string) error {
 }
 
 func next(t *Term, ctx callContext, args string) error {
+	if ctx.Prefix == scopePrefix {
+		if ctx.Scope.Frame != 0 {
+			return errors.New("can not prefix next with frame")
+		}
+		if ctx.Scope.GoroutineID > 0 {
+			_, err := t.client.SwitchGoroutine(ctx.Scope.GoroutineID)
+			if err != nil {
+				return err
+			}
+		}
+	}
 	state, err := t.client.Next()
 	if err != nil {
 		return err


### PR DESCRIPTION
Applies on top of #448.

I've refactored the code for `proc.(*Process).Next` to make it work on parked goroutines. Our previous behavior when the user switched to a parked goroutine was to simply step through the goroutine running on `CurrentThread`, which was wrong. 

I've implemented the same changes to `Step` and `StepInstruction` as well, for consistency.

Finally I have implemented `stepout` that continues the execution of the program until the selected goroutine returns from the function in execution. In gdb this command is called `finish` but graphical debuggers usually call it "Step out".