### PR TITLE
proc: bugfix: Step doesn't progress on CALL with breakpoint

### DIFF
--- a/_fixtures/issue561.go
+++ b/_fixtures/issue561.go
@@ -1,0 +1,11 @@
+package main
+
+import "fmt"
+
+func testfunction() {
+	fmt.Printf("here!\n")
+}
+
+func main() {
+	testfunction()
+}

--- a/proc/proc_test.go
+++ b/proc/proc_test.go
@@ -1881,3 +1881,18 @@ func TestUnsupportedArch(t *testing.T) {
 		t.Fatal(err)
 	}
 }
+
+func TestIssue561(t *testing.T) {
+	// Step fails to make progress when PC is at a CALL instruction
+	// where a breakpoint is also set
+	withTestProcess("issue561", t, func(p *Process, fixture protest.Fixture) {
+		_, err := setFunctionBreakpoint(p, "main.main")
+		assertNoError(err, t, "setFunctionBreakpoint()")
+		assertNoError(p.Continue(), t, "Continue()")
+		assertNoError(p.Step(), t, "Step()")
+		_, ln := currentLineNumber(p, t)
+		if ln != 5 {
+			t.Fatalf("wrong line number after Step, expected 5 got %d", ln)
+		}
+	})
+}

--- a/proc/threads.go
+++ b/proc/threads.go
@@ -358,6 +358,12 @@ func (thread *Thread) SetCurrentBreakpoint() error {
 	return nil
 }
 
+func (thread *Thread) resetBreakpoint() {
+	thread.CurrentBreakpoint = nil
+	thread.BreakpointConditionMet = false
+	thread.BreakpointConditionError = nil
+}
+
 func (thread *Thread) onTriggeredBreakpoint() bool {
 	return (thread.CurrentBreakpoint != nil) && thread.BreakpointConditionMet
 }


### PR DESCRIPTION
If step is called on a CALL instruction where a breakpoint is also set
it will make no progress because information about the breakpoint is
cleared at the beginning of Step, Step calls Continue and Continue just
hits the breakpoint again.

Fixes #561

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/derekparker/delve/565)
<!-- Reviewable:end -->
