### PR TITLE
cmd: Support space separate flags for build-flags

### DIFF
--- a/cmd/dlv/cmds/commands.go
+++ b/cmd/dlv/cmds/commands.go
@@ -10,6 +10,7 @@ import (
 	"path/filepath"
 	"runtime"
 	"strconv"
+	"strings"
 	"syscall"
 
 	"github.com/derekparker/delve/config"
@@ -446,7 +447,7 @@ func execute(attachPid int, processArgs []string, conf *config.Config, kind exec
 func gobuild(debugname, pkg string) error {
 	args := []string{"-gcflags", "-N -l", "-o", debugname}
 	if BuildFlags != "" {
-		args = append(args, BuildFlags)
+		args = append(args, strings.Fields(BuildFlags)...)
 	}
 	args = append(args, pkg)
 	return gocommand("build", args...)
@@ -455,7 +456,7 @@ func gobuild(debugname, pkg string) error {
 func gotestbuild(pkg string) error {
 	args := []string{"-gcflags", "-N -l", "-c", "-o", testdebugname}
 	if BuildFlags != "" {
-		args = append(args, BuildFlags)
+		args = append(args, strings.Fields(BuildFlags)...)
 	}
 	args = append(args, pkg)
 	return gocommand("test", args...)


### PR DESCRIPTION
Currently, `dlv` not support multiple build flags such as `-v -x`.
If set `--build-flags='-v -x'`, will occur `flag provided but not defined: -v -x` error from go compiler because append the `-v` and `-x` does not separate by space.
Also, `--build-flags=-v --build-flags=-x` is recognizes `-x` only.

This pull request will split `BuildFlags` variable to `[]string` slice uses `string.Fields`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/derekparker/delve/619)
<!-- Reviewable:end -->
