### PR TITLE
proc: Implement Step using Continue 

### DIFF
--- a/_fixtures/defercall.go
+++ b/_fixtures/defercall.go
@@ -1,0 +1,29 @@
+package main
+
+var n = 0
+
+func sampleFunction() {
+	n++
+}
+
+func callAndDeferReturn() {
+	defer sampleFunction()
+	sampleFunction()
+	n++
+}
+
+func callAndPanic2() {
+	defer sampleFunction()
+	sampleFunction()
+	panic("panicking")
+}
+
+func callAndPanic() {
+	defer recover()
+	callAndPanic2()
+}
+
+func main() {
+	callAndDeferReturn()
+	callAndPanic()
+}

--- a/_fixtures/issue561.go
+++ b/_fixtures/issue561.go
@@ -1,0 +1,11 @@
+package main
+
+import "fmt"
+
+func testfunction() {
+	fmt.Printf("here!\n")
+}
+
+func main() {
+	testfunction()
+}

--- a/_fixtures/issue573.go
+++ b/_fixtures/issue573.go
@@ -9,7 +9,7 @@ package main
 // Expect to be stopped in fmt.Printf or runtime.duffzero
 // In bug, s #2 runs to the process exit because the call
 // to duffzero enters duffzero well after the nominal entry
-// and skips the temporary breakpoint placed by StepZero().
+// and skips the internal breakpoint placed by Step().
 import "fmt"
 
 var v int = 99

--- a/_fixtures/teststepconcurrent.go
+++ b/_fixtures/teststepconcurrent.go
@@ -1,0 +1,42 @@
+package main
+
+import (
+	"fmt"
+	"time"
+	"sync"
+)
+
+var v int = 99
+var wg sync.WaitGroup
+var s string
+
+func Foo(x, y int) (z int) {
+	//s = fmt.Sprintf("x=%d, y=%d, z=%d\n", x, y, z)
+	z = x + y
+	return
+}
+
+func Threads(fn func(x, y int) int) {
+	for j := 0; j < 100; j++ {
+		wg.Add(1)
+		go func() {
+			for k := 0; k < 100; k++ {
+				fn(1, 2)
+				time.Sleep(10 * time.Millisecond)
+			}
+			wg.Done()
+		}()
+	}
+}
+
+func main() {
+	x := v
+	y := x * x
+	var z int
+	Threads(Foo)
+	for i := 0; i < 100; i++ {
+		z = Foo(x, y)
+	}
+	fmt.Printf("z=%d\n", z)
+	wg.Wait()
+}

--- a/_fixtures/teststepprog.go
+++ b/_fixtures/teststepprog.go
@@ -1,0 +1,22 @@
+package main
+
+var n = 0
+
+func CallFn2() {
+	n++
+}
+
+func CallFn(fn func()) {
+	fn()
+}
+
+func CallEface(eface interface{}) {
+	if eface != nil {
+		n++
+	}
+}
+
+func main() {
+	CallFn(CallFn2)
+	CallEface(n)
+}

