### PR TITLE
proc: bugfix: unsigned integer overflow in proc.(*memCache).contains

### DIFF
--- a/proc/mem.go
+++ b/proc/mem.go
@@ -14,7 +14,7 @@ type memCache struct {
 }
 
 func (m *memCache) contains(addr uintptr, size int) bool {
-	return addr >= m.cacheAddr && (addr+uintptr(size)) <= (m.cacheAddr+uintptr(len(m.cache)))
+	return addr >= m.cacheAddr && addr <= (m.cacheAddr+uintptr(len(m.cache) - size))
 }
 
 func (m *memCache) readMemory(addr uintptr, size int) (data []byte, err error) {

--- a/proc/proc_test.go
+++ b/proc/proc_test.go
@@ -1741,3 +1741,12 @@ func TestIssue462(t *testing.T) {
 		assertNoError(err, t, "Stacktrace()")
 	})
 }
+
+func TestIssue554(t *testing.T) {
+	// unsigned integer overflow in proc.(*memCache).contains was
+	// causing it to always return true for address 0xffffffffffffffff
+	mem := memCache{0x20, make([]byte, 100), nil}
+	if mem.contains(0xffffffffffffffff, 40) {
+		t.Fatalf("should be false")
+	}
+}


### PR DESCRIPTION
Fixes #554