### PR TITLE
dlv: bugfix: Allow quoting in build flags argument

### DIFF
--- a/_fixtures/buildtest/main.go
+++ b/_fixtures/buildtest/main.go
@@ -1,0 +1,7 @@
+package main
+
+import "fmt"
+
+func main() {
+	fmt.Println("hello world!")
+}

--- a/cmd/dlv/cmds/commands_test.go
+++ b/cmd/dlv/cmds/commands_test.go
@@ -1,0 +1,21 @@
+package cmds
+
+import (
+	"testing"
+)
+
+func TestSplitQuotedFields(t *testing.T) {
+	in := `field'A' 'fieldB' fie'l\'d'C fieldD 'another field' fieldE`
+	tgt := []string{"fieldA", "fieldB", "fiel'dC", "fieldD", "another field", "fieldE"}
+	out := splitQuotedFields(in)
+
+	if len(tgt) != len(out) {
+		t.Fatalf("expected %#v, got %#v (len mismatch)", tgt, out)
+	}
+
+	for i := range tgt {
+		if tgt[i] != out[i] {
+			t.Fatalf(" expected %#v, got %#v (mismatch at %d)", tgt, out, i)
+		}
+	}
+}

--- a/cmd/dlv/dlv_test.go
+++ b/cmd/dlv/dlv_test.go
@@ -1,0 +1,61 @@
+package main
+
+import (
+	"bufio"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"testing"
+
+	protest "github.com/derekparker/delve/proc/test"
+	"github.com/derekparker/delve/service/rpc2"
+)
+
+func assertNoError(err error, t testing.TB, s string) {
+	if err != nil {
+		_, file, line, _ := runtime.Caller(1)
+		fname := filepath.Base(file)
+		t.Fatalf("failed assertion at %s:%d: %s - %s\n", fname, line, s, err)
+	}
+}
+
+func TestBuild(t *testing.T) {
+	const listenAddr = "localhost:40573"
+	cmd := exec.Command("go", "build", "github.com/derekparker/delve/cmd/dlv")
+	assertNoError(cmd.Run(), t, "go build")
+	wd, _ := os.Getwd()
+	dlvbin := filepath.Join(wd, "dlv")
+
+	defer os.Remove(dlvbin)
+
+	fixtures := protest.FindFixturesDir()
+
+	buildtestdir := filepath.Join(fixtures, "buildtest")
+
+	cmd = exec.Command(dlvbin, "debug", "--headless=true", "--listen="+listenAddr, "--api-version=2")
+	cmd.Dir = buildtestdir
+	stdout, err := cmd.StdoutPipe()
+	assertNoError(err, t, "stdout pipe")
+	cmd.Start()
+	defer func() {
+		cmd.Process.Signal(os.Interrupt)
+		cmd.Wait()
+	}()
+
+	scan := bufio.NewScanner(stdout)
+	// wait for the debugger to start
+	scan.Scan()
+	go func() {
+		for scan.Scan() {
+			// keep pipe empty
+		}
+	}()
+
+	client := rpc2.NewClient(listenAddr)
+	state := <-client.Continue()
+
+	if !state.Exited {
+		t.Fatal("Program did not exit")
+	}
+}

--- a/terminal/command_test.go
+++ b/terminal/command_test.go
@@ -13,8 +13,8 @@ import (
 	"github.com/derekparker/delve/proc/test"
 	"github.com/derekparker/delve/service"
 	"github.com/derekparker/delve/service/api"
-	"github.com/derekparker/delve/service/rpccommon"
 	"github.com/derekparker/delve/service/rpc2"
+	"github.com/derekparker/delve/service/rpccommon"
 )
 
 type FakeTerminal struct {


### PR DESCRIPTION
Allows quoted substrings in build-flags flag. This fixes a build
problem on windows where the default build flags must contain a space.

Fixes #634 and #638

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/derekparker/delve/639)
<!-- Reviewable:end -->