--- a/proc/breakpoints.go
+++ b/proc/breakpoints.go
@@ -17,11 +17,11 @@ type Breakpoint struct {
 	File         string
 	Line         int
 
-	Addr         uint64 // Address breakpoint is set for.
-	OriginalData []byte // If software breakpoint, the data we replace with breakpoint instruction.
-	Name         string // User defined name of the breakpoint
-	ID           int    // Monotonically increasing ID.
-	Temp         bool   // Whether this is a temp breakpoint (for next'ing).
+	Addr         uint64         // Address breakpoint is set for.
+	OriginalData []byte         // If software breakpoint, the data we replace with breakpoint instruction.
+	Name         string         // User defined name of the breakpoint
+	ID           int            // Monotonically increasing ID.
+	Kind         BreakpointKind // Whether this is a temp breakpoint (for next'ing or stepping).
 
 	// Breakpoint information
 	Tracepoint    bool     // Tracepoint flag
@@ -33,19 +33,40 @@ type Breakpoint struct {
 	HitCount      map[int]uint64 // Number of times a breakpoint has been reached in a certain goroutine
 	TotalHitCount uint64         // Number of times a breakpoint has been reached
 
-	// When DeferCond is set the breakpoint will only trigger
-	// if the caller is runtime.gopanic or if the return address
-	// is in the DeferReturns array.
-	// Next sets DeferCond for the breakpoint it sets on the
+	// DeferReturns: when kind == NextDeferBreakpoint this breakpoint
+	// will also check if the caller is runtime.gopanic or if the return
+	// address is in the DeferReturns array.
+	// Next uses NextDeferBreakpoints for the breakpoint it sets on the
 	// deferred function, DeferReturns is populated with the
 	// addresses of calls to runtime.deferreturn in the current
 	// function. This insures that the breakpoint on the deferred
 	// function only triggers on panic or on the defer call to
 	// the function, not when the function is called directly
-	DeferCond    bool
 	DeferReturns []uint64
-	Cond         ast.Expr // When Cond is not nil the breakpoint will be triggered only if evaluating Cond returns true
+	// Cond: if not nil the breakpoint will be triggered only if evaluating Cond returns true
+	Cond ast.Expr
 }
+
+// Breakpoint Kind determines the behavior of delve when the
+// breakpoint is reached.
+type BreakpointKind int
+
+const (
+	// UserBreakpoint is a user set breakpoint
+	UserBreakpoint BreakpointKind = iota
+	// NextBreakpoint is a breakpoint set by Next, Continue
+	// will stop on it and delete it
+	NextBreakpoint
+	// NextDeferBreakpoint is a breakpoint set by Next on the
+	// first deferred function. In addition to checking their condition
+	// breakpoints of this kind will also check that the function has been
+	// called by runtime.gopanic or through runtime.deferreturn.
+	NextDeferBreakpoint
+	// StepBreakpoint is a breakpoint set by Step on a CALL instruction,
+	// Continue will set a new breakpoint (of NextBreakpoint kind) on the
+	// destination of CALL, delete this breakpoint and then continue again
+	StepBreakpoint
+)
 
 func (bp *Breakpoint) String() string {
 	return fmt.Sprintf("Breakpoint %d at %#v %s:%d (%d)", bp.ID, bp.Addr, bp.File, bp.Line, bp.TotalHitCount)
@@ -82,7 +103,7 @@ func (iae InvalidAddressError) Error() string {
 	return fmt.Sprintf("Invalid address %#v\n", iae.address)
 }
 
-func (dbp *Process) setBreakpoint(tid int, addr uint64, temp bool) (*Breakpoint, error) {
+func (dbp *Process) setBreakpoint(tid int, addr uint64, kind BreakpointKind) (*Breakpoint, error) {
 	if bp, ok := dbp.FindBreakpoint(addr); ok {
 		return nil, BreakpointExistsError{bp.File, bp.Line, bp.Addr}
 	}
@@ -97,12 +118,12 @@ func (dbp *Process) setBreakpoint(tid int, addr uint64, temp bool) (*Breakpoint,
 		File:         f,
 		Line:         l,
 		Addr:         addr,
-		Temp:         temp,
+		Kind:         kind,
 		Cond:         nil,
 		HitCount:     map[int]uint64{},
 	}
 
-	if temp {
+	if kind != UserBreakpoint {
 		dbp.tempBreakpointIDCounter++
 		newBreakpoint.ID = dbp.tempBreakpointIDCounter
 	} else {
@@ -133,7 +154,7 @@ func (bp *Breakpoint) checkCondition(thread *Thread) (bool, error) {
 	if bp.Cond == nil {
 		return true, nil
 	}
-	if bp.DeferCond {
+	if bp.Kind == NextDeferBreakpoint {
 		frames, err := thread.Stacktrace(2)
 		if err == nil {
 			ispanic := len(frames) >= 3 && frames[2].Current.Fn != nil && frames[2].Current.Fn.Name == "runtime.gopanic"
@@ -166,6 +187,11 @@ func (bp *Breakpoint) checkCondition(thread *Thread) (bool, error) {
 		return true, errors.New("condition expression not boolean")
 	}
 	return constant.BoolVal(v.Value), nil
+}
+
+// Internal returns true for breakpoints not set directly by the user.
+func (bp *Breakpoint) Internal() bool {
+	return bp.Kind != UserBreakpoint
 }
 
 // NoBreakpointError is returned when trying to

--- a/proc/proc_test.go
+++ b/proc/proc_test.go
@@ -138,7 +138,7 @@ func setFunctionBreakpoint(p *Process, fname string) (*Breakpoint, error) {
 	if err != nil {
 		return nil, err
 	}
-	return p.SetBreakpoint(addr)
+	return p.SetBreakpoint(addr, UserBreakpoint, nil)
 }
 
 func TestHalt(t *testing.T) {
@@ -188,7 +188,7 @@ func TestStep(t *testing.T) {
 		helloworldfunc := p.goSymTable.LookupFunc("main.helloworld")
 		helloworldaddr := helloworldfunc.Entry
 
-		_, err := p.SetBreakpoint(helloworldaddr)
+		_, err := p.SetBreakpoint(helloworldaddr, UserBreakpoint, nil)
 		assertNoError(err, t, "SetBreakpoint()")
 		assertNoError(p.Continue(), t, "Continue()")
 
@@ -210,7 +210,7 @@ func TestBreakpoint(t *testing.T) {
 		helloworldfunc := p.goSymTable.LookupFunc("main.helloworld")
 		helloworldaddr := helloworldfunc.Entry
 
-		bp, err := p.SetBreakpoint(helloworldaddr)
+		bp, err := p.SetBreakpoint(helloworldaddr, UserBreakpoint, nil)
 		assertNoError(err, t, "SetBreakpoint()")
 		assertNoError(p.Continue(), t, "Continue()")
 
@@ -237,7 +237,7 @@ func TestBreakpointInSeperateGoRoutine(t *testing.T) {
 			t.Fatal("No fn exists")
 		}
 
-		_, err := p.SetBreakpoint(fn.Entry)
+		_, err := p.SetBreakpoint(fn.Entry, UserBreakpoint, nil)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -261,7 +261,7 @@ func TestBreakpointInSeperateGoRoutine(t *testing.T) {
 
 func TestBreakpointWithNonExistantFunction(t *testing.T) {
 	withTestProcess("testprog", t, func(p *Process, fixture protest.Fixture) {
-		_, err := p.SetBreakpoint(0)
+		_, err := p.SetBreakpoint(0, UserBreakpoint, nil)
 		if err == nil {
 			t.Fatal("Should not be able to break at non existant function")
 		}
@@ -271,7 +271,7 @@ func TestBreakpointWithNonExistantFunction(t *testing.T) {
 func TestClearBreakpointBreakpoint(t *testing.T) {
 	withTestProcess("testprog", t, func(p *Process, fixture protest.Fixture) {
 		fn := p.goSymTable.LookupFunc("main.sleepytime")
-		bp, err := p.SetBreakpoint(fn.Entry)
+		bp, err := p.SetBreakpoint(fn.Entry, UserBreakpoint, nil)
 		assertNoError(err, t, "SetBreakpoint()")
 
 		bp, err = p.ClearBreakpoint(fn.Entry)
@@ -324,7 +324,7 @@ func testseq(program string, contFunc contFunc, testcases []nextTest, initialLoc
 			var pc uint64
 			pc, err = p.FindFileLocation(fixture.Source, testcases[0].begin)
 			assertNoError(err, t, "FindFileLocation()")
-			bp, err = p.SetBreakpoint(pc)
+			bp, err = p.SetBreakpoint(pc, UserBreakpoint, nil)
 		}
 		assertNoError(err, t, "SetBreakpoint()")
 		assertNoError(p.Continue(), t, "Continue()")
@@ -579,7 +579,7 @@ func TestFindReturnAddress(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		_, err = p.SetBreakpoint(start)
+		_, err = p.SetBreakpoint(start, UserBreakpoint, nil)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -605,7 +605,7 @@ func TestFindReturnAddressTopOfStackFn(t *testing.T) {
 		if fn == nil {
 			t.Fatalf("could not find function %s", fnName)
 		}
-		if _, err := p.SetBreakpoint(fn.Entry); err != nil {
+		if _, err := p.SetBreakpoint(fn.Entry, UserBreakpoint, nil); err != nil {
 			t.Fatal(err)
 		}
 		if err := p.Continue(); err != nil {
@@ -628,7 +628,7 @@ func TestSwitchThread(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		_, err = p.SetBreakpoint(pc)
+		_, err = p.SetBreakpoint(pc, UserBreakpoint, nil)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -670,7 +670,7 @@ func TestCGONext(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		_, err = p.SetBreakpoint(pc)
+		_, err = p.SetBreakpoint(pc, UserBreakpoint, nil)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -953,7 +953,7 @@ func TestBreakpointOnFunctionEntry(t *testing.T) {
 	withTestProcess("testprog", t, func(p *Process, fixture protest.Fixture) {
 		addr, err := p.FindFunctionLocation("main.main", false, 0)
 		assertNoError(err, t, "FindFunctionLocation()")
-		_, err = p.SetBreakpoint(addr)
+		_, err = p.SetBreakpoint(addr, UserBreakpoint, nil)
 		assertNoError(err, t, "SetBreakpoint()")
 		assertNoError(p.Continue(), t, "Continue()")
 		_, ln := currentLineNumber(p, t)
@@ -977,7 +977,7 @@ func TestIssue239(t *testing.T) {
 	withTestProcess("is sue239", t, func(p *Process, fixture protest.Fixture) {
 		pos, _, err := p.goSymTable.LineToPC(fixture.Source, 17)
 		assertNoError(err, t, "LineToPC()")
-		_, err = p.SetBreakpoint(pos)
+		_, err = p.SetBreakpoint(pos, UserBreakpoint, nil)
 		assertNoError(err, t, fmt.Sprintf("SetBreakpoint(%d)", pos))
 		assertNoError(p.Continue(), t, fmt.Sprintf("Continue()"))
 	})
@@ -1238,7 +1238,7 @@ func TestBreakpointCounts(t *testing.T) {
 	withTestProcess("bpcountstest", t, func(p *Process, fixture protest.Fixture) {
 		addr, _, err := p.goSymTable.LineToPC(fixture.Source, 12)
 		assertNoError(err, t, "LineToPC")
-		bp, err := p.SetBreakpoint(addr)
+		bp, err := p.SetBreakpoint(addr, UserBreakpoint, nil)
 		assertNoError(err, t, "SetBreakpoint()")
 
 		for {
@@ -1289,7 +1289,7 @@ func TestBreakpointCountsWithDetection(t *testing.T) {
 	withTestProcess("bpcountstest", t, func(p *Process, fixture protest.Fixture) {
 		addr, _, err := p.goSymTable.LineToPC(fixture.Source, 12)
 		assertNoError(err, t, "LineToPC")
-		bp, err := p.SetBreakpoint(addr)
+		bp, err := p.SetBreakpoint(addr, UserBreakpoint, nil)
 		assertNoError(err, t, "SetBreakpoint()")
 
 		for {
@@ -1384,7 +1384,7 @@ func TestIssue262(t *testing.T) {
 	withTestProcess("issue262", t, func(p *Process, fixture protest.Fixture) {
 		addr, _, err := p.goSymTable.LineToPC(fixture.Source, 11)
 		assertNoError(err, t, "LineToPC")
-		_, err = p.SetBreakpoint(addr)
+		_, err = p.SetBreakpoint(addr, UserBreakpoint, nil)
 		assertNoError(err, t, "SetBreakpoint()")
 
 		assertNoError(p.Continue(), t, "Continue()")
@@ -1400,12 +1400,13 @@ func TestIssue262(t *testing.T) {
 }
 
 func TestIssue305(t *testing.T) {
-	// If 'next' hits a breakpoint on the goroutine it's stepping through the temp breakpoints aren't cleared
-	// preventing further use of 'next' command
+	// If 'next' hits a breakpoint on the goroutine it's stepping through
+	// the internal breakpoints aren't cleared preventing further use of
+	// 'next' command
 	withTestProcess("issue305", t, func(p *Process, fixture protest.Fixture) {
 		addr, _, err := p.goSymTable.LineToPC(fixture.Source, 5)
 		assertNoError(err, t, "LineToPC()")
-		_, err = p.SetBreakpoint(addr)
+		_, err = p.SetBreakpoint(addr, UserBreakpoint, nil)
 		assertNoError(err, t, "SetBreakpoint()")
 
 		assertNoError(p.Continue(), t, "Continue()")
@@ -1445,7 +1446,7 @@ func TestCondBreakpoint(t *testing.T) {
 	withTestProcess("parallel_next", t, func(p *Process, fixture protest.Fixture) {
 		addr, _, err := p.goSymTable.LineToPC(fixture.Source, 9)
 		assertNoError(err, t, "LineToPC")
-		bp, err := p.SetBreakpoint(addr)
+		bp, err := p.SetBreakpoint(addr, UserBreakpoint, nil)
 		assertNoError(err, t, "SetBreakpoint()")
 		bp.Cond = &ast.BinaryExpr{
 			Op: token.EQL,
@@ -1469,7 +1470,7 @@ func TestCondBreakpointError(t *testing.T) {
 	withTestProcess("parallel_next", t, func(p *Process, fixture protest.Fixture) {
 		addr, _, err := p.goSymTable.LineToPC(fixture.Source, 9)
 		assertNoError(err, t, "LineToPC")
-		bp, err := p.SetBreakpoint(addr)
+		bp, err := p.SetBreakpoint(addr, UserBreakpoint, nil)
 		assertNoError(err, t, "SetBreakpoint()")
 		bp.Cond = &ast.BinaryExpr{
 			Op: token.EQL,
@@ -1549,7 +1550,7 @@ func TestIssue384(t *testing.T) {
 	withTestProcess("issue384", t, func(p *Process, fixture protest.Fixture) {
 		start, _, err := p.goSymTable.LineToPC(fixture.Source, 13)
 		assertNoError(err, t, "LineToPC()")
-		_, err = p.SetBreakpoint(start)
+		_, err = p.SetBreakpoint(start, UserBreakpoint, nil)
 		assertNoError(err, t, "SetBreakpoint()")
 		assertNoError(p.Continue(), t, "Continue()")
 		_, err = evalVariable(p, "st")
@@ -1562,7 +1563,7 @@ func TestIssue332_Part1(t *testing.T) {
 	withTestProcess("issue332", t, func(p *Process, fixture protest.Fixture) {
 		start, _, err := p.goSymTable.LineToPC(fixture.Source, 8)
 		assertNoError(err, t, "LineToPC()")
-		_, err = p.SetBreakpoint(start)
+		_, err = p.SetBreakpoint(start, UserBreakpoint, nil)
 		assertNoError(err, t, "SetBreakpoint()")
 		assertNoError(p.Continue(), t, "Continue()")
 		assertNoError(p.Next(), t, "first Next()")
@@ -1588,7 +1589,7 @@ func TestIssue332_Part2(t *testing.T) {
 	withTestProcess("issue332", t, func(p *Process, fixture protest.Fixture) {
 		start, _, err := p.goSymTable.LineToPC(fixture.Source, 8)
 		assertNoError(err, t, "LineToPC()")
-		_, err = p.SetBreakpoint(start)
+		_, err = p.SetBreakpoint(start, UserBreakpoint, nil)
 		assertNoError(err, t, "SetBreakpoint()")
 		assertNoError(p.Continue(), t, "Continue()")
 
@@ -1639,7 +1640,7 @@ func TestIssue414(t *testing.T) {
 	withTestProcess("math", t, func(p *Process, fixture protest.Fixture) {
 		start, _, err := p.goSymTable.LineToPC(fixture.Source, 9)
 		assertNoError(err, t, "LineToPC()")
-		_, err = p.SetBreakpoint(start)
+		_, err = p.SetBreakpoint(start, UserBreakpoint, nil)
 		assertNoError(err, t, "SetBreakpoint()")
 		assertNoError(p.Continue(), t, "Continue()")
 		for {
@@ -1905,10 +1906,10 @@ func TestUnsupportedArch(t *testing.T) {
 
 func TestIssue573(t *testing.T) {
 	// calls to runtime.duffzero and runtime.duffcopy jump directly into the middle
-	// of the function and the temp breakpoint set by StepInto may be missed.
+	// of the function and the internal breakpoint set by StepInto may be missed.
 	withTestProcess("issue573", t, func(p *Process, fixture protest.Fixture) {
 		f := p.goSymTable.LookupFunc("main.foo")
-		_, err := p.SetBreakpoint(f.Entry)
+		_, err := p.SetBreakpoint(f.Entry, UserBreakpoint, nil)
 		assertNoError(err, t, "SetBreakpoint()")
 		assertNoError(p.Continue(), t, "Continue()")
 		assertNoError(p.Step(), t, "Step() #1")
@@ -2044,7 +2045,7 @@ func TestStepConcurrentDirect(t *testing.T) {
 	withTestProcess("teststepconcurrent", t, func(p *Process, fixture protest.Fixture) {
 		pc, err := p.FindFileLocation(fixture.Source, 37)
 		assertNoError(err, t, "FindFileLocation()")
-		bp, err := p.SetBreakpoint(pc)
+		bp, err := p.SetBreakpoint(pc, UserBreakpoint, nil)
 		assertNoError(err, t, "SetBreakpoint()")
 
 		assertNoError(p.Continue(), t, "Continue()")
@@ -2095,7 +2096,7 @@ func TestStepConcurrentPtr(t *testing.T) {
 	withTestProcess("teststepconcurrent", t, func(p *Process, fixture protest.Fixture) {
 		pc, err := p.FindFileLocation(fixture.Source, 24)
 		assertNoError(err, t, "FindFileLocation()")
-		_, err = p.SetBreakpoint(pc)
+		_, err = p.SetBreakpoint(pc, UserBreakpoint, nil)
 		assertNoError(err, t, "SetBreakpoint()")
 
 		kvals := map[int]int64{}
@@ -2129,7 +2130,7 @@ func TestStepConcurrentPtr(t *testing.T) {
 			assertNoError(p.Step(), t, "Step()")
 			for nextInProgress(p) {
 				if p.SelectedGoroutine.ID == gid {
-					t.Fatalf("step did not step into function call (but temp breakpoints still active?) (%d %d)", gid, p.SelectedGoroutine.ID)
+					t.Fatalf("step did not step into function call (but internal breakpoints still active?) (%d %d)", gid, p.SelectedGoroutine.ID)
 				}
 				assertNoError(p.Continue(), t, "Continue()")
 			}
@@ -2161,7 +2162,7 @@ func TestStepOnCallPtrInstr(t *testing.T) {
 	withTestProcess("teststepprog", t, func(p *Process, fixture protest.Fixture) {
 		pc, err := p.FindFileLocation(fixture.Source, 10)
 		assertNoError(err, t, "FindFileLocation()")
-		_, err = p.SetBreakpoint(pc)
+		_, err = p.SetBreakpoint(pc, UserBreakpoint, nil)
 		assertNoError(err, t, "SetBreakpoint()")
 
 		assertNoError(p.Continue(), t, "Continue()")

--- a/proc/proc_test.go
+++ b/proc/proc_test.go
@@ -1907,3 +1907,30 @@ func TestTestvariables2Prologue(t *testing.T) {
 		}
 	})
 }
+
+func TestNextDeferReturnAndDirectCall(t *testing.T) {
+	// Next should not step into a deferred function if it is called
+	// directly, only if it is called through a panic or a deferreturn.
+	// Here we test the case where the function is called by a deferreturn
+	testnext("defercall", []nextTest{
+		{9, 10},
+		{10, 11},
+		{11, 12},
+		{12, 13},
+		{13, 5},
+		{5, 6},
+		{6, 7},
+		{7, 13},
+		{13, 28}}, "main.callAndDeferReturn", t)
+}
+
+func TestNextPanicAndDirectCall(t *testing.T) {
+	// Next should not step into a deferred function if it is called
+	// directly, only if it is called through a panic or a deferreturn.
+	// Here we test the case where the function is called by a panic
+	testnext("defercall", []nextTest{
+		{15, 16},
+		{16, 17},
+		{17, 18},
+		{18, 5}}, "main.callAndPanic2", t)
+}

--- a/proc/threads.go
+++ b/proc/threads.go
@@ -9,6 +9,7 @@ import (
 	"path/filepath"
 	"reflect"
 	"runtime"
+	"strings"
 
 	"golang.org/x/debug/dwarf"
 )
@@ -145,99 +146,165 @@ func topframe(g *G, thread *Thread) (Stackframe, error) {
 	return frames[0], nil
 }
 
-// Set breakpoints for potential next lines.
-func (dbp *Process) setNextBreakpoints() (err error) {
+// Set breakpoints at every line, and the return address. Also look for
+// a deferred function and set a breakpoint there too.
+// If stepInto is true it will also set breakpoints inside all
+// functions called on the current source line, for non-absolute CALLs
+// a breakpoint of kind StepBreakpoint is set on the CALL instruction,
+// Continue will take care of setting a breakpoint to the destination
+// once the CALL is reached.
+func (dbp *Process) next(stepInto bool) error {
 	topframe, err := topframe(dbp.SelectedGoroutine, dbp.CurrentThread)
 	if err != nil {
 		return err
 	}
 
-	if filepath.Ext(topframe.Current.File) != ".go" {
-		return dbp.cnext(topframe)
+	csource := filepath.Ext(topframe.Current.File) != ".go"
+	thread := dbp.CurrentThread
+	currentGoroutine := false
+	if dbp.SelectedGoroutine != nil && dbp.SelectedGoroutine.thread != nil {
+		thread = dbp.SelectedGoroutine.thread
+		currentGoroutine = true
 	}
 
-	return dbp.next(dbp.SelectedGoroutine, topframe)
-}
+	text, err := thread.Disassemble(topframe.FDE.Begin(), topframe.FDE.End(), currentGoroutine)
+	if err != nil && stepInto {
+		return err
+	}
 
-// Set breakpoints at every line, and the return address. Also look for
-// a deferred function and set a breakpoint there too.
-func (dbp *Process) next(g *G, topframe Stackframe) error {
 	cond := sameGoroutineCondition(dbp.SelectedGoroutine)
 
-	// Disassembles function to find all runtime.deferreturn locations
-	// See documentation of Breakpoint.DeferCond for why this is necessary
-	deferreturns := []uint64{}
-	text, err := dbp.CurrentThread.Disassemble(topframe.FDE.Begin(), topframe.FDE.End(), false)
-	if err == nil {
+	if stepInto {
+		for _, instr := range text {
+			if instr.Loc.File != topframe.Current.File || instr.Loc.Line != topframe.Current.Line || !instr.IsCall() {
+				continue
+			}
+
+			if instr.DestLoc != nil && instr.DestLoc.Fn != nil {
+				if err := dbp.setStepIntoBreakpoint([]AsmInstruction{instr}, cond); err != nil {
+					dbp.ClearTempBreakpoints()
+					return err
+				}
+			} else {
+				// Non-absolute call instruction, set a StepBreakpoint here
+				if _, err := dbp.SetTempBreakpoint(instr.Loc.PC, StepBreakpoint, cond); err != nil {
+					if _, ok := err.(BreakpointExistsError); !ok {
+						dbp.ClearTempBreakpoints()
+						return err
+					}
+				}
+			}
+		}
+	}
+
+	if !csource {
+		deferreturns := []uint64{}
+
+		// Find all runtime.deferreturn locations in the function
+		// See documentation of Breakpoint.DeferCond for why this is necessary
 		for _, instr := range text {
 			if instr.IsCall() && instr.DestLoc != nil && instr.DestLoc.Fn != nil && instr.DestLoc.Fn.Name == "runtime.deferreturn" {
 				deferreturns = append(deferreturns, instr.Loc.PC)
 			}
 		}
-	}
 
-	// Set breakpoint on the most recently deferred function (if any)
-	var deferpc uint64 = 0
-	if g != nil && g.DeferPC != 0 {
-		_, _, deferfn := dbp.goSymTable.PCToLine(g.DeferPC)
-		var err error
-		deferpc, err = dbp.FirstPCAfterPrologue(deferfn, false)
-		if err != nil {
-			return err
-		}
-	}
-	if deferpc != 0 {
-		bp, err := dbp.SetTempBreakpoint(deferpc, cond)
-		if err != nil {
-			if _, ok := err.(BreakpointExistsError); !ok {
-				dbp.ClearTempBreakpoints()
+		// Set breakpoint on the most recently deferred function (if any)
+		var deferpc uint64 = 0
+		if dbp.SelectedGoroutine != nil && dbp.SelectedGoroutine.DeferPC != 0 {
+			_, _, deferfn := dbp.goSymTable.PCToLine(dbp.SelectedGoroutine.DeferPC)
+			var err error
+			deferpc, err = dbp.FirstPCAfterPrologue(deferfn, false)
+			if err != nil {
 				return err
 			}
 		}
-		bp.DeferCond = true
-		bp.DeferReturns = deferreturns
+		if deferpc != 0 && deferpc != topframe.Current.PC {
+			bp, err := dbp.SetTempBreakpoint(deferpc, NextDeferBreakpoint, cond)
+			if err != nil {
+				if _, ok := err.(BreakpointExistsError); !ok {
+					dbp.ClearTempBreakpoints()
+					return err
+				}
+			}
+			if bp != nil {
+				bp.DeferReturns = deferreturns
+			}
+		}
 	}
 
 	// Add breakpoints on all the lines in the current function
 	pcs := dbp.lineInfo.AllPCsBetween(topframe.FDE.Begin(), topframe.FDE.End()-1, topframe.Current.File)
 
-	var covered bool
-	for i := range pcs {
-		if topframe.FDE.Cover(pcs[i]) {
-			covered = true
-			break
+	if !csource {
+		var covered bool
+		for i := range pcs {
+			if topframe.FDE.Cover(pcs[i]) {
+				covered = true
+				break
+			}
 		}
-	}
 
-	if !covered {
-		fn := dbp.goSymTable.PCToFunc(topframe.Ret)
-		if g != nil && fn != nil && fn.Name == "runtime.goexit" {
-			return nil
+		if !covered {
+			fn := dbp.goSymTable.PCToFunc(topframe.Ret)
+			if dbp.SelectedGoroutine != nil && fn != nil && fn.Name == "runtime.goexit" {
+				return nil
+			}
 		}
 	}
 
 	// Add a breakpoint on the return address for the current frame
 	pcs = append(pcs, topframe.Ret)
-	return dbp.setTempBreakpoints(topframe.Current.PC, pcs, cond)
+	return dbp.setTempBreakpoints(topframe.Current.PC, pcs, NextBreakpoint, cond)
 }
 
-// Set a breakpoint at every reachable location, as well as the return address. Without
-// the benefit of an AST we can't be sure we're not at a branching statement and thus
-// cannot accurately predict where we may end up.
-func (dbp *Process) cnext(topframe Stackframe) error {
-	pcs := dbp.lineInfo.AllPCsBetween(topframe.FDE.Begin(), topframe.FDE.End(), topframe.Current.File)
-	pcs = append(pcs, topframe.Ret)
-	return dbp.setTempBreakpoints(topframe.Current.PC, pcs, sameGoroutineCondition(dbp.SelectedGoroutine))
+func (dbp *Process) setStepIntoBreakpoint(text []AsmInstruction, cond ast.Expr) error {
+	if len(text) <= 0 {
+		return nil
+	}
+
+	instr := text[0]
+
+	if instr.DestLoc == nil || instr.DestLoc.Fn == nil {
+		return nil
+	}
+
+	fn := instr.DestLoc.Fn
+
+	// Ensure PC and Entry match, otherwise StepInto is likely to set
+	// its breakpoint before DestLoc.PC and hence run too far ahead.
+	// Calls to runtime.duffzero and duffcopy have this problem.
+	if fn.Entry != instr.DestLoc.PC {
+		return nil
+	}
+
+	// Skip unexported runtime functions
+	if strings.HasPrefix(fn.Name, "runtime.") && !isExportedRuntime(fn.Name) {
+		return nil
+	}
+
+	//TODO(aarzilli): if we want to let users hide functions
+	// or entire packages from being stepped into with 'step'
+	// those extra checks should be done here.
+
+	// Set a breakpoint after the function's prologue
+	pc, _ := dbp.FirstPCAfterPrologue(fn, false)
+	if _, err := dbp.SetTempBreakpoint(pc, NextBreakpoint, cond); err != nil {
+		if _, ok := err.(BreakpointExistsError); !ok {
+			return err
+		}
+	}
+
+	return nil
 }
 
 // setTempBreakpoints sets a breakpoint to all addresses specified in pcs
 // skipping over curpc and curpc-1
-func (dbp *Process) setTempBreakpoints(curpc uint64, pcs []uint64, cond ast.Expr) error {
+func (dbp *Process) setTempBreakpoints(curpc uint64, pcs []uint64, kind BreakpointKind, cond ast.Expr) error {
 	for i := range pcs {
 		if pcs[i] == curpc || pcs[i] == curpc-1 {
 			continue
 		}
-		if _, err := dbp.SetTempBreakpoint(pcs[i], cond); err != nil {
+		if _, err := dbp.SetTempBreakpoint(pcs[i], kind, cond); err != nil {
 			if _, ok := err.(BreakpointExistsError); !ok {
 				dbp.ClearTempBreakpoints()
 				return err
@@ -384,12 +451,18 @@ func (thread *Thread) SetCurrentBreakpoint() error {
 	return nil
 }
 
+func (thread *Thread) clearBreakpointState() {
+	thread.CurrentBreakpoint = nil
+	thread.BreakpointConditionMet = false
+	thread.BreakpointConditionError = nil
+}
+
 func (thread *Thread) onTriggeredBreakpoint() bool {
 	return (thread.CurrentBreakpoint != nil) && thread.BreakpointConditionMet
 }
 
 func (thread *Thread) onTriggeredTempBreakpoint() bool {
-	return thread.onTriggeredBreakpoint() && thread.CurrentBreakpoint.Temp
+	return thread.onTriggeredBreakpoint() && thread.CurrentBreakpoint.Internal()
 }
 
 func (thread *Thread) onRuntimeBreakpoint() bool {
@@ -404,18 +477,20 @@ func (thread *Thread) onRuntimeBreakpoint() bool {
 func (thread *Thread) onNextGoroutine() (bool, error) {
 	var bp *Breakpoint
 	for i := range thread.dbp.Breakpoints {
-		if thread.dbp.Breakpoints[i].Temp {
+		if thread.dbp.Breakpoints[i].Internal() {
 			bp = thread.dbp.Breakpoints[i]
+			break
 		}
 	}
 	if bp == nil {
 		return false, nil
 	}
-	// we just want to check the condition on the goroutine id here
-	dc := bp.DeferCond
-	bp.DeferCond = false
-	defer func() {
-		bp.DeferCond = dc
-	}()
+	if bp.Kind == NextDeferBreakpoint {
+		// we just want to check the condition on the goroutine id here
+		bp.Kind = NextBreakpoint
+		defer func() {
+			bp.Kind = NextDeferBreakpoint
+		}()
+	}
 	return bp.checkCondition(thread)
 }

--- a/service/debugger/debugger.go
+++ b/service/debugger/debugger.go
@@ -120,7 +120,7 @@ func (d *Debugger) Restart() error {
 		if oldBp.ID < 0 {
 			continue
 		}
-		newBp, err := p.SetBreakpoint(oldBp.Addr)
+		newBp, err := p.SetBreakpoint(oldBp.Addr, proc.UserBreakpoint, nil)
 		if err != nil {
 			return err
 		}
@@ -224,7 +224,7 @@ func (d *Debugger) CreateBreakpoint(requestedBp *api.Breakpoint) (*api.Breakpoin
 		return nil, err
 	}
 
-	bp, err := d.process.SetBreakpoint(addr)
+	bp, err := d.process.SetBreakpoint(addr, proc.UserBreakpoint, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -254,7 +254,7 @@ func (d *Debugger) AmendBreakpoint(amend *api.Breakpoint) error {
 }
 
 func (d *Debugger) CancelNext() error {
-	return d.process.ClearTempBreakpoints()
+	return d.process.ClearInternalBreakpoints()
 }
 
 func copyBreakpointInfo(bp *proc.Breakpoint, requested *api.Breakpoint) (err error) {

--- a/service/debugger/debugger.go
+++ b/service/debugger/debugger.go
@@ -167,7 +167,7 @@ func (d *Debugger) state() (*api.DebuggerState, error) {
 	}
 
 	for _, bp := range d.process.Breakpoints {
-		if bp.Temp {
+		if bp.Internal() {
 			state.NextInProgress = true
 			break
 		}
@@ -297,7 +297,7 @@ func (d *Debugger) Breakpoints() []*api.Breakpoint {
 func (d *Debugger) breakpoints() []*api.Breakpoint {
 	bps := []*api.Breakpoint{}
 	for _, bp := range d.process.Breakpoints {
-		if bp.Temp {
+		if bp.Internal() {
 			continue
 		}
 		bps = append(bps, api.ConvertBreakpoint(bp))


### PR DESCRIPTION
Instead of repeatedly calling StepInstruction set breakpoints to the
destination of CALL instructions (or on the CALL instructions
themselves for indirect CALLs), then call Continue.
Calls to unexported runtime functions are skipped.
Reduces the number of code paths managing inferior state from 3 to 2
(StepInstruction, Continue).

Fixes #561

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/derekparker/delve/603)
<!-- Reviewable:end -->
