### PR TITLE
proc: Fix stepping into runtime.duff*

### DIFF
--- a/_fixtures/issue573.go
+++ b/_fixtures/issue573.go
@@ -1,0 +1,25 @@
+package main
+
+// A debugger test.
+//   dlv debug
+//   b main.foo
+//   c
+//   s
+//   s
+// Expect to be stopped in fmt.Printf or runtime.duffzero
+import "fmt"
+
+var v int = 99
+
+func foo(x, y int) (z int) { // c goes here
+	fmt.Printf("x=%d, y=%d, z=%d\n", x, y, z) // s #1 goes here
+	z = x + y
+	return
+}
+
+func main() {
+	x := v
+	y := x * x
+	z := foo(x, y)
+	fmt.Printf("z=%d\n", z)
+}

--- a/proc/proc.go
+++ b/proc/proc.go
@@ -462,7 +462,13 @@ func (dbp *Process) Step() (err error) {
 			}
 			text, err := dbp.CurrentThread.Disassemble(pc, pc+maxInstructionLength, true)
 			if err == nil && len(text) > 0 && text[0].IsCall() && text[0].DestLoc != nil && text[0].DestLoc.Fn != nil {
-				return dbp.StepInto(text[0].DestLoc.Fn)
+				fn := text[0].DestLoc.Fn
+				// Ensure PC and Entry match, otherwise StepInto is likely to set
+				// its breakpoint before DestLoc.PC and hence run too far ahead.
+				// Calls to runtime.duffzero and duffcopy have this problem.
+				if fn.Entry == text[0].DestLoc.PC {
+					return dbp.StepInto(fn)
+				}
 			}
 
 			err = dbp.CurrentThread.StepInstruction()

--- a/service/test/integration1_test.go
+++ b/service/test/integration1_test.go
@@ -945,6 +945,23 @@ func Test1NegativeStackDepthBug(t *testing.T) {
 	})
 }
 
+func Test1Issue573(t *testing.T) {
+	// In bug, Step() #2 runs to exit, so Step() #3 will fail.
+	withTestClient1("issue573", t, func(c *rpc1.RPCClient) {
+		_, err := c.CreateBreakpoint(&api.Breakpoint{FunctionName: "main.foo", Line: -1})
+		assertNoError(err, t, "CreateBreakpoint()")
+		ch := c.Continue()
+		state := <-ch
+		assertNoError(state.Err, t, "Continue()")
+		_, err = c.Step()
+		assertNoError(err, t, "Step()")
+		_, err = c.Step()
+		assertNoError(err, t, "Step()")
+		_, err = c.Step() // Third step ought to be possible; program ought not have exited.
+		assertNoError(err, t, "Step()")
+	})
+}
+
 func Test1ClientServer_CondBreakpoint(t *testing.T) {
 	withTestClient1("parallel_next", t, func(c *rpc1.RPCClient) {
 		bp, err := c.CreateBreakpoint(&api.Breakpoint{FunctionName: "main.sayhi", Line: 1})


### PR DESCRIPTION
Detect calls that do not target a function's entrypoint
(i.e, calls to runtime.duffzero and runtime.duffcopy) and
instead step into them directly.  StepInto sets a breakpoint
past the called function's prologue and expects that continue
will hit that breakpoint, but because the call is into the
interior of the function (well past the prologue) this fails.

Fixes #573