### PR TITLE
proc/variables: extend sign of read negative integers.

### DIFF
--- a/_fixtures/testvariables2.go
+++ b/_fixtures/testvariables2.go
@@ -203,11 +203,16 @@ func main() {
 		benchparr[i] = &benchstruct{}
 	}
 
+	ni8 := int8(-5)
+	ni16 := int16(-5)
+	ni32 := int32(-5)
+
 	var amb1 = 1
 	runtime.Breakpoint()
 	for amb1 := 0; amb1 < 10; amb1++ {
 		fmt.Println(amb1)
 	}
+
 	runtime.Breakpoint()
-	fmt.Println(i1, i2, i3, p1, amb1, s1, s3, a1, p2, p3, s2, as1, str1, f1, fn1, fn2, nilslice, nilptr, ch1, chnil, m1, mnil, m2, m3, up1, i4, i5, i6, err1, err2, errnil, iface1, iface2, ifacenil, arr1, parr, cpx1, const1, iface3, iface4, recursive1, recursive1.x, iface5, iface2fn1, iface2fn2, bencharr, benchparr, mapinf, mainMenu, b, b2, sd, anonstruct1, anonstruct2, anoniface1, anonfunc, mapanonstruct1, ifacearr, efacearr)
+	fmt.Println(i1, i2, i3, p1, amb1, s1, s3, a1, p2, p3, s2, as1, str1, f1, fn1, fn2, nilslice, nilptr, ch1, chnil, m1, mnil, m2, m3, up1, i4, i5, i6, err1, err2, errnil, iface1, iface2, ifacenil, arr1, parr, cpx1, const1, iface3, iface4, recursive1, recursive1.x, iface5, iface2fn1, iface2fn2, bencharr, benchparr, mapinf, mainMenu, b, b2, sd, anonstruct1, anonstruct2, anoniface1, anonfunc, mapanonstruct1, ifacearr, efacearr, ni8, ni16, ni32)
 }

--- a/proc/proc_test.go
+++ b/proc/proc_test.go
@@ -2326,3 +2326,28 @@ func TestWorkDir(t *testing.T) {
 		}
 	}, []string{})
 }
+
+func TestNegativeIntEvaluation(t *testing.T) {
+	testcases := []struct {
+		name  string
+		typ   string
+		value interface{}
+	}{
+		{"ni8", "int8", int64(-5)},
+		{"ni16", "int16", int64(-5)},
+		{"ni32", "int32", int64(-5)},
+	}
+	withTestProcess("testvariables2", t, func(p *Process, fixture protest.Fixture) {
+		assertNoError(p.Continue(), t, "Continue()")
+		for _, tc := range testcases {
+			v, err := evalVariable(p, tc.name)
+			assertNoError(err, t, "EvalVariable()")
+			if typ := v.RealType.String(); typ != tc.typ {
+				t.Fatalf("Wrong type for variable %q: %q (expected: %q)", tc.name, typ, tc.typ)
+			}
+			if val, _ := constant.Int64Val(v.Value); val != tc.value {
+				t.Fatalf("Wrong value for variable %q: %v (expected: %v)", tc.name, val, tc.value)
+			}
+		}
+	})
+}

--- a/proc/variables.go
+++ b/proc/variables.go
@@ -1015,11 +1015,11 @@ func readIntRaw(mem memoryReadWriter, addr uintptr, size int64) (int64, error) {
 
 	switch size {
 	case 1:
-		n = int64(val[0])
+		n = int64(int8(val[0]))
 	case 2:
-		n = int64(binary.LittleEndian.Uint16(val))
+		n = int64(int16(binary.LittleEndian.Uint16(val)))
 	case 4:
-		n = int64(binary.LittleEndian.Uint32(val))
+		n = int64(int32(binary.LittleEndian.Uint32(val)))
 	case 8:
 		n = int64(binary.LittleEndian.Uint64(val))
 	}


### PR DESCRIPTION
Since we store all signed integers as int64 the sign bit should be
extended, otherwise we read negative integers as their 2-complement
value.
