### PR TITLE
debugger/locations: prioritize exact matches of function names

### DIFF
--- a/_fixtures/locationsprog3.go
+++ b/_fixtures/locationsprog3.go
@@ -1,0 +1,12 @@
+package main
+
+import (
+	"fmt"
+	"math/rand"
+	"runtime"
+)
+
+func main() {
+	runtime.Breakpoint()
+	fmt.Println(rand.Intn(10))
+}

--- a/service/debugger/locations.go
+++ b/service/debugger/locations.go
@@ -346,9 +346,13 @@ func (loc *NormalLocationSpec) Find(d *Debugger, scope *proc.EvalScope, locStr s
 				continue
 			}
 			if loc.FuncBase.Match(f.Sym) {
-				candidates = append(candidates, f.Name)
-				if len(candidates) >= maxFindLocationCandidates {
+				if loc.Base == f.Name {
+					// if an exact match for the function name is found use it
+					candidates = []string{f.Name}
 					break
+				}
+				if len(candidates) < maxFindLocationCandidates {
+					candidates = append(candidates, f.Name)
 				}
 			}
 		}

--- a/service/test/integration2_test.go
+++ b/service/test/integration2_test.go
@@ -666,6 +666,18 @@ func TestClientServer_FindLocationsAddr(t *testing.T) {
 	})
 }
 
+func TestClientServer_FindLocationsExactMatch(t *testing.T) {
+	// if an expression matches multiple functions but one of them is an exact
+	// match it should be used anyway.
+	// In this example "math/rand.Intn" would normally match "math/rand.Intn"
+	// and "math/rand.(*Rand).Intn" but since the first match is exact it
+	// should be prioritized.
+	withTestClient2("locationsprog3", t, func(c service.Client) {
+		<-c.Continue()
+		findLocationHelper(t, c, "math/rand.Intn", false, 1, 0)
+	})
+}
+
 func TestClientServer_EvalVariable(t *testing.T) {
 	withTestClient2("testvariables", t, func(c service.Client) {
 		state := <-c.Continue()


### PR DESCRIPTION
If the location specification matches the name of a function exactly
return that function as a match event if the expression matches other
functions as well.

Without this some functions, like math/rand.Intn are unmatchable.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/derekparker/delve/651)
<!-- Reviewable:end -->
