### PR TITLE
Fix command-line arguments on Windows

### DIFF
--- a/_fixtures/testargs.go
+++ b/_fixtures/testargs.go
@@ -8,13 +8,13 @@ import (
 func main() {
 	// this test expects AT LEAST 1 argument, and the first one needs to be "test".
 	// second one is optional but if given, it should be "-passFlag"
-	fmt.Println("Hello, args world!", os.Args)
+	fmt.Printf("received args %#v\n", os.Args)
 	if len(os.Args) < 2 {
 		panic("os.args too short!")
 	} else if os.Args[1] != "test" {
 		panic("os.args[1] is not test!")
 	}
-	if len(os.Args) >= 3 && os.Args[2] != "-passFlag" {
-		panic("os.args[2] is not -passFlag!")
+	if len(os.Args) >= 3 && os.Args[2] != "pass flag" {
+		panic("os.args[2] is not \"pass flag\"!")
 	}
 }

--- a/_fixtures/testargs.go
+++ b/_fixtures/testargs.go
@@ -6,14 +6,15 @@ import (
 )
 
 func main() {
+	// this test expects AT LEAST 1 argument, and the first one needs to be "test".
+	// second one is optional but if given, it should be "-passFlag"
 	fmt.Println("Hello, args world!", os.Args)
-	if len(os.Args) < 3 {
+	if len(os.Args) < 2 {
 		panic("os.args too short!")
-	}
-	if os.Args[1] != "test" {
+	} else if os.Args[1] != "test" {
 		panic("os.args[1] is not test!")
 	}
-	if os.Args[2] != "-passFlag" {
+	if len(os.Args) >= 3 && os.Args[2] != "-passFlag" {
 		panic("os.args[2] is not -passFlag!")
 	}
 }

--- a/_fixtures/testargs.go
+++ b/_fixtures/testargs.go
@@ -1,0 +1,19 @@
+package main
+
+import (
+	"fmt"
+	"os"
+)
+
+func main() {
+	fmt.Println("Hello, args world!", os.Args)
+	if len(os.Args) < 3 {
+		panic("os.args too short!")
+	}
+	if os.Args[1] != "test" {
+		panic("os.args[1] is not test!")
+	}
+	if os.Args[2] != "-passFlag" {
+		panic("os.args[2] is not -passFlag!")
+	}
+}

--- a/proc/proc_test.go
+++ b/proc/proc_test.go
@@ -1672,6 +1672,7 @@ func TestPanicBreakpoint(t *testing.T) {
 }
 
 func TestCmdLineArgs(t *testing.T) {
+	// make sure first and second flag pass
 	withTestProcessArgs("testargs", t, func(p *Process, fixture protest.Fixture) {
 		err := p.Continue()
 		bp := p.CurrentBreakpoint()
@@ -1686,15 +1687,23 @@ func TestCmdLineArgs(t *testing.T) {
 				t.Fatalf("process exited with invalid status", exit.Status)
 			}
 		}
-
-	}, []string{"test", "-passFlag"})
+	}, []string{"test"})
 	withTestProcessArgs("testargs", t, func(p *Process, fixture protest.Fixture) {
-		p.Continue()
+		err := p.Continue()
 		bp := p.CurrentBreakpoint()
-		if bp == nil || bp.Name != "unrecovered-panic" {
-			t.Fatalf("not on unrecovered-panic breakpoint: %v", p.CurrentBreakpoint)
+		if bp != nil && bp.Name == "unrecovered-panic" {
+			t.Fatalf("testing args failed on unrecovered-panic breakpoint: %v", p.CurrentBreakpoint)
 		}
-	}, []string{"txest", "-pxassFlag"})
+		exit, exited := err.(ProcessExitedError)
+		if !exited {
+			t.Fatalf("Process did not exit!", err)
+		} else {
+			if exit.Status != 0 {
+				t.Fatalf("process exited with invalid status", exit.Status)
+			}
+		}
+	}, []string{"test", "-passFlag"})
+	// and that invalid cases (wrong flags or no flags) panic
 	withTestProcess("testargs", t, func(p *Process, fixture protest.Fixture) {
 		p.Continue()
 		bp := p.CurrentBreakpoint()
@@ -1702,6 +1711,27 @@ func TestCmdLineArgs(t *testing.T) {
 			t.Fatalf("not on unrecovered-panic breakpoint: %v", p.CurrentBreakpoint)
 		}
 	})
+	withTestProcessArgs("testargs", t, func(p *Process, fixture protest.Fixture) {
+		p.Continue()
+		bp := p.CurrentBreakpoint()
+		if bp == nil || bp.Name != "unrecovered-panic" {
+			t.Fatalf("not on unrecovered-panic breakpoint: %v", p.CurrentBreakpoint)
+		}
+	}, []string{"txest"})
+	withTestProcessArgs("testargs", t, func(p *Process, fixture protest.Fixture) {
+		p.Continue()
+		bp := p.CurrentBreakpoint()
+		if bp == nil || bp.Name != "unrecovered-panic" {
+			t.Fatalf("not on unrecovered-panic breakpoint: %v", p.CurrentBreakpoint)
+		}
+	}, []string{"test", "-pxassFlag"})
+	withTestProcessArgs("testargs", t, func(p *Process, fixture protest.Fixture) {
+		p.Continue()
+		bp := p.CurrentBreakpoint()
+		if bp == nil || bp.Name != "unrecovered-panic" {
+			t.Fatalf("not on unrecovered-panic breakpoint: %v", p.CurrentBreakpoint)
+		}
+	}, []string{"txest", "-passFlag"})
 }
 
 func TestIssue462(t *testing.T) {

--- a/proc/proc_test.go
+++ b/proc/proc_test.go
@@ -43,6 +43,21 @@ func withTestProcess(name string, t testing.TB, fn func(p *Process, fixture prot
 	fn(p, fixture)
 }
 
+func withTestProcessArgs(name string, t testing.TB, fn func(p *Process, fixture protest.Fixture), args []string) {
+	fixture := protest.BuildFixture(name)
+	p, err := Launch(append([]string{fixture.Path}, args...))
+	if err != nil {
+		t.Fatal("Launch():", err)
+	}
+
+	defer func() {
+		p.Halt()
+		p.Kill()
+	}()
+
+	fn(p, fixture)
+}
+
 func getRegisters(p *Process, t *testing.T) Registers {
 	regs, err := p.Registers()
 	if err != nil {
@@ -1649,6 +1664,39 @@ func TestIssue149(t *testing.T) {
 func TestPanicBreakpoint(t *testing.T) {
 	withTestProcess("panic", t, func(p *Process, fixture protest.Fixture) {
 		assertNoError(p.Continue(), t, "Continue()")
+		bp := p.CurrentBreakpoint()
+		if bp == nil || bp.Name != "unrecovered-panic" {
+			t.Fatalf("not on unrecovered-panic breakpoint: %v", p.CurrentBreakpoint)
+		}
+	})
+}
+
+func TestCmdLineArgs(t *testing.T) {
+	withTestProcessArgs("testargs", t, func(p *Process, fixture protest.Fixture) {
+		err := p.Continue()
+		bp := p.CurrentBreakpoint()
+		if bp != nil && bp.Name == "unrecovered-panic" {
+			t.Fatalf("testing args failed on unrecovered-panic breakpoint: %v", p.CurrentBreakpoint)
+		}
+		exit, exited := err.(ProcessExitedError)
+		if !exited {
+			t.Fatalf("Process did not exit!", err)
+		} else {
+			if exit.Status != 0 {
+				t.Fatalf("process exited with invalid status", exit.Status)
+			}
+		}
+
+	}, []string{"test", "-passFlag"})
+	withTestProcessArgs("testargs", t, func(p *Process, fixture protest.Fixture) {
+		p.Continue()
+		bp := p.CurrentBreakpoint()
+		if bp == nil || bp.Name != "unrecovered-panic" {
+			t.Fatalf("not on unrecovered-panic breakpoint: %v", p.CurrentBreakpoint)
+		}
+	}, []string{"txest", "-pxassFlag"})
+	withTestProcess("testargs", t, func(p *Process, fixture protest.Fixture) {
+		p.Continue()
 		bp := p.CurrentBreakpoint()
 		if bp == nil || bp.Name != "unrecovered-panic" {
 			t.Fatalf("not on unrecovered-panic breakpoint: %v", p.CurrentBreakpoint)

--- a/proc/proc_windows.go
+++ b/proc/proc_windows.go
@@ -47,9 +47,6 @@ func Launch(cmd []string) (*Process, error) {
 	if _, err := os.Stat(argv0Go); err != nil {
 		return nil, err
 	}
-
-	argv0, _ := syscall.UTF16PtrFromString(argv0Go)
-
 	// Duplicate the stdin/stdout/stderr handles
 	files := []uintptr{uintptr(syscall.Stdin), uintptr(syscall.Stdout), uintptr(syscall.Stderr)}
 	p, _ := syscall.GetCurrentProcess()
@@ -62,6 +59,32 @@ func Launch(cmd []string) (*Process, error) {
 		defer syscall.CloseHandle(syscall.Handle(fd[i]))
 	}
 
+	argv0, err := syscall.UTF16PtrFromString(argv0Go)
+	if err != nil {
+		return nil, err
+	}
+
+	// create suitable command line for CreateProcess
+	// see https://github.com/golang/go/blob/master/src/syscall/exec_windows.go#L326
+	// adapted from standard library makeCmdLine
+	// see https://github.com/golang/go/blob/master/src/syscall/exec_windows.go#L86
+	var cmdLineGo string
+	if len(cmd) > 1 {
+		for _, v := range cmd {
+			if cmdLineGo != "" {
+				cmdLineGo += " "
+			}
+			cmdLineGo += syscall.EscapeArg(v)
+		}
+	}
+
+	var cmdLine *uint16
+	if cmdLineGo != "" {
+		if cmdLine, err = syscall.UTF16PtrFromString(cmdLineGo); err != nil {
+			return nil, err
+		}
+	}
+
 	// Initialize the startup info and create process
 	si := new(sys.StartupInfo)
 	si.Cb = uint32(unsafe.Sizeof(*si))
@@ -70,7 +93,7 @@ func Launch(cmd []string) (*Process, error) {
 	si.StdOutput = sys.Handle(fd[1])
 	si.StdErr = sys.Handle(fd[2])
 	pi := new(sys.ProcessInformation)
-	err = sys.CreateProcess(argv0, nil, nil, nil, true, DEBUGONLYTHISPROCESS, nil, nil, si, pi)
+	err = sys.CreateProcess(argv0, cmdLine, nil, nil, true, DEBUGONLYTHISPROCESS, nil, nil, si, pi)
 	if err != nil {
 		return nil, err
 	}

--- a/proc/proc_windows.go
+++ b/proc/proc_windows.go
@@ -69,7 +69,7 @@ func Launch(cmd []string) (*Process, error) {
 	// adapted from standard library makeCmdLine
 	// see https://github.com/golang/go/blob/master/src/syscall/exec_windows.go#L86
 	var cmdLineGo string
-	if len(cmd) > 1 {
+	if len(cmd) >= 1 {
 		for _, v := range cmd {
 			if cmdLineGo != "" {
 				cmdLineGo += " "


### PR DESCRIPTION
This is a better-formatted PR replacing #479 and fixing the issue of command-line arguments not getting passed to the binary on Windows, including tests.

The nit has been fixed and commits are formatted better. Sorry for not reading the documentation on contributing!