### PR TITLE
Sort methods in alphabetical order

### DIFF
--- a/service/rpc2/server.go
+++ b/service/rpc2/server.go
@@ -14,20 +14,224 @@ import (
 	"github.com/derekparker/delve/service/debugger"
 )
 
-type ServerImpl struct {
-	s *RPCServer
-}
+type (
+	AmendBreakpointIn struct {
+		Breakpoint api.Breakpoint
+	}
 
-type RPCServer struct {
-	// config is all the information necessary to start the debugger and server.
-	config *service.Config
-	// listener is used to serve HTTP.
-	listener net.Listener
-	// stopChan is used to stop the listener goroutine
-	stopChan chan struct{}
-	// debugger is a debugger service.
-	debugger *debugger.Debugger
-}
+	AmendBreakpointOut struct {
+	}
+
+	AttachedToExistingProcessIn struct {
+	}
+
+	AttachedToExistingProcessOut struct {
+		Answer bool
+	}
+
+	ClearBreakpointIn struct {
+		Id   int
+		Name string
+	}
+
+	ClearBreakpointOut struct {
+		Breakpoint *api.Breakpoint
+	}
+
+	CommandOut struct {
+		State api.DebuggerState
+	}
+
+	CreateBreakpointIn struct {
+		Breakpoint api.Breakpoint
+	}
+
+	CreateBreakpointOut struct {
+		Breakpoint api.Breakpoint
+	}
+
+	DetachIn struct {
+		Kill bool
+	}
+
+	DetachOut struct {
+	}
+
+	DisassembleIn struct {
+		Scope          api.EvalScope
+		StartPC, EndPC uint64
+		Flavour        api.AssemblyFlavour
+	}
+
+	DisassembleOut struct {
+		Disassemble api.AsmInstructions
+	}
+
+	EvalIn struct {
+		Scope api.EvalScope
+		Expr  string
+	}
+
+	EvalOut struct {
+		Variable *api.Variable
+	}
+
+	FindLocationIn struct {
+		Scope api.EvalScope
+		Loc   string
+	}
+
+	FindLocationOut struct {
+		Locations []api.Location
+	}
+
+	GetBreakpointIn struct {
+		Id   int
+		Name string
+	}
+
+	GetBreakpointOut struct {
+		Breakpoint api.Breakpoint
+	}
+
+	GetThreadIn struct {
+		Id int
+	}
+
+	GetThreadOut struct {
+		Thread *api.Thread
+	}
+
+	ListBreakpointsIn struct {
+	}
+
+	ListBreakpointsOut struct {
+		Breakpoints []*api.Breakpoint
+	}
+
+	ListFunctionArgsIn struct {
+		Scope api.EvalScope
+	}
+
+	ListFunctionArgsOut struct {
+		Args []api.Variable
+	}
+
+	ListFunctionsIn struct {
+		Filter string
+	}
+
+	ListFunctionsOut struct {
+		Funcs []string
+	}
+
+	ListGoroutinesIn struct {
+	}
+
+	ListGoroutinesOut struct {
+		Goroutines []*api.Goroutine
+	}
+
+	ListLocalVarsIn struct {
+		Scope api.EvalScope
+	}
+
+	ListLocalVarsOut struct {
+		Variables []api.Variable
+	}
+
+	ListPackageVarsIn struct {
+		Filter string
+	}
+
+	ListPackageVarsOut struct {
+		Variables []api.Variable
+	}
+
+	ListRegistersIn struct {
+	}
+
+	ListRegistersOut struct {
+		Registers string
+	}
+
+	ListSourcesIn struct {
+		Filter string
+	}
+
+	ListSourcesOut struct {
+		Sources []string
+	}
+
+	ListThreadsIn struct {
+	}
+
+	ListThreadsOut struct {
+		Threads []*api.Thread
+	}
+
+	ListTypesIn struct {
+		Filter string
+	}
+
+	ListTypesOut struct {
+		Types []string
+	}
+
+	ProcessPidIn struct {
+	}
+
+	ProcessPidOut struct {
+		Pid int
+	}
+
+	RestartIn struct {
+	}
+
+	RestartOut struct {
+	}
+
+	RPCServer struct {
+		// config is all the information necessary to start the debugger and server.
+		config *service.Config
+		// listener is used to serve HTTP.
+		listener net.Listener
+		// stopChan is used to stop the listener goroutine
+		stopChan chan struct{}
+		// debugger is a debugger service.
+		debugger *debugger.Debugger
+	}
+
+	ServerImpl struct {
+		s *RPCServer
+	}
+
+	SetIn struct {
+		Scope  api.EvalScope
+		Symbol string
+		Value  string
+	}
+
+	SetOut struct {
+	}
+
+	StacktraceIn struct {
+		Id    int
+		Depth int
+		Full  bool
+	}
+
+	StacktraceOut struct {
+		Locations []api.Stackframe
+	}
+
+	StateIn struct {
+	}
+
+	StateOut struct {
+		State *api.DebuggerState
+	}
+)
 
 // NewServer creates a new RPCServer.
 func NewServer(config *service.Config, logEnabled bool) *ServerImpl {
@@ -45,17 +249,8 @@ func NewServer(config *service.Config, logEnabled bool) *ServerImpl {
 	}
 }
 
