### PR TITLE
Fix typos and unformatted code

### DIFF
--- a/dwarf/line/line_parser_test.go
+++ b/dwarf/line/line_parser_test.go
@@ -25,7 +25,7 @@ func grabDebugLineSection(p string, t *testing.T) []byte {
 		data, _ := ef.Section(".debug_line").Data()
 		return data
 	}
-	
+
 	pf, err := pe.NewFile(f)
 	if err == nil {
 		data, _ := pf.Section(".debug_line").Data()

--- a/proc/proc_windows.go
+++ b/proc/proc_windows.go
@@ -465,7 +465,7 @@ func (dbp *Process) setCurrentBreakpoints(trapthread *Thread) error {
 	// TODO: In theory, we should also be setting the breakpoints on other
 	// threads that happen to have hit this BP. But doing so leads to periodic
 	// failures in the TestBreakpointsCounts test with hit counts being too high,
-	// which can be traced back to occurences of multiple threads hitting a BP
+	// which can be traced back to occurrences of multiple threads hitting a BP
 	// at the same time.
 
 	// My guess is that Windows will correctly trigger multiple DEBUG_EVENT's

--- a/proc/registers.go
+++ b/proc/registers.go
@@ -5,7 +5,7 @@ import "errors"
 
 // Registers is an interface for a generic register type. The
 // interface encapsulates the generic values / actions
-// we need independant of arch. The concrete register types
+// we need independent of arch. The concrete register types
 // will be different depending on OS/Arch.
 type Registers interface {
 	PC() uint64

--- a/proc/threads_windows.go
+++ b/proc/threads_windows.go
@@ -114,7 +114,7 @@ func (t *Thread) blocked() bool {
 
 func (t *Thread) stopped() bool {
 	// TODO: We are assuming that threads are always stopped
-	// during command exection.
+	// during command execution.
 	return true
 }
 

--- a/proc/variables.go
+++ b/proc/variables.go
@@ -368,7 +368,7 @@ func (gvar *Variable) parseG() (*G, error) {
 		if thread, ok := mem.(*Thread); ok {
 			id = thread.ID
 		}
-		return nil, NoGError{ tid: id }
+		return nil, NoGError{tid: id}
 	}
 	gvar.loadValue(loadFullValue)
 	if gvar.Unreadable != nil {

--- a/service/api/types.go
+++ b/service/api/types.go
@@ -168,7 +168,7 @@ type Variable struct {
 	// The Name field in this slice will always be the empty string except for structs (when it will be the field name) and for complex numbers (when it will be "real" and "imaginary")
 	// For maps each map entry will have to items in this slice, even numbered items will represent map keys and odd numbered items will represent their values
 	// This field's length is capped at proc.maxArrayValues for slices and arrays and 2*proc.maxArrayValues for maps, in the circumnstances where the cap takes effect len(Children) != Len
-	// The other length cap applied to this field is related to maximum recursion depth, when the maximum recursion depth is reached this field is left empty, contrary to the previous one this cap also applies to structs (otherwise structs will always have all thier member fields returned)
+	// The other length cap applied to this field is related to maximum recursion depth, when the maximum recursion depth is reached this field is left empty, contrary to the previous one this cap also applies to structs (otherwise structs will always have all their member fields returned)
 	Children []Variable `json:"children"`
 
 	// Unreadable addresses will have this field set

--- a/service/rpc1/client.go
+++ b/service/rpc1/client.go
@@ -1,14 +1,15 @@
 package rpc1
 
 import (
+	"errors"
 	"fmt"
 	"log"
 	"net/rpc"
 	"net/rpc/jsonrpc"
-	"errors"
+
+	"sync"
 
 	"github.com/derekparker/delve/service/api"
-	"sync"
 )
 
 // Client is a RPC service.Client.
@@ -74,7 +75,7 @@ func (c *RPCClient) Continue() <-chan *api.DebuggerState {
 				state.Err = err
 			}
 			if state.Exited {
-				// Error types apparantly cannot be marshalled by Go correctly. Must reset error here.
+				// Error types apparently cannot be marshalled by Go correctly. Must reset error here.
 				state.Err = fmt.Errorf("Process %d has exited with status %d", c.ProcessPid(), state.ExitStatus)
 			}
 			ch <- state


### PR DESCRIPTION
Simple patch, just fixes some typos and fixes some format errors.