### PR TITLE
proc: bugfix: cleaning up spurious process exited errors

### DIFF
--- a/proc/proc_linux.go
+++ b/proc/proc_linux.go
@@ -292,6 +292,10 @@ func (dbp *Process) trapWait(pid int) (*Thread, error) {
 			var cloned uint
 			dbp.execPtraceFunc(func() { cloned, err = sys.PtraceGetEventMsg(wpid) })
 			if err != nil {
+				if err == sys.ESRCH {
+					// thread died while we were adding it
+					continue
+				}
 				return nil, fmt.Errorf("could not get event message: %s", err)
 			}
 			th, err = dbp.addThread(int(cloned), false)

--- a/proc/proc_test.go
+++ b/proc/proc_test.go
@@ -1685,7 +1685,7 @@ func TestCmdLineArgs(t *testing.T) {
 		}
 		exit, exited := err.(ProcessExitedError)
 		if !exited {
-			t.Fatalf("Process did not exit!", err)
+			t.Fatalf("Process did not exit: %v", err)
 		} else {
 			if exit.Status != 0 {
 				t.Fatalf("process exited with invalid status", exit.Status)

--- a/proc/registers.go
+++ b/proc/registers.go
@@ -1,6 +1,5 @@
 package proc
 
-import "fmt"
 import "errors"
 
 // Registers is an interface for a generic register type. The
@@ -21,11 +20,7 @@ var UnknownRegisterError = errors.New("unknown register")
 
 // Registers obtains register values from the debugged process.
 func (t *Thread) Registers() (Registers, error) {
-	regs, err := registers(t)
-	if err != nil {
-		return nil, fmt.Errorf("could not get registers: %s", err)
-	}
-	return regs, nil
+	return registers(t)
 }
 
 // PC returns the current PC for this thread.


### PR DESCRIPTION
Fixes flakiness of TestCmdLineArgs.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/derekparker/delve/599)
<!-- Reviewable:end -->
