### PR TITLE
Misc osx refactors

### DIFF
--- a/proc/exec_darwin.c
+++ b/proc/exec_darwin.c
@@ -3,29 +3,37 @@
 extern char** environ;
 
 int
+close_exec_pipe(int fd[2]) {
+	if (pipe(fd) < 0) return -1;
+	if (fcntl(fd[0], F_SETFD, FD_CLOEXEC) < 0) return -1;
+	if (fcntl(fd[1], F_SETFD, FD_CLOEXEC) < 0) return -1;
+	return 0;
+}
+
+int
 fork_exec(char *argv0, char **argv, int size,
 		mach_port_name_t *task,
 		mach_port_t *port_set,
 		mach_port_t *exception_port,
 		mach_port_t *notification_port)
 {
-	// In order to call PT_SIGEXC below, we must ensure that we have acquired the mach task first.
-	// We facilitate this by creating a pipe and using it to let the forked process know that we've
-	// finishing acquiring the mach task, and it can go ahead with the calls to PT_TRACE_ME and PT_SIGEXC.
+	// Since we're using mach exceptions instead of signals,
+	// we need to coordinate between parent and child via pipes
+	// to ensure that the parent has set the exception ports on
+	// the child task before it execs.
 	int fd[2];
-	if (pipe(fd) < 0) return -1;
+	if (close_exec_pipe(fd) < 0) return -1;
 
-       // Create another pipe so that we know when we're about to exec. This ensures that control only returns
-       // back to Go-land when we call exec, effectively eliminating a race condition between launching the new
-       // process and trying to read its memory.
-       int wfd[2];
-       if (pipe(wfd) < 0) return -1;
+	// Create another pipe to signal the parent on exec.
+	int efd[2];
+	if (close_exec_pipe(efd) < 0) return -1;
 
 	kern_return_t kret;
 	pid_t pid = fork();
 	if (pid > 0) {
 		// In parent.
 		close(fd[0]);
+		close(efd[1]);
 		kret = acquire_mach_task(pid, task, port_set, exception_port, notification_port);
 		if (kret != KERN_SUCCESS) return -1;
 
@@ -33,10 +41,14 @@ fork_exec(char *argv0, char **argv, int size,
 		write(fd[1], &msg, 1);
 		close(fd[1]);
 
-               char w;
-               read(wfd[0], &w, 1);
-               close(wfd[0]);
-
+		char w;
+		size_t n = read(efd[0], &w, 1);
+		close(efd[0]);
+		if (n != 0) {
+			// Child died, reap it.
+			waitpid(pid, NULL, 0);
+			return -1;
+		}
 		return pid;
 	}
 
@@ -64,13 +76,14 @@ fork_exec(char *argv0, char **argv, int size,
 	pret = ptrace(PT_SIGEXC, 0, 0, 0);
 	if (pret != 0 && errno != 0) return -errno;
 
-	char msg = 'd';
-	write(wfd[1], &msg, 1);
-	close(wfd[1]);
-
 	// Create the child process.
 	execve(argv0, argv, environ);
 
 	// We should never reach here, but if we did something went wrong.
+	// Write a message to parent to alert that exec failed.
+	char msg = 'd';
+	write(efd[1], &msg, 1);
+	close(efd[1]);
+
 	exit(1);
 }

--- a/proc/exec_darwin.c
+++ b/proc/exec_darwin.c
@@ -12,7 +12,7 @@ close_exec_pipe(int fd[2]) {
 
 int
 fork_exec(char *argv0, char **argv, int size,
-		mach_port_name_t *task,
+		task_t *task,
 		mach_port_t *port_set,
 		mach_port_t *exception_port,
 		mach_port_t *notification_port)

--- a/proc/exec_darwin.h
+++ b/proc/exec_darwin.h
@@ -7,4 +7,4 @@
 #include <fcntl.h>
 
 int
-fork_exec(char *, char **, int, mach_port_name_t*, mach_port_t*, mach_port_t*, mach_port_t*);
+fork_exec(char *, char **, int, task_t*, mach_port_t*, mach_port_t*, mach_port_t*);

--- a/proc/exec_darwin.h
+++ b/proc/exec_darwin.h
@@ -4,6 +4,7 @@
 #include <sys/ptrace.h>
 #include <errno.h>
 #include <stdlib.h>
+#include <fcntl.h>
 
 int
 fork_exec(char *, char **, int, mach_port_name_t*, mach_port_t*, mach_port_t*, mach_port_t*);

--- a/proc/proc_darwin.c
+++ b/proc/proc_darwin.c
@@ -23,7 +23,7 @@ __attribute__ ((section ("__TEXT,__info_plist"),used)) =
 
 kern_return_t
 acquire_mach_task(int tid,
-		mach_port_name_t *task,
+		task_t *task,
 		mach_port_t *port_set,
 		mach_port_t *exception_port,
 		mach_port_t *notification_port)

--- a/proc/proc_darwin.h
+++ b/proc/proc_darwin.h
@@ -24,7 +24,7 @@ boolean_t mach_exc_server(
 		mach_msg_header_t *OutHeadP);
 
 kern_return_t
-acquire_mach_task(int, mach_port_name_t*, mach_port_t*, mach_port_t*, mach_port_t*);
+acquire_mach_task(int, task_t*, mach_port_t*, mach_port_t*, mach_port_t*);
 
 char *
 find_executable(int pid);

--- a/proc/threads_darwin.c
+++ b/proc/threads_darwin.c
@@ -1,7 +1,7 @@
 #include "threads_darwin.h"
 
 int
-write_memory(mach_port_name_t task, mach_vm_address_t addr, void *d, mach_msg_type_number_t len) {
+write_memory(task_t task, mach_vm_address_t addr, void *d, mach_msg_type_number_t len) {
 	kern_return_t kret;
 	vm_region_submap_short_info_data_64_t info;
 	mach_msg_type_number_t count = VM_REGION_SUBMAP_SHORT_INFO_COUNT_64;
@@ -27,7 +27,7 @@ write_memory(mach_port_name_t task, mach_vm_address_t addr, void *d, mach_msg_ty
 }
 
 int
-read_memory(mach_port_name_t task, mach_vm_address_t addr, void *d, mach_msg_type_number_t len) {
+read_memory(task_t task, mach_vm_address_t addr, void *d, mach_msg_type_number_t len) {
 	kern_return_t kret;
 	pointer_t data;
 	mach_msg_type_number_t count;

--- a/proc/threads_darwin.h
+++ b/proc/threads_darwin.h
@@ -5,10 +5,10 @@
 #include <mach/thread_info.h>
 
 int
-write_memory(mach_port_name_t, mach_vm_address_t, void *, mach_msg_type_number_t);
+write_memory(task_t, mach_vm_address_t, void *, mach_msg_type_number_t);
 
 int
-read_memory(mach_port_name_t, mach_vm_address_t, void *, mach_msg_type_number_t);
+read_memory(task_t, mach_vm_address_t, void *, mach_msg_type_number_t);
 
 kern_return_t
 get_registers(mach_port_name_t, x86_thread_state64_t*);


### PR DESCRIPTION
This set of patches sets the close-on-exec flag on the pipes used for parent/child coordination. Also includes a small refactor to avoid type coercion for C types.

I should have another PR up soon to clean up a few other issues on OSX.