### PR TITLE
dlv: Display subcommads in alphabetic order.

### DIFF
--- a/cmd/dlv/cmds/commands.go
+++ b/cmd/dlv/cmds/commands.go
@@ -85,73 +85,6 @@ func New() *cobra.Command {
 	RootCommand.PersistentFlags().StringVar(&InitFile, "init", "", "Init file, executed by the terminal client.")
 	RootCommand.PersistentFlags().StringVar(&BuildFlags, "build-flags", buildFlagsDefault, "Build flags, to be passed to the compiler.")
 
-	// 'version' subcommand.
-	versionCommand := &cobra.Command{
-		Use:   "version",
-		Short: "Prints version.",
-		Run: func(cmd *cobra.Command, args []string) {
-			fmt.Printf("Delve Debugger\n%s\n", version.DelveVersion)
-		},
-	}
-	RootCommand.AddCommand(versionCommand)
-
-	// Deprecated 'run' subcommand.
-	runCommand := &cobra.Command{
-		Use:   "run",
-		Short: "Deprecated command. Use 'debug' instead.",
-		Run: func(cmd *cobra.Command, args []string) {
-			fmt.Println("This command is deprecated, please use 'debug' instead.")
-			os.Exit(0)
-		},
-	}
-	RootCommand.AddCommand(runCommand)
-
-	// 'debug' subcommand.
-	debugCommand := &cobra.Command{
-		Use:   "debug [package]",
-		Short: "Compile and begin debugging program.",
-		Long: `Compiles your program with optimizations disabled,
-starts and attaches to it, and enables you to immediately begin debugging your program.`,
-		Run: debugCmd,
-	}
-	RootCommand.AddCommand(debugCommand)
-
-	// 'exec' subcommand.
-	execCommand := &cobra.Command{
-		Use:   "exec [./path/to/binary]",
-		Short: "Runs precompiled binary, attaches and begins debug session.",
-		PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
-			if len(args) == 0 {
-				return errors.New("you must provide a path to a binary")
-			}
-			return nil
-		},
-		Run: func(cmd *cobra.Command, args []string) {
-			os.Exit(execute(0, args, conf))
-		},
-	}
-	RootCommand.AddCommand(execCommand)
-
-	// 'trace' subcommand.
-	traceCommand := &cobra.Command{
-		Use:   "trace [package] regexp",
-		Short: "Compile and begin tracing program.",
-		Long:  "Trace program execution. Will set a tracepoint on every function matching the provided regular expression and output information when tracepoint is hit.",
-		Run:   traceCmd,
-	}
-	traceCommand.Flags().IntVarP(&traceAttachPid, "pid", "p", 0, "Pid to attach to.")
-	traceCommand.Flags().IntVarP(&traceStackDepth, "stack", "s", 0, "Show stack trace with given depth.")
-	RootCommand.AddCommand(traceCommand)
-
-	// 'test' subcommand.
-	testCommand := &cobra.Command{
-		Use:   "test [package]",
-		Short: "Compile test binary and begin debugging program.",
-		Long:  `Compiles a test binary with optimizations disabled, starts and attaches to it, and enable you to immediately begin debugging your program.`,
-		Run:   testCmd,
-	}
-	RootCommand.AddCommand(testCommand)
-
 	// 'attach' subcommand.
 	attachCommand := &cobra.Command{
 		Use:   "attach pid",
@@ -181,6 +114,73 @@ starts and attaches to it, and enables you to immediately begin debugging your p
 		Run: connectCmd,
 	}
 	RootCommand.AddCommand(connectCommand)
+
+	// 'debug' subcommand.
+	debugCommand := &cobra.Command{
+		Use:   "debug [package]",
+		Short: "Compile and begin debugging program.",
+		Long: `Compiles your program with optimizations disabled,
+starts and attaches to it, and enables you to immediately begin debugging your program.`,
+		Run: debugCmd,
+	}
+	RootCommand.AddCommand(debugCommand)
+
+	// 'exec' subcommand.
+	execCommand := &cobra.Command{
+		Use:   "exec [./path/to/binary]",
+		Short: "Runs precompiled binary, attaches and begins debug session.",
+		PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
+			if len(args) == 0 {
+				return errors.New("you must provide a path to a binary")
+			}
+			return nil
+		},
+		Run: func(cmd *cobra.Command, args []string) {
+			os.Exit(execute(0, args, conf))
+		},
+	}
+	RootCommand.AddCommand(execCommand)
+
+	// Deprecated 'run' subcommand.
+	runCommand := &cobra.Command{
+		Use:   "run",
+		Short: "Deprecated command. Use 'debug' instead.",
+		Run: func(cmd *cobra.Command, args []string) {
+			fmt.Println("This command is deprecated, please use 'debug' instead.")
+			os.Exit(0)
+		},
+	}
+	RootCommand.AddCommand(runCommand)
+
+	// 'test' subcommand.
+	testCommand := &cobra.Command{
+		Use:   "test [package]",
+		Short: "Compile test binary and begin debugging program.",
+		Long:  `Compiles a test binary with optimizations disabled, starts and attaches to it, and enable you to immediately begin debugging your program.`,
+		Run:   testCmd,
+	}
+	RootCommand.AddCommand(testCommand)
+
+	// 'trace' subcommand.
+	traceCommand := &cobra.Command{
+		Use:   "trace [package] regexp",
+		Short: "Compile and begin tracing program.",
+		Long:  "Trace program execution. Will set a tracepoint on every function matching the provided regular expression and output information when tracepoint is hit.",
+		Run:   traceCmd,
+	}
+	traceCommand.Flags().IntVarP(&traceAttachPid, "pid", "p", 0, "Pid to attach to.")
+	traceCommand.Flags().IntVarP(&traceStackDepth, "stack", "s", 0, "Show stack trace with given depth.")
+	RootCommand.AddCommand(traceCommand)
+
+	// 'version' subcommand.
+	versionCommand := &cobra.Command{
+		Use:   "version",
+		Short: "Prints version.",
+		Run: func(cmd *cobra.Command, args []string) {
+			fmt.Printf("Delve Debugger\n%s\n", version.DelveVersion)
+		},
+	}
+	RootCommand.AddCommand(versionCommand)
 
 	return RootCommand
 }


### PR DESCRIPTION
For better user experience, display subcommands in alphaetic order.