### PR TITLE
proc: Fix stepping into runtime.duff*

### DIFF
--- a/_fixtures/issue573.go
+++ b/_fixtures/issue573.go
@@ -1,0 +1,28 @@
+package main
+
+// A debugger test.
+//   dlv debug
+//   b main.foo
+//   c
+//   s
+//   s
+// Expect to be stopped in fmt.Printf or runtime.duffzero
+// In bug, s #2 runs to the process exit because the call
+// to duffzero enters duffzero well after the nominal entry
+// and skips the temporary breakpoint placed by StepZero().
+import "fmt"
+
+var v int = 99
+
+func foo(x, y int) (z int) { // c stops here
+	fmt.Printf("x=%d, y=%d, z=%d\n", x, y, z) // s #1 stops here; s #2 is supposed to stop in Printf or duffzero.
+	z = x + y
+	return
+}
+
+func main() {
+	x := v
+	y := x * x
+	z := foo(x, y)
+	fmt.Printf("z=%d\n", z)
+}


### PR DESCRIPTION
Detect calls that do not target a function's entrypoint
(i.e, calls to runtime.duffzero and runtime.duffcopy) and
instead step into them directly.  StepInto sets a breakpoint
past the called function's prologue and expects that continue
will hit that breakpoint, but because the call is into the
interior of the function (well past the prologue) this fails.

Fixes #573

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/derekparker/delve/575)
<!-- Reviewable:end -->
