### PR TITLE
proc: support for ver. 10.12.1 the OS formerly known as Mac OS X

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -64,7 +64,7 @@ else
 endif
 
 test-proc-run:
-	go test $(TEST_FLAGS) $(BUILD_FLAGS) -test.run="$(RUN)" $(PREFIX)/proc
+	go test $(TEST_FLAGS) $(BUILD_FLAGS) -test.v -test.run="$(RUN)" $(PREFIX)/proc
 
 test-integration-run:
 	go test $(TEST_FLAGS) $(BUILD_FLAGS) -test.run="$(RUN)" $(PREFIX)/service/test

--- a/proc/exec_darwin.c
+++ b/proc/exec_darwin.c
@@ -97,6 +97,8 @@ fork_exec(char *argv0, char **argv, int size,
 		exit(1);
 	}
 
+	sleep(1);
+
 	// Create the child process.
 	execve(argv0, argv, environ);
 

--- a/proc/proc_darwin.h
+++ b/proc/proc_darwin.h
@@ -36,10 +36,19 @@ int
 thread_count(task_t task);
 
 mach_port_t
-mach_port_wait(mach_port_t, int);
+mach_port_wait(mach_port_t, task_t*, int);
 
 kern_return_t
 mach_send_reply(mach_msg_header_t);
 
 kern_return_t
 raise_exception(mach_port_t, mach_port_t, mach_port_t, exception_type_t);
+
+kern_return_t
+reset_exception_ports(task_t task, mach_port_t *exception_port, mach_port_t *notification_port);
+
+task_t
+get_task_for_pid(int pid);
+
+int
+task_is_valid(task_t task);

--- a/proc/proc_windows.go
+++ b/proc/proc_windows.go
@@ -82,7 +82,7 @@ func Launch(cmd []string, wd string) (*Process, error) {
 			return nil, err
 		}
 	}
-	
+
 	var workingDir *uint16
 	if wd != "" {
 		if workingDir, err = syscall.UTF16PtrFromString(wd); err != nil {

--- a/proc/test/support.go
+++ b/proc/test/support.go
@@ -54,10 +54,13 @@ func BuildFixture(name string) Fixture {
 		// Work-around for https://github.com/golang/go/issues/13154
 		buildFlags = append(buildFlags, "-ldflags=-linkmode internal")
 	}
-	buildFlags = append(buildFlags, "-gcflags=-N -l", "-o", tmpfile, path)
+	buildFlags = append(buildFlags, "-gcflags=-N -l", "-o", tmpfile, name+".go")
+	
+	cmd := exec.Command("go", buildFlags...)
+	cmd.Dir = fixturesDir
 
 	// Build the test binary
-	if err := exec.Command("go", buildFlags...).Run(); err != nil {
+	if err := cmd.Run(); err != nil {
 		fmt.Printf("Error compiling %s: %s\n", path, err)
 		os.Exit(1)
 	}

--- a/proc/variables.go
+++ b/proc/variables.go
@@ -834,7 +834,6 @@ func (v *Variable) setValue(y *Variable) error {
 		imag, _ := constant.Float64Val(constant.Imag(y.Value))
 		err = v.writeComplex(real, imag, v.RealType.Size())
 	default:
-		fmt.Printf("default\n")
 		if t, isptr := v.RealType.(*dwarf.PtrType); isptr {
 			err = v.writeUint(uint64(y.Children[0].Addr), int64(t.ByteSize))
 		} else {


### PR DESCRIPTION
Fixes #645

Works on minimal example, makes delve slower, not tested on versions of OS X before 10.12.1, not tested on 10.12.2, needs printf cleanup, needs gofmt.

If someone wants to finish this instead of me I want nothing more than wash my hands of the undocumented mess that is Mac OS X, OS X or macOS is.