### PR TITLE
Add support for Appengine; parsing Appengine Go custom version

### DIFF
--- a/proc/go_version.go
+++ b/proc/go_version.go
@@ -25,6 +25,7 @@ func ParseVersionString(ver string) (GoVersion, bool) {
 	}
 
 	if strings.HasPrefix(ver, "go") {
+		ver := strings.Split(ver, " ")[0]
 		v := strings.SplitN(ver[2:], ".", 3)
 		switch len(v) {
 		case 2:

--- a/proc/proc_test.go
+++ b/proc/proc_test.go
@@ -914,6 +914,7 @@ func TestParseVersionString(t *testing.T) {
 	versionAfterOrEqual(t, "go1.4.2", GoVersion{1, 4, 2, 0, 0})
 	versionAfterOrEqual(t, "go1.5beta2", GoVersion{1, 5, -1, 2, 0})
 	versionAfterOrEqual(t, "go1.5rc2", GoVersion{1, 5, -1, 0, 2})
+	versionAfterOrEqual(t, "go1.6.1 (appengine-1.9.37)", GoVersion{1, 6, 1, 0, 0})
 	ver, ok := ParseVersionString("devel +17efbfc Tue Jul 28 17:39:19 2015 +0000 linux/amd64")
 	if !ok {
 		t.Fatalf("Could not parse devel version string")


### PR DESCRIPTION
Appengine run its own version of Go.
The version returned is "go1.6.1 (appengine-1.9.37)".
The function ParseVersionString does not support that customization of the version.
This PR provides a simple patch that uses only the first part of the string (before space) to parse the version.