### PR TITLE
area/makefile: Check $GOBIN before codesign, if not exist using $GOPATH/bin

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -37,13 +37,21 @@ endif
 build: check-cert
 	go build $(BUILD_FLAGS) github.com/derekparker/delve/cmd/dlv
 ifdef DARWIN
-	codesign -s "$(CERT)" ./dlv
+ifneq "$(GOBIN)" ""
+	codesign -s "$(CERT)"  $(GOBIN)/dlv
+else
+	codesign -s "$(CERT)"  $(GOPATH)/bin/dlv
+endif
 endif
 
 install: check-cert
 	go install $(BUILD_FLAGS) github.com/derekparker/delve/cmd/dlv
 ifdef DARWIN
-	codesign -s "$(CERT)" $(GOPATH)/bin/dlv
+ifneq "$(GOBIN)" ""
+	codesign -s "$(CERT)"  $(GOBIN)/dlv
+else
+	codesign -s "$(CERT)"  $(GOPATH)/bin/dlv
+endif
 endif
 
 test: check-cert


### PR DESCRIPTION
For codesign part in Makefile, we should check if $GOBIN is set instant using $GOPATH/bin.
For all homebrew user the $GOBIN will always set on /usr/local/Cellar/go/VERSION/libexec/bin

Fixs #502