-// Stop detaches from the debugger and waits for it to stop.
-func (s *ServerImpl) Stop(kill bool) error {
-	if s.s.config.AcceptMulti {
-		close(s.s.stopChan)
-		s.s.listener.Close()
-	}
-	err := s.s.debugger.Detach(kill)
-	if err != nil {
-		return err
-	}
-	return nil
+func (s *ServerImpl) Restart() error {
+	return s.s.Restart(RestartIn{}, nil)
 }
 
 // Run starts a debugger and exposes it with an HTTP server. The debugger
@@ -96,156 +291,28 @@ func (s *ServerImpl) Run() error {
 	return nil
 }
 
-func (s *ServerImpl) Restart() error {
-	return s.s.Restart(RestartIn{}, nil)
-}
-
-type ProcessPidIn struct {
-}
-
-type ProcessPidOut struct {
-	Pid int
-}
-
-func (s *RPCServer) ProcessPid(arg ProcessPidIn, out *ProcessPidOut) error {
-	out.Pid = s.debugger.ProcessPid()
-	return nil
-}
-
-type DetachIn struct {
-	Kill bool
-}
-
-type DetachOut struct {
-}
-
-func (s *RPCServer) Detach(arg DetachIn, out *DetachOut) error {
-	return s.debugger.Detach(arg.Kill)
-}
-
-type RestartIn struct {
-}
-
-type RestartOut struct {
-}
-
-func (s *RPCServer) Restart(arg RestartIn, out *RestartOut) error {
-	if s.config.AttachPid != 0 {
-		return errors.New("cannot restart process Delve did not create")
+// Stop detaches from the debugger and waits for it to stop.
+func (s *ServerImpl) Stop(kill bool) error {
+	if s.s.config.AcceptMulti {
+		close(s.s.stopChan)
+		s.s.listener.Close()
 	}
-	return s.debugger.Restart()
-}
-
-type StateIn struct {
-}
-
-type StateOut struct {
-	State *api.DebuggerState
-}
-
-func (s *RPCServer) State(arg StateIn, out *StateOut) error {
-	st, err := s.debugger.State()
+	err := s.s.debugger.Detach(kill)
 	if err != nil {
 		return err
 	}
-	out.State = st
 	return nil
 }
 
-type CommandOut struct {
-	State api.DebuggerState
+func (s *RPCServer) AmendBreakpoint(arg AmendBreakpointIn, out *AmendBreakpointOut) error {
+	return s.debugger.AmendBreakpoint(&arg.Breakpoint)
 }
 
-func (s *RPCServer) Command(command api.DebuggerCommand, out *CommandOut) error {
-	st, err := s.debugger.Command(&command)
-	if err != nil {
-		return err
+func (c *RPCServer) AttachedToExistingProcess(arg AttachedToExistingProcessIn, out *AttachedToExistingProcessOut) error {
+	if c.config.AttachPid != 0 {
+		out.Answer = true
 	}
-	out.State = *st
 	return nil
-}
-
-type GetBreakpointIn struct {
-	Id   int
-	Name string
-}
-
-type GetBreakpointOut struct {
-	Breakpoint api.Breakpoint
-}
-
-func (s *RPCServer) GetBreakpoint(arg GetBreakpointIn, out *GetBreakpointOut) error {
-	var bp *api.Breakpoint
-	if arg.Name != "" {
-		bp = s.debugger.FindBreakpointByName(arg.Name)
-		if bp == nil {
-			return fmt.Errorf("no breakpoint with name %s", arg.Name)
-		}
-	} else {
-		bp = s.debugger.FindBreakpoint(arg.Id)
-		if bp == nil {
-			return fmt.Errorf("no breakpoint with id %d", arg.Id)
-		}
-	}
-	out.Breakpoint = *bp
-	return nil
-}
-
-type StacktraceIn struct {
-	Id    int
-	Depth int
-	Full  bool
-}
-
-type StacktraceOut struct {
-	Locations []api.Stackframe
-}
-
-func (s *RPCServer) Stacktrace(arg StacktraceIn, out *StacktraceOut) error {
-	locs, err := s.debugger.Stacktrace(arg.Id, arg.Depth, arg.Full)
-	if err != nil {
-		return err
-	}
-	out.Locations = locs
-	return nil
-}
-
-type ListBreakpointsIn struct {
-}
-
-type ListBreakpointsOut struct {
-	Breakpoints []*api.Breakpoint
-}
-
-func (s *RPCServer) ListBreakpoints(arg ListBreakpointsIn, out *ListBreakpointsOut) error {
-	out.Breakpoints = s.debugger.Breakpoints()
-	return nil
-}
-
-type CreateBreakpointIn struct {
-	Breakpoint api.Breakpoint
-}
-
-type CreateBreakpointOut struct {
-	Breakpoint api.Breakpoint
-}
-
-func (s *RPCServer) CreateBreakpoint(arg CreateBreakpointIn, out *CreateBreakpointOut) error {
-	createdbp, err := s.debugger.CreateBreakpoint(&arg.Breakpoint)
-	if err != nil {
-		return err
-	}
-	out.Breakpoint = *createdbp
-	return nil
-}
-
-type ClearBreakpointIn struct {
-	Id   int
-	Name string
-}
-
-type ClearBreakpointOut struct {
-	Breakpoint *api.Breakpoint
 }
 
 func (s *RPCServer) ClearBreakpoint(arg ClearBreakpointIn, out *ClearBreakpointOut) error {
@@ -269,35 +336,64 @@ func (s *RPCServer) ClearBreakpoint(arg ClearBreakpointIn, out *ClearBreakpointO
 	return nil
 }
 
-type AmendBreakpointIn struct {
-	Breakpoint api.Breakpoint
+func (s *RPCServer) Command(command api.DebuggerCommand, out *CommandOut) error {
+	st, err := s.debugger.Command(&command)
+	if err != nil {
+		return err
+	}
+	out.State = *st
+	return nil
 }
 
-type AmendBreakpointOut struct {
+func (s *RPCServer) CreateBreakpoint(arg CreateBreakpointIn, out *CreateBreakpointOut) error {
+	createdbp, err := s.debugger.CreateBreakpoint(&arg.Breakpoint)
+	if err != nil {
+		return err
+	}
+	out.Breakpoint = *createdbp
+	return nil
 }
 
-func (s *RPCServer) AmendBreakpoint(arg AmendBreakpointIn, out *AmendBreakpointOut) error {
-	return s.debugger.AmendBreakpoint(&arg.Breakpoint)
+func (s *RPCServer) Detach(arg DetachIn, out *DetachOut) error {
+	return s.debugger.Detach(arg.Kill)
 }
 
-type ListThreadsIn struct {
-}
-
-type ListThreadsOut struct {
-	Threads []*api.Thread
-}
-
-func (s *RPCServer) ListThreads(arg ListThreadsIn, out *ListThreadsOut) (err error) {
-	out.Threads, err = s.debugger.Threads()
+func (c *RPCServer) Disassemble(arg DisassembleIn, out *DisassembleOut) error {
+	var err error
+	out.Disassemble, err = c.debugger.Disassemble(arg.Scope, arg.StartPC, arg.EndPC, arg.Flavour)
 	return err
 }
 
-type GetThreadIn struct {
-	Id int
+func (s *RPCServer) Eval(arg EvalIn, out *EvalOut) error {
+	v, err := s.debugger.EvalVariableInScope(arg.Scope, arg.Expr)
+	if err != nil {
+		return err
+	}
+	out.Variable = v
+	return nil
 }
 
-type GetThreadOut struct {
-	Thread *api.Thread
+func (c *RPCServer) FindLocation(arg FindLocationIn, out *FindLocationOut) error {
+	var err error
+	out.Locations, err = c.debugger.FindLocation(arg.Scope, arg.Loc)
+	return err
+}
+
+func (s *RPCServer) GetBreakpoint(arg GetBreakpointIn, out *GetBreakpointOut) error {
+	var bp *api.Breakpoint
+	if arg.Name != "" {
+		bp = s.debugger.FindBreakpointByName(arg.Name)
+		if bp == nil {
+			return fmt.Errorf("no breakpoint with name %s", arg.Name)
+		}
+	} else {
+		bp = s.debugger.FindBreakpoint(arg.Id)
+		if bp == nil {
+			return fmt.Errorf("no breakpoint with id %d", arg.Id)
+		}
+	}
+	out.Breakpoint = *bp
+	return nil
 }
 
 func (s *RPCServer) GetThread(arg GetThreadIn, out *GetThreadOut) error {
@@ -312,12 +408,45 @@ func (s *RPCServer) GetThread(arg GetThreadIn, out *GetThreadOut) error {
 	return nil
 }
 
-type ListPackageVarsIn struct {
-	Filter string
+func (s *RPCServer) ListBreakpoints(arg ListBreakpointsIn, out *ListBreakpointsOut) error {
+	out.Breakpoints = s.debugger.Breakpoints()
+	return nil
 }
 
-type ListPackageVarsOut struct {
-	Variables []api.Variable
+func (s *RPCServer) ListFunctionArgs(arg ListFunctionArgsIn, out *ListFunctionArgsOut) error {
+	vars, err := s.debugger.FunctionArguments(arg.Scope)
+	if err != nil {
+		return err
+	}
+	out.Args = vars
+	return nil
+}
+
+func (s *RPCServer) ListFunctions(arg ListFunctionsIn, out *ListFunctionsOut) error {
+	fns, err := s.debugger.Functions(arg.Filter)
+	if err != nil {
+		return err
+	}
+	out.Funcs = fns
+	return nil
+}
+
+func (s *RPCServer) ListGoroutines(arg ListGoroutinesIn, out *ListGoroutinesOut) error {
+	gs, err := s.debugger.Goroutines()
+	if err != nil {
+		return err
+	}
+	out.Goroutines = gs
+	return nil
+}
+
+func (s *RPCServer) ListLocalVars(arg ListLocalVarsIn, out *ListLocalVarsOut) error {
+	vars, err := s.debugger.LocalVariables(arg.Scope)
+	if err != nil {
+		return err
+	}
+	out.Variables = vars
+	return nil
 }
 
 func (s *RPCServer) ListPackageVars(arg ListPackageVarsIn, out *ListPackageVarsOut) error {
@@ -339,13 +468,6 @@ func (s *RPCServer) ListPackageVars(arg ListPackageVarsIn, out *ListPackageVarsO
 	return nil
 }
 
-type ListRegistersIn struct {
-}
-
-type ListRegistersOut struct {
-	Registers string
-}
-
 func (s *RPCServer) ListRegisters(arg ListRegistersIn, out *ListRegistersOut) error {
 	state, err := s.debugger.State()
 	if err != nil {
@@ -360,79 +482,6 @@ func (s *RPCServer) ListRegisters(arg ListRegistersIn, out *ListRegistersOut) er
 	return nil
 }
 
-type ListLocalVarsIn struct {
-	Scope api.EvalScope
-}
-
-type ListLocalVarsOut struct {
-	Variables []api.Variable
-}
-
-func (s *RPCServer) ListLocalVars(arg ListLocalVarsIn, out *ListLocalVarsOut) error {
-	vars, err := s.debugger.LocalVariables(arg.Scope)
-	if err != nil {
-		return err
-	}
-	out.Variables = vars
-	return nil
-}
-
-type ListFunctionArgsIn struct {
-	Scope api.EvalScope
-}
-
-type ListFunctionArgsOut struct {
-	Args []api.Variable
-}
-
-func (s *RPCServer) ListFunctionArgs(arg ListFunctionArgsIn, out *ListFunctionArgsOut) error {
-	vars, err := s.debugger.FunctionArguments(arg.Scope)
-	if err != nil {
-		return err
-	}
-	out.Args = vars
-	return nil
-}
-
-type EvalIn struct {
-	Scope api.EvalScope
-	Expr  string
-}
-
-type EvalOut struct {
-	Variable *api.Variable
-}
-
-func (s *RPCServer) Eval(arg EvalIn, out *EvalOut) error {
-	v, err := s.debugger.EvalVariableInScope(arg.Scope, arg.Expr)
-	if err != nil {
-		return err
-	}
-	out.Variable = v
-	return nil
-}
-
-type SetIn struct {
-	Scope  api.EvalScope
-	Symbol string
-	Value  string
-}
-
-type SetOut struct {
-}
-
-func (s *RPCServer) Set(arg SetIn, out *SetOut) error {
-	return s.debugger.SetVariableInScope(arg.Scope, arg.Symbol, arg.Value)
-}
-
-type ListSourcesIn struct {
-	Filter string
-}
-
-type ListSourcesOut struct {
-	Sources []string
-}
-
 func (s *RPCServer) ListSources(arg ListSourcesIn, out *ListSourcesOut) error {
 	ss, err := s.debugger.Sources(arg.Filter)
 	if err != nil {
@@ -442,29 +491,9 @@ func (s *RPCServer) ListSources(arg ListSourcesIn, out *ListSourcesOut) error {
 	return nil
 }
 
-type ListFunctionsIn struct {
-	Filter string
-}
-
-type ListFunctionsOut struct {
-	Funcs []string
-}
-
-func (s *RPCServer) ListFunctions(arg ListFunctionsIn, out *ListFunctionsOut) error {
-	fns, err := s.debugger.Functions(arg.Filter)
-	if err != nil {
-		return err
-	}
-	out.Funcs = fns
-	return nil
-}
-
-type ListTypesIn struct {
-	Filter string
-}
-
-type ListTypesOut struct {
-	Types []string
+func (s *RPCServer) ListThreads(arg ListThreadsIn, out *ListThreadsOut) (err error) {
+	out.Threads, err = s.debugger.Threads()
+	return err
 }
 
 func (s *RPCServer) ListTypes(arg ListTypesIn, out *ListTypesOut) error {
@@ -476,63 +505,36 @@ func (s *RPCServer) ListTypes(arg ListTypesIn, out *ListTypesOut) error {
 	return nil
 }
 
-type ListGoroutinesIn struct {
+func (s *RPCServer) ProcessPid(arg ProcessPidIn, out *ProcessPidOut) error {
+	out.Pid = s.debugger.ProcessPid()
+	return nil
 }
 
-type ListGoroutinesOut struct {
-	Goroutines []*api.Goroutine
+func (s *RPCServer) Restart(arg RestartIn, out *RestartOut) error {
+	if s.config.AttachPid != 0 {
+		return errors.New("cannot restart process Delve did not create")
+	}
+	return s.debugger.Restart()
 }
 
-func (s *RPCServer) ListGoroutines(arg ListGoroutinesIn, out *ListGoroutinesOut) error {
-	gs, err := s.debugger.Goroutines()
+func (s *RPCServer) Set(arg SetIn, out *SetOut) error {
+	return s.debugger.SetVariableInScope(arg.Scope, arg.Symbol, arg.Value)
+}
+
+func (s *RPCServer) Stacktrace(arg StacktraceIn, out *StacktraceOut) error {
+	locs, err := s.debugger.Stacktrace(arg.Id, arg.Depth, arg.Full)
 	if err != nil {
 		return err
 	}
-	out.Goroutines = gs
+	out.Locations = locs
 	return nil
 }
 
-type AttachedToExistingProcessIn struct {
-}
-
-type AttachedToExistingProcessOut struct {
-	Answer bool
-}
-
-func (c *RPCServer) AttachedToExistingProcess(arg AttachedToExistingProcessIn, out *AttachedToExistingProcessOut) error {
-	if c.config.AttachPid != 0 {
-		out.Answer = true
+func (s *RPCServer) State(arg StateIn, out *StateOut) error {
+	st, err := s.debugger.State()
+	if err != nil {
+		return err
 	}
+	out.State = st
 	return nil
-}
-
-type FindLocationIn struct {
-	Scope api.EvalScope
-	Loc   string
-}
-
-type FindLocationOut struct {
-	Locations []api.Location
-}
-
-func (c *RPCServer) FindLocation(arg FindLocationIn, out *FindLocationOut) error {
-	var err error
-	out.Locations, err = c.debugger.FindLocation(arg.Scope, arg.Loc)
-	return err
-}
-
-type DisassembleIn struct {
-	Scope          api.EvalScope
-	StartPC, EndPC uint64
-	Flavour        api.AssemblyFlavour
-}
-
-type DisassembleOut struct {
-	Disassemble api.AsmInstructions
-}
-
-func (c *RPCServer) Disassemble(arg DisassembleIn, out *DisassembleOut) error {
-	var err error
-	out.Disassemble, err = c.debugger.Disassemble(arg.Scope, arg.StartPC, arg.EndPC, arg.Flavour)
-	return err
 }


### PR DESCRIPTION
This should help out comparing differences between API versions.
I've tried to diff things before but it was simply too much surface to cover and the methods being out of order between commits didn't helped.
As such, I hope this will help others if needed.
Would be helpful to keep this ordered in the future to also ensure easier updates between same version or cross version.
Thanks.