### PR TITLE
terminal/commands/bt: don't panic on goroutines with only one stackframe

### DIFF
--- a/terminal/command.go
+++ b/terminal/command.go
@@ -819,6 +819,9 @@ func (c *Commands) sourceCommand(t *Term, args string) error {
 }
 
 func digits(n int) int {
+	if n <= 0 {
+		return 1
+	}
 	return int(math.Floor(math.Log10(float64(n)))) + 1
 }
 

--- a/terminal/command_test.go
+++ b/terminal/command_test.go
@@ -98,3 +98,26 @@ func TestExecuteFile(t *testing.T) {
 		t.Fatalf("Wrong counts break: %d trace: %d\n", breakCount, traceCount)
 	}
 }
+
+func TestDigits(t *testing.T) {
+	var tests = []struct {
+		input, want int
+	}{
+		{1000, 4},
+		{1001, 4},
+		{999, 3},
+		{99, 2},
+		{9, 1},
+		{1, 1},
+		{0, 1},
+		{-1, 1},
+	}
+
+	for _, test := range tests {
+		got := digits(test.input)
+		if got != test.want {
+			t.Errorf("expected digits(%d) = %d, got %d instead\n",
+				test.input, test.want, got)
+		}
+	}
+}


### PR DESCRIPTION
If a goroutine has only one stack frame, like this:

(dlv) bt
0  0x00000000000d0621 in runtime.goexit
   at /usr/local/Cellar/go/1.7.3/libexec/src/runtime/asm_amd64.s:2087

digits() is called with n == 0 and math.Log10 returns -Inf, which later,
after conversion to int, causes panic() in strings.Repeat (because it
tries to allocate huge memory area).

Signed-off-by: Pavel Borzenkov <pavel.borzenkov@gmail.com>