### PR TITLE
prettyprint: Print type of the elements of arrays of interface type

### DIFF
--- a/_fixtures/testvariables2.go
+++ b/_fixtures/testvariables2.go
@@ -187,6 +187,9 @@ func main() {
 	b2 := B{A: A{42}, a: A{47}}
 	var sd D
 
+	ifacearr := []error{&astruct{}, nil}
+	efacearr := []interface{}{&astruct{}, "test", nil}
+
 	var mapanonstruct1 map[string]struct{}
 	var anonstruct1 struct{ val constant.Value }
 	var anonstruct2 struct{ i, j int }
@@ -195,7 +198,6 @@ func main() {
 		OtherFunction(i, j int)
 	}
 	var anonfunc func(a struct{ i int }, b interface{}, c struct{ val constant.Value })
-
 
 	for i := range benchparr {
 		benchparr[i] = &benchstruct{}
@@ -207,5 +209,5 @@ func main() {
 		fmt.Println(amb1)
 	}
 	runtime.Breakpoint()
-	fmt.Println(i1, i2, i3, p1, amb1, s1, s3, a1, p2, p3, s2, as1, str1, f1, fn1, fn2, nilslice, nilptr, ch1, chnil, m1, mnil, m2, m3, up1, i4, i5, i6, err1, err2, errnil, iface1, iface2, ifacenil, arr1, parr, cpx1, const1, iface3, iface4, recursive1, recursive1.x, iface5, iface2fn1, iface2fn2, bencharr, benchparr, mapinf, mainMenu, b, b2, sd, anonstruct1, anonstruct2, anoniface1, anonfunc, mapanonstruct1)
+	fmt.Println(i1, i2, i3, p1, amb1, s1, s3, a1, p2, p3, s2, as1, str1, f1, fn1, fn2, nilslice, nilptr, ch1, chnil, m1, mnil, m2, m3, up1, i4, i5, i6, err1, err2, errnil, iface1, iface2, ifacenil, arr1, parr, cpx1, const1, iface3, iface4, recursive1, recursive1.x, iface5, iface2fn1, iface2fn2, bencharr, benchparr, mapinf, mainMenu, b, b2, sd, anonstruct1, anonstruct2, anoniface1, anonfunc, mapanonstruct1, ifacearr, efacearr)
 }

--- a/service/api/prettyprint.go
+++ b/service/api/prettyprint.go
@@ -35,7 +35,11 @@ func (v *Variable) writeTo(buf io.Writer, top, newlines, includeType bool, inden
 	}
 
 	if !top && v.Addr == 0 {
-		fmt.Fprintf(buf, "%s nil", v.Type)
+		if includeType && v.Type != "void" {
+			fmt.Fprintf(buf, "%s nil", v.Type)
+		} else {
+			fmt.Fprintf(buf, "nil")
+		}
 		return
 	}
 
@@ -88,10 +92,10 @@ func (v *Variable) writeTo(buf io.Writer, top, newlines, includeType bool, inden
 			} else if data.Children[0].OnlyAddr {
 				fmt.Fprintf(buf, "0x%x", v.Children[0].Addr)
 			} else {
-				v.Children[0].writeTo(buf, false, newlines, false, indent)
+				v.Children[0].writeTo(buf, false, newlines, !includeType, indent)
 			}
 		} else {
-			v.Children[0].writeTo(buf, false, newlines, false, indent)
+			v.Children[0].writeTo(buf, false, newlines, !includeType, indent)
 		}
 	case reflect.Map:
 		v.writeMapTo(buf, newlines, includeType, indent)

--- a/service/test/variables_test.go
+++ b/service/test/variables_test.go
@@ -622,6 +622,9 @@ func TestEvalExpression(t *testing.T) {
 		{"mainMenu", true, `main.Menu len: 3, cap: 3, [{Name: "home", Route: "/", Active: 1},{Name: "About", Route: "/about", Active: 1},{Name: "Login", Route: "/login", Active: 1}]`, `main.Menu len: 3, cap: 3, [...]`, "main.Menu", nil},
 		{"mainMenu[0]", false, `main.Item {Name: "home", Route: "/", Active: 1}`, `main.Item {Name: "home", Route: "/", Active: 1}`, "main.Item", nil},
 		{"sd", false, "main.D {u1: 0, u2: 0, u3: 0, u4: 0, u5: 0, u6: 0}", "main.D {u1: 0, u2: 0, u3: 0,...+3 more}", "main.D", nil},
+
+		{"ifacearr", false, "[]error len: 2, cap: 2, [*main.astruct {A: 0, B: 0},nil]", "[]error len: 2, cap: 2, [...]", "[]error", nil},
+		{"efacearr", false, `[]interface {} len: 3, cap: 3, [*main.astruct {A: 0, B: 0},*"test",nil]`, "[]interface {} len: 3, cap: 3, [...]", "[]interface {}", nil},
 	}
 
 	withTestProcess("testvariables2", t, func(p *proc.Process, fixture protest.Fixture) {


### PR DESCRIPTION
It's often useful to see the concrete type of the individual elements that comprise an array of interface type.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/derekparker/delve/591)
<!-- Reviewable:end -->
