### PR TITLE
proc: load more registers

### DIFF
--- a/Documentation/cli/README.md
+++ b/Documentation/cli/README.md
@@ -29,6 +29,7 @@ Command | Description
 [stack](#stack) | Print stack trace.
 [step](#step) | Single step through program.
 [step-instruction](#step-instruction) | Single step a single cpu instruction.
+[stepout](#stepout) | Step out of the current function.
 [thread](#thread) | Switch to the specified thread.
 [threads](#threads) | Print out info for every traced thread.
 [trace](#trace) | Set tracepoint.
@@ -195,6 +196,10 @@ Aliases: p
 ## regs
 Print contents of CPU registers.
 
+	regs [-a]
+	
+Argument -a shows more registers.
+
 
 ## restart
 Restart process.
@@ -242,6 +247,10 @@ Single step a single cpu instruction.
 
 Aliases: si
 
+## stepout
+Step out of the current function.
+
+
 ## thread
 Switch to the specified thread.
 
@@ -278,3 +287,5 @@ Print package variables.
 	vars [-v] [<regex>]
 
 If regex is specified only package variables with a name matching it will be returned. If -v is specified more information about each package variable will be shown.
+
+

--- a/_fixtures/fputest/fputest.go
+++ b/_fixtures/fputest/fputest.go
@@ -1,0 +1,19 @@
+package main
+
+import "runtime"
+
+func fputestsetup(f64a, f64b, f64c, f64d float64, f32a, f32b, f32c, f32d float32)
+
+func main() {
+	var f64a float64 = 1.1
+	var f64b float64 = 1.2
+	var f64c float64 = 1.3
+	var f64d float64 = 1.4
+	var f32a float32 = 1.5
+	var f32b float32 = 1.6
+	var f32c float32 = 1.7
+	var f32d float32 = 1.8
+
+	fputestsetup(f64a, f64b, f64c, f64d, f32a, f32b, f32c, f32d)
+	runtime.Breakpoint()
+}

--- a/_fixtures/fputest/fputest_amd64.s
+++ b/_fixtures/fputest/fputest_amd64.s
@@ -1,0 +1,56 @@
+TEXT ·fputestsetup(SB),$0-48
+	// setup x87 stack
+	FMOVD f64a+0(FP), F0
+	FMOVD f64b+8(FP), F0
+	FMOVD f64c+16(FP), F0
+	FMOVD f64d+24(FP), F0
+	
+	FMOVF f32a+32(FP), F0
+	FMOVF f32b+36(FP), F0
+	FMOVF f32c+40(FP), F0
+	FMOVF f32d+44(FP), F0
+	
+	// setup SSE registers
+	// XMM0 = { f64b, f64a } = { 1.2, 1.1 }
+	MOVLPS f64a+0(FP), X0
+	MOVHPS f64b+8(FP), X0
+	
+	// XMM1 = { f64d, f64c } = { 1.4, 1.3 }
+	MOVLPS f64c+16(FP), X1
+	MOVHPS f64d+24(FP), X1
+	
+	// XMM2 = { f32d, f32c, f32b, f32a } = { 1.8, 1.7, 1.6, 1.5 }
+	MOVQ f32a+32(FP), AX
+	MOVQ AX, X2
+	MOVQ f32c+40(FP), AX
+	MOVQ AX, X3
+	PUNPCKLQDQ X3, X2
+	
+	// XMM3 = { f64a, f64b } = { 1.1, 1.2 }
+	MOVLPS f64b+8(FP), X3
+	MOVHPS f64a+0(FP), X3
+	
+	// XMM4 = { f64c, f64d } = { 1.3, 1.4 }
+	MOVLPS f64d+24(FP), X4
+	MOVHPS f64c+16(FP), X4
+	
+	// XMM5 = { f32b, f32a, f32d, f32c } = { 1.6, 1.5, 1.8, 1.7 }
+	MOVQ f32c+40(FP), AX
+	MOVQ AX, X5
+	MOVQ f32a+32(FP), AX
+	MOVQ AX, X6
+	PUNPCKLQDQ X6, X5
+	
+	// XMM6 = XMM0 + XMM1 = { f64b+f64d, f64a+f64c } = { 2.6, 2.4 }
+	MOVAPS X0,X6
+	ADDPD X1, X6
+	
+	// XMM7 = XMM0 + XMM3 = { f64b+f64a, f64a+f64b } = { 2.3, 2.3 }
+	MOVAPS X0, X7
+	ADDPD X3, X7
+	
+	// XMM8 = XMM2 + XMM5 = { f32d+f32b, f32c+f32a, f32b+f32d, f32a+f32c } = { 3.4, 3.2, 3.4, 3.2 }
+	MOVAPS X2, X8
+	ADDPS X5, X8
+	
+	RET

--- a/proc/disasm.go
+++ b/proc/disasm.go
@@ -34,7 +34,7 @@ func (thread *Thread) Disassemble(startPC, endPC uint64, currentGoroutine bool) 
 	var curpc uint64
 	var regs Registers
 	if currentGoroutine {
-		regs, _ = thread.Registers()
+		regs, _ = thread.Registers(false)
 		if regs != nil {
 			curpc = regs.PC()
 		}

--- a/proc/disasm_amd64.go
+++ b/proc/disasm_amd64.go
@@ -88,7 +88,7 @@ func (thread *Thread) resolveCallArg(inst *ArchInst, currentGoroutine bool, regs
 		if arg.Segment != 0 {
 			return nil
 		}
-		regs, err := thread.Registers()
+		regs, err := thread.Registers(false)
 		if err != nil {
 			return nil
 		}

--- a/proc/proc.go
+++ b/proc/proc.go
@@ -689,7 +689,7 @@ func (dbp *Process) Halt() (err error) {
 // Registers obtains register values from the
 // "current" thread of the traced process.
 func (dbp *Process) Registers() (Registers, error) {
-	return dbp.CurrentThread.Registers()
+	return dbp.CurrentThread.Registers(false)
 }
 
 // PC returns the PC of the current thread.

--- a/proc/proc_test.go
+++ b/proc/proc_test.go
@@ -163,7 +163,7 @@ func TestHalt(t *testing.T) {
 			if th.running != false {
 				t.Fatal("expected running = false for thread", th.ID)
 			}
-			_, err := th.Registers()
+			_, err := th.Registers(false)
 			assertNoError(err, t, "Registers")
 		}
 		go func() {
@@ -189,7 +189,7 @@ func TestHalt(t *testing.T) {
 			if th.running != false {
 				t.Fatal("expected running = false for thread", th.ID)
 			}
-			_, err := th.Registers()
+			_, err := th.Registers(false)
 			assertNoError(err, t, "Registers")
 		}
 	})
@@ -676,6 +676,9 @@ func TestCGONext(t *testing.T) {
 	if runtime.GOOS == "darwin" && strings.Contains(runtime.Version(), "1.4") {
 		return
 	}
+	if os.Getenv("CGO_ENABLED") == "" {
+		return
+	}
 
 	withTestProcess("cgotest", t, func(p *Process, fixture protest.Fixture) {
 		pc, err := p.FindFunctionLocation("main.main", true, 0)
@@ -893,6 +896,9 @@ func TestGetG(t *testing.T) {
 
 	// On OSX with Go < 1.5 CGO is not supported due to: https://github.com/golang/go/issues/8973
 	if runtime.GOOS == "darwin" && strings.Contains(runtime.Version(), "1.4") {
+		return
+	}
+	if os.Getenv("CGO_ENABLED") == "" {
 		return
 	}
 

--- a/proc/ptrace_linux.go
+++ b/proc/ptrace_linux.go
@@ -1,6 +1,7 @@
 package proc
 
 import (
+	"encoding/binary"
 	"syscall"
 	"unsafe"
 
@@ -48,4 +49,48 @@ func PtracePeekUser(tid int, off uintptr) (uintptr, error) {
 		return 0, err
 	}
 	return val, nil
+}
+
+// PtraceGetRegset returns floating point registers of the specified thread
+// using PTRACE.
+// See amd64_linux_fetch_inferior_registers in gdb/amd64-linux-nat.c.html
+// and amd64_supply_xsave in gdb/amd64-tdep.c.html
+// and Section 13.1 (and following) of Intel® 64 and IA-32 Architectures Software Developer’s Manual, Volume 1: Basic Architecture
+func PtraceGetRegset(tid int) (regset PtraceXsave, err error) {
+	_, _, err = syscall.Syscall6(syscall.SYS_PTRACE, sys.PTRACE_GETFPREGS, uintptr(tid), uintptr(0), uintptr(unsafe.Pointer(&regset.PtraceFpRegs)), 0, 0)
+	if err == syscall.Errno(0) {
+		err = nil
+	}
+
+	var xstateargs [_X86_XSTATE_MAX_SIZE]byte
+	iov := sys.Iovec{Base: &xstateargs[0], Len: _X86_XSTATE_MAX_SIZE}
+	_, _, err = syscall.Syscall6(syscall.SYS_PTRACE, sys.PTRACE_GETREGSET, uintptr(tid), _NT_X86_XSTATE, uintptr(unsafe.Pointer(&iov)), 0, 0)
+	if err != syscall.Errno(0) {
+		return
+	} else {
+		err = nil
+	}
+
+	if _XSAVE_HEADER_START+_XSAVE_HEADER_LEN >= iov.Len {
+		return
+	}
+	xsaveheader := xstateargs[_XSAVE_HEADER_START : _XSAVE_HEADER_START+_XSAVE_HEADER_LEN]
+	xstate_bv := binary.LittleEndian.Uint64(xsaveheader[0:8])
+	xcomp_bv := binary.LittleEndian.Uint64(xsaveheader[8:16])
+
+	if xcomp_bv&(1<<63) != 0 {
+		// compact format not supported
+		return
+	}
+
+	if xstate_bv&(1<<2) == 0 {
+		// AVX state not present
+		return
+	}
+
+	avxstate := xstateargs[_XSAVE_EXTENDED_REGION_START:iov.Len]
+	regset.AvxState = true
+	copy(regset.YmmSpace[:], avxstate[:len(regset.YmmSpace)])
+
+	return
 }

--- a/proc/registers.go
+++ b/proc/registers.go
@@ -1,6 +1,14 @@
 package proc
 
-import "errors"
+import (
+	"bytes"
+	"encoding/binary"
+	"errors"
+	"fmt"
+	"math"
+	"os"
+	"strings"
+)
 
 // Registers is an interface for a generic register type. The
 // interface encapsulates the generic values / actions
@@ -13,21 +21,210 @@ type Registers interface {
 	TLS() uint64
 	Get(int) (uint64, error)
 	SetPC(*Thread, uint64) error
-	String() string
+	Slice() []Register
+}
+
+type Register struct {
+	Name  string
+	Value string
+}
+
+func appendWordReg(regs []Register, name string, value uint16) []Register {
+	return append(regs, Register{name, fmt.Sprintf("%#04x", value)})
+}
+
+func appendDwordReg(regs []Register, name string, value uint32) []Register {
+	return append(regs, Register{name, fmt.Sprintf("%#08x", value)})
+}
+
+func appendQwordReg(regs []Register, name string, value uint64) []Register {
+	return append(regs, Register{name, fmt.Sprintf("%#016x", value)})
+}
+
+func appendFlagReg(regs []Register, name string, value uint64, descr flagRegisterDescr, size int) []Register {
+	return append(regs, Register{name, descr.Describe(value, size)})
+}
+
+func appendX87Reg(regs []Register, index int, exponent uint16, mantissa uint64) []Register {
+	var f float64
+	fset := false
+
+	const (
+		_SIGNBIT    = 1 << 15
+		_EXP_BIAS   = (1 << 14) - 1 // 2^(n-1) - 1 = 16383
+		_SPECIALEXP = (1 << 15) - 1 // all bits set
+		_HIGHBIT    = 1 << 63
+		_QUIETBIT   = 1 << 62
+	)
+
+	sign := 1.0
+	if exponent&_SIGNBIT != 0 {
+		sign = -1.0
+	}
+	exponent &= ^uint16(_SIGNBIT)
+
+	NaN := math.NaN()
+	Inf := math.Inf(+1)
+
+	switch exponent {
+	case 0:
+		switch {
+		case mantissa == 0:
+			f = sign * 0.0
+			fset = true
+		case mantissa&_HIGHBIT != 0:
+			f = NaN
+			fset = true
+		}
+	case _SPECIALEXP:
+		switch {
+		case mantissa&_HIGHBIT == 0:
+			f = sign * Inf
+			fset = true
+		default:
+			f = NaN // signaling NaN
+			fset = true
+		}
+	default:
+		if mantissa&_HIGHBIT == 0 {
+			f = NaN
+			fset = true
+		}
+	}
+
+	if !fset {
+		significand := float64(mantissa) / (1 << 63)
+		f = sign * math.Ldexp(significand, int(exponent-_EXP_BIAS))
+	}
+
+	return append(regs, Register{fmt.Sprintf("ST(%d)", index), fmt.Sprintf("%#04x%016x\t%g", exponent, mantissa, f)})
+}
+
+func appendSSEReg(regs []Register, name string, xmm []byte) []Register {
+	buf := bytes.NewReader(xmm)
+
+	var out bytes.Buffer
+	var vi [16]uint8
+	for i := range vi {
+		binary.Read(buf, binary.LittleEndian, &vi[i])
+	}
+
+	fmt.Fprintf(&out, "0x%02x%02x%02x%02x%02x%02x%02x%02x%02x%02x%02x%02x%02x%02x%02x%02x", vi[15], vi[14], vi[13], vi[12], vi[11], vi[10], vi[9], vi[8], vi[7], vi[6], vi[5], vi[4], vi[3], vi[2], vi[1], vi[0])
+
+	fmt.Fprintf(&out, "\tv2_int={ %02x%02x%02x%02x%02x%02x%02x%02x %02x%02x%02x%02x%02x%02x%02x%02x }", vi[7], vi[6], vi[5], vi[4], vi[3], vi[2], vi[1], vi[0], vi[15], vi[14], vi[13], vi[12], vi[11], vi[10], vi[9], vi[8])
+
+	fmt.Fprintf(&out, "\tv4_int={ %02x%02x%02x%02x %02x%02x%02x%02x %02x%02x%02x%02x %02x%02x%02x%02x }", vi[3], vi[2], vi[1], vi[0], vi[7], vi[6], vi[5], vi[4], vi[11], vi[10], vi[9], vi[8], vi[15], vi[14], vi[13], vi[12])
+
+	fmt.Fprintf(&out, "\tv8_int={ %02x%02x %02x%02x %02x%02x %02x%02x %02x%02x %02x%02x %02x%02x %02x%02x }", vi[1], vi[0], vi[3], vi[2], vi[5], vi[4], vi[7], vi[6], vi[9], vi[8], vi[11], vi[10], vi[13], vi[12], vi[15], vi[14])
+
+	fmt.Fprintf(&out, "\tv16_int={ %02x %02x %02x %02x %02x %02x %02x %02x %02x %02x %02x %02x %02x %02x %02x %02x }", vi[0], vi[1], vi[2], vi[3], vi[4], vi[5], vi[6], vi[7], vi[8], vi[9], vi[10], vi[11], vi[12], vi[13], vi[14], vi[15])
+
+	buf.Seek(0, os.SEEK_SET)
+	var v2 [2]float64
+	for i := range v2 {
+		binary.Read(buf, binary.LittleEndian, &v2[i])
+	}
+	fmt.Fprintf(&out, "\tv2_float={ %g %g }", v2[0], v2[1])
+
+	buf.Seek(0, os.SEEK_SET)
+	var v4 [4]float32
+	for i := range v4 {
+		binary.Read(buf, binary.LittleEndian, &v4[i])
+	}
+	fmt.Fprintf(&out, "\tv4_float={ %g %g %g %g }", v4[0], v4[1], v4[2], v4[3])
+
+	return append(regs, Register{name, out.String()})
 }
 
 var UnknownRegisterError = errors.New("unknown register")
 
 // Registers obtains register values from the debugged process.
-func (t *Thread) Registers() (Registers, error) {
-	return registers(t)
+func (t *Thread) Registers(floatingPoint bool) (Registers, error) {
+	return registers(t, floatingPoint)
 }
 
 // PC returns the current PC for this thread.
 func (t *Thread) PC() (uint64, error) {
-	regs, err := t.Registers()
+	regs, err := t.Registers(false)
 	if err != nil {
 		return 0, err
 	}
 	return regs.PC(), nil
+}
+
+type flagRegisterDescr []flagDescr
+type flagDescr struct {
+	name string
+	mask uint64
+}
+
+var mxcsrDescription flagRegisterDescr = []flagDescr{
+	{"FZ", 1 << 15},
+	{"RZ/RN", 1<<14 | 1<<13},
+	{"PM", 1 << 12},
+	{"UM", 1 << 11},
+	{"OM", 1 << 10},
+	{"ZM", 1 << 9},
+	{"DM", 1 << 8},
+	{"IM", 1 << 7},
+	{"DAZ", 1 << 6},
+	{"PE", 1 << 5},
+	{"UE", 1 << 4},
+	{"OE", 1 << 3},
+	{"ZE", 1 << 2},
+	{"DE", 1 << 1},
+	{"IE", 1 << 0},
+}
+
+var eflagsDescription flagRegisterDescr = []flagDescr{
+	{"CF", 1 << 0},
+	{"", 1 << 1},
+	{"PF", 1 << 2},
+	{"AF", 1 << 4},
+	{"ZF", 1 << 6},
+	{"SF", 1 << 7},
+	{"TF", 1 << 8},
+	{"IF", 1 << 9},
+	{"DF", 1 << 10},
+	{"OF", 1 << 11},
+	{"IOPL", 1<<12 | 1<<13},
+	{"NT", 1 << 14},
+	{"RF", 1 << 16},
+	{"VM", 1 << 17},
+	{"AC", 1 << 18},
+	{"VIF", 1 << 19},
+	{"VIP", 1 << 20},
+	{"ID", 1 << 21},
+}
+
+func (descr flagRegisterDescr) Mask() uint64 {
+	var r uint64
+	for _, f := range descr {
+		r = r | f.mask
+	}
+	return r
+}
+
+func (descr flagRegisterDescr) Describe(reg uint64, bitsize int) string {
+	var r []string
+	for _, f := range descr {
+		if f.name == "" {
+			continue
+		}
+		// rbm is f.mask with only the right-most bit set:
+		// 0001 1100 -> 0000 0100
+		rbm := f.mask & -f.mask
+		if rbm == f.mask {
+			if reg&f.mask != 0 {
+				r = append(r, f.name)
+			}
+		} else {
+			x := (reg & f.mask) >> uint64(math.Log2(float64(rbm)))
+			r = append(r, fmt.Sprintf("%s=%x", f.name, x))
+		}
+	}
+	if reg & ^descr.Mask() != 0 {
+		r = append(r, fmt.Sprintf("unknown_flags=%x", reg&^descr.Mask()))
+	}
+	return fmt.Sprintf("%#0*x\t[%s]", bitsize/4, reg, strings.Join(r, " "))
 }

--- a/proc/stack.go
+++ b/proc/stack.go
@@ -50,7 +50,7 @@ func (t *Thread) ReturnAddress() (uint64, error) {
 }
 
 func (t *Thread) stackIterator() (*stackIterator, error) {
-	regs, err := t.Registers()
+	regs, err := t.Registers(false)
 	if err != nil {
 		return nil, err
 	}

--- a/proc/syscall_windows_amd64.go
+++ b/proc/syscall_windows_amd64.go
@@ -22,6 +22,25 @@ type _M128A struct {
 	High int64
 }
 
+type _XMM_SAVE_AREA32 struct {
+	ControlWord    uint16
+	StatusWord     uint16
+	TagWord        byte
+	Reserved1      byte
+	ErrorOpcode    uint16
+	ErrorOffset    uint32
+	ErrorSelector  uint16
+	Reserved2      uint16
+	DataOffset     uint32
+	DataSelector   uint16
+	Reserved3      uint16
+	MxCsr          uint32
+	MxCsr_Mask     uint32
+	FloatRegisters [8]_M128A
+	XmmRegisters   [256]byte
+	Reserved4      [96]byte
+}
+
 type _CONTEXT struct {
 	P1Home uint64
 	P2Home uint64
@@ -67,7 +86,7 @@ type _CONTEXT struct {
 
 	Rip uint64
 
-	FltSave [512]byte
+	FltSave _XMM_SAVE_AREA32
 
 	VectorRegister [26]_M128A
 	VectorControl  uint64

--- a/proc/threads.go
+++ b/proc/threads.go
@@ -316,7 +316,7 @@ func (dbp *Process) setInternalBreakpoints(curpc uint64, pcs []uint64, kind Brea
 
 // SetPC sets the PC for this thread.
 func (thread *Thread) SetPC(pc uint64) error {
-	regs, err := thread.Registers()
+	regs, err := thread.Registers(false)
 	if err != nil {
 		return err
 	}
@@ -324,7 +324,7 @@ func (thread *Thread) SetPC(pc uint64) error {
 }
 
 func (thread *Thread) getGVariable() (*Variable, error) {
-	regs, err := thread.Registers()
+	regs, err := thread.Registers(false)
 	if err != nil {
 		return nil, err
 	}

--- a/proc/threads_darwin.c
+++ b/proc/threads_darwin.c
@@ -51,6 +51,13 @@ get_registers(mach_port_name_t task, x86_thread_state64_t *state) {
 }
 
 kern_return_t
+get_fpu_registers(mach_port_name_t task, x86_float_state64_t *state) {
+	kern_return_t kret;
+	mach_msg_type_number_t stateCount = x86_FLOAT_STATE64_COUNT;
+	return thread_get_state(task, x86_FLOAT_STATE64, (thread_state_t)state, &stateCount);
+}
+
+kern_return_t
 get_identity(mach_port_name_t task, thread_identifier_info_data_t *idinfo) {
 	mach_msg_type_number_t idinfoCount = THREAD_IDENTIFIER_INFO_COUNT;
 	return thread_info(task, THREAD_IDENTIFIER_INFO, (thread_info_t)idinfo, &idinfoCount);

--- a/proc/threads_darwin.h
+++ b/proc/threads_darwin.h
@@ -14,6 +14,9 @@ kern_return_t
 get_registers(mach_port_name_t, x86_thread_state64_t*);
 
 kern_return_t
+get_fpu_registers(mach_port_name_t, x86_float_state64_t *);
+
+kern_return_t
 set_pc(thread_act_t, uint64_t);
 
 kern_return_t

--- a/proc/threads_linux.go
+++ b/proc/threads_linux.go
@@ -82,7 +82,7 @@ func (t *Thread) saveRegisters() (Registers, error) {
 	if err != nil {
 		return nil, fmt.Errorf("could not save register contents")
 	}
-	return &Regs{&t.os.registers}, nil
+	return &Regs{&t.os.registers, nil}, nil
 }
 
 func (t *Thread) restoreRegisters() (err error) {

--- a/service/api/conversions.go
+++ b/service/api/conversions.go
@@ -9,8 +9,8 @@ import (
 	"reflect"
 	"strconv"
 
-	"golang.org/x/debug/dwarf"
 	"github.com/derekparker/delve/proc"
+	"golang.org/x/debug/dwarf"
 )
 
 // ConvertBreakpoint converts from a proc.Breakpoint to
@@ -199,7 +199,7 @@ func ConvertGoroutine(g *proc.G) *Goroutine {
 		CurrentLoc:     ConvertLocation(g.CurrentLoc),
 		UserCurrentLoc: ConvertLocation(g.UserCurrent()),
 		GoStatementLoc: ConvertLocation(g.Go()),
-		ThreadID: tid,
+		ThreadID:       tid,
 	}
 }
 
@@ -253,4 +253,12 @@ func LoadConfigFromProc(cfg *proc.LoadConfig) *LoadConfig {
 		cfg.MaxArrayValues,
 		cfg.MaxStructFields,
 	}
+}
+
+func ConvertRegisters(in []proc.Register) (out []Register) {
+	out = make([]Register, len(in))
+	for i := range in {
+		out[i] = Register{in[i].Name, in[i].Value}
+	}
+	return
 }

--- a/service/api/types.go
+++ b/service/api/types.go
@@ -1,6 +1,7 @@
 package api
 
 import (
+	"bytes"
 	"errors"
 	"fmt"
 	"reflect"
@@ -289,4 +290,26 @@ type SetAPIVersionIn struct {
 }
 
 type SetAPIVersionOut struct {
+}
+
+type Register struct {
+	Name  string
+	Value string
+}
+
+type Registers []Register
+
+func (regs Registers) String() string {
+	maxlen := 0
+	for _, reg := range regs {
+		if n := len(reg.Name); n > maxlen {
+			maxlen = n
+		}
+	}
+
+	var buf bytes.Buffer
+	for _, reg := range regs {
+		fmt.Fprintf(&buf, "%*s = %s\n", maxlen, reg.Name, reg.Value)
+	}
+	return buf.String()
 }

--- a/service/client.go
+++ b/service/client.go
@@ -79,7 +79,7 @@ type Client interface {
 	// ListFunctionArgs lists all arguments to the current function.
 	ListFunctionArgs(scope api.EvalScope, cfg api.LoadConfig) ([]api.Variable, error)
 	// ListRegisters lists registers and their values.
-	ListRegisters() (string, error)
+	ListRegisters(threadID int, includeFp bool) (api.Registers, error)
 
 	// ListGoroutines lists all goroutines.
 	ListGoroutines() ([]*api.Goroutine, error)

--- a/service/debugger/debugger.go
+++ b/service/debugger/debugger.go
@@ -602,19 +602,19 @@ func (d *Debugger) PackageVariables(threadID int, filter string, cfg proc.LoadCo
 }
 
 // Registers returns string representation of the CPU registers.
-func (d *Debugger) Registers(threadID int) (string, error) {
+func (d *Debugger) Registers(threadID int, floatingPoint bool) (api.Registers, error) {
 	d.processMutex.Lock()
 	defer d.processMutex.Unlock()
 
 	thread, found := d.process.Threads[threadID]
 	if !found {
-		return "", fmt.Errorf("couldn't find thread %d", threadID)
+		return nil, fmt.Errorf("couldn't find thread %d", threadID)
 	}
-	regs, err := thread.Registers()
+	regs, err := thread.Registers(floatingPoint)
 	if err != nil {
-		return "", err
+		return nil, err
 	}
-	return regs.String(), err
+	return api.ConvertRegisters(regs.Slice()), err
 }
 
 func convertVars(pv []*proc.Variable) []api.Variable {

--- a/service/rpc1/server.go
+++ b/service/rpc1/server.go
@@ -199,11 +199,11 @@ func (s *RPCServer) ListRegisters(arg interface{}, registers *string) error {
 		return err
 	}
 
-	regs, err := s.debugger.Registers(state.CurrentThread.ID)
+	regs, err := s.debugger.Registers(state.CurrentThread.ID, false)
 	if err != nil {
 		return err
 	}
-	*registers = regs
+	*registers = regs.String()
 	return nil
 }
 

--- a/service/rpc2/client.go
+++ b/service/rpc2/client.go
@@ -105,7 +105,7 @@ func (c *RPCClient) Step() (*api.DebuggerState, error) {
 
 func (c *RPCClient) StepOut() (*api.DebuggerState, error) {
 	var out CommandOut
-	err := c.call("Command", &api.DebuggerCommand{ Name: api.StepOut}, &out)
+	err := c.call("Command", &api.DebuggerCommand{Name: api.StepOut}, &out)
 	return &out.State, err
 }
 
@@ -241,10 +241,10 @@ func (c *RPCClient) ListLocalVariables(scope api.EvalScope, cfg api.LoadConfig) 
 	return out.Variables, err
 }
 
-func (c *RPCClient) ListRegisters() (string, error) {
+func (c *RPCClient) ListRegisters(threadID int, includeFp bool) (api.Registers, error) {
 	out := new(ListRegistersOut)
-	err := c.call("ListRegisters", ListRegistersIn{}, out)
-	return out.Registers, err
+	err := c.call("ListRegisters", ListRegistersIn{ThreadID: threadID, IncludeFp: includeFp}, out)
+	return out.Regs, err
 }
 
 func (c *RPCClient) ListFunctionArgs(scope api.EvalScope, cfg api.LoadConfig) ([]api.Variable, error) {

--- a/service/rpc2/server.go
+++ b/service/rpc2/server.go
@@ -312,24 +312,32 @@ func (s *RPCServer) ListPackageVars(arg ListPackageVarsIn, out *ListPackageVarsO
 }
 
 type ListRegistersIn struct {
+	ThreadID  int
+	IncludeFp bool
 }
 
 type ListRegistersOut struct {
 	Registers string
+	Regs      api.Registers
 }
 
 // ListRegisters lists registers and their values.
 func (s *RPCServer) ListRegisters(arg ListRegistersIn, out *ListRegistersOut) error {
-	state, err := s.debugger.State()
-	if err != nil {
-		return err
+	if arg.ThreadID == 0 {
+		state, err := s.debugger.State()
+		if err != nil {
+			return err
+		}
+		arg.ThreadID = state.CurrentThread.ID
 	}
 
-	regs, err := s.debugger.Registers(state.CurrentThread.ID)
+	regs, err := s.debugger.Registers(arg.ThreadID, arg.IncludeFp)
 	if err != nil {
 		return err
 	}
-	out.Registers = regs
+	out.Regs = regs
+	out.Registers = out.Regs.String()
+
 	return nil
 }
 

--- a/terminal/command.go
+++ b/terminal/command.go
@@ -176,7 +176,11 @@ If regex is specified only local variables with a name matching it will be retur
 	vars [-v] [<regex>]
 
 If regex is specified only package variables with a name matching it will be returned. If -v is specified more information about each package variable will be shown.`},
-		{aliases: []string{"regs"}, cmdFn: regs, helpMsg: "Print contents of CPU registers."},
+		{aliases: []string{"regs"}, cmdFn: regs, helpMsg: `Print contents of CPU registers.
+
+	regs [-a]
+	
+Argument -a shows more registers.`},
 		{aliases: []string{"exit", "quit", "q"}, cmdFn: exitCommand, helpMsg: "Exit the debugger."},
 		{aliases: []string{"list", "ls"}, allowedPrefixes: scopePrefix, cmdFn: listCommand, helpMsg: `Show source code.
 
@@ -963,7 +967,11 @@ func vars(t *Term, ctx callContext, args string) error {
 }
 
 func regs(t *Term, ctx callContext, args string) error {
-	regs, err := t.client.ListRegisters()
+	includeFp := false
+	if args == "-a" {
+		includeFp = true
+	}
+	regs, err := t.client.ListRegisters(0, includeFp)
 	if err != nil {
 		return err
 	}

--- a/terminal/terminal_test.go
+++ b/terminal/terminal_test.go
@@ -1,15 +1,15 @@
 package terminal
 
 import (
-	"testing"
 	"runtime"
+	"testing"
 
 	"github.com/derekparker/delve/config"
 )
 
 type tRule struct {
 	from string
-	to string
+	to   string
 }
 
 type tCase struct {
@@ -66,9 +66,9 @@ func platformCases() []tCase {
 }
 
 func TestSubstitutePath(t *testing.T) {
-	for _, c := range(platformCases()) {
+	for _, c := range platformCases() {
 		var subRules config.SubstitutePathRules
-		for _, r := range(c.rules) {
+		for _, r := range c.rules {
 			subRules = append(subRules, config.SubstitutePathRule{From: r.from, To: r.to})
 		}
 		res := New(nil, &config.Config{SubstitutePath: subRules}).substitutePath(c.path)


### PR DESCRIPTION
Adds ability to load x87, SSE and AVX registers.

Fixes #666 

@derekparker: this does not compile on 1.5.x because I'm using bytes.Buffer.Reset, should I make it compile with 1.5?
@dgryski: congratulations on getting issue 666, is this formatting acceptable:

```
(dlv) regs -a
       Rip = 0x00000000004010fa
       Rsp = 0x000000c420041ed8
       Rax = 0x3fcccccd3fc00000
       Rbx = 0x000000c42001c0b8
       Rcx = 0x000000c4200001a0
       Rdx = 0x0000000000000000
       Rdi = 0x0000000000000000
       Rsi = 0x000000c42001c080
       Rbp = 0x000000c420041f38
        R8 = 0x000000c41ffff1fc
        R9 = 0x0000000000000011
       R10 = 0x00000000ffffffee
       R11 = 0x0000000000000000
       R12 = 0x0000000000000060
       R13 = 0x0000000000000060
       R14 = 0x0000000000000002
       R15 = 0x0000000000000000
  Orig_rax = 0xffffffffffffffff
        Cs = 0x0000000000000033
    Eflags = 0000000000000206	[PF IF IOPL=0]
        Ss = 0x000000000000002b
   Fs_base = 0x0000000000499b48
   Gs_base = 0x0000000000000000
        Ds = 0x0000000000000000
        Es = 0x0000000000000000
        Fs = 0x0000000000000063
        Gs = 0x0000000000000000
        CW = 0x037f
        SW = 0x0000
        TW = 0x00ff
       FOP = 0x0000
       FIP = 0x000000000040117c
       FDP = 0x000000c420041f04
     ST(0) = 0x3fffe666660000000000	1.7999999523162842
     ST(1) = 0x3fffd9999a0000000000	1.7000000476837158
     ST(2) = 0x3fffcccccd0000000000	1.600000023841858
     ST(3) = 0x3fffc000000000000000	1.5
     ST(4) = 0x3fffb333333333333000	1.4
     ST(5) = 0x3fffa666666666666800	1.3
     ST(6) = 0x3fff9999999999999800	1.2
     ST(7) = 0x3fff8cccccccccccd000	1.1
     MXCSR = 00001fa0	[RZ/RN=0 PM UM OM ZM DM IM PE]
MXCSR_MASK = 0x0000ffff
      XMM0 = 0x3ff3 3333 3333 3333 3ff1 9999 9999 999a	v2={ 1.2 1.1 }	v4={ 1.9 4.172325e-08 1.8874999 -1.5881868e-23 }
      XMM1 = 0x3ff6 6666 6666 6666 3ff4 cccc cccc cccd	v2={ 1.4 1.3 }	v4={ 1.925 2.720083e+23 1.9124999 -1.07374184e+08 }
      XMM2 = 0x3fe6 6666 3fd9 999a 3fcc cccd 3fc0 0000	v2={ 0.6999999281950295 0.22500005352776498 }	v4={ 1.8 1.7 1.6 1.5 }
      XMM3 = 0x3ff1 9999 9999 999a 3ff3 3333 3333 3333	v2={ 1.1 1.2 }	v4={ 1.8874999 -1.5881868e-23 1.9 4.172325e-08 }
      XMM4 = 0x3ff4 cccc cccc cccd 3ff6 6666 6666 6666	v2={ 1.3 1.4 }	v4={ 1.9124999 -1.07374184e+08 1.925 2.720083e+23 }
      XMM5 = 0x3fcc cccd 3fc0 0000 3fe6 6666 3fd9 999a	v2={ 0.22500005352776498 0.6999999281950295 }	v4={ 1.6 1.5 1.8 1.7 }
      XMM6 = 0x4004 cccc cccc cccc 4003 3333 3333 3334	v2={ 2.5999999999999996 2.4000000000000004 }	v4={ 2.0749998 -1.0737418e+08 2.05 4.1723254e-08 }
      XMM7 = 0x4002 6666 6666 6666 4002 6666 6666 6666	v2={ 2.3 2.3 }	v4={ 2.0375 2.720083e+23 2.0375 2.720083e+23 }
      XMM8 = 0x4059 999a 404c cccd 4059 999a 404c cccd	v2={ 102.40003974437714 102.40003974437714 }	v4={ 3.4 3.2 3.4 3.2 }
      XMM9 = 0x0000 0000 0042 46e6 0000 00c4 2004 6fa0	v2={ 2.145987e-317 4.16176568138e-312 }	v4={ 0 6.086576e-39 2.75e-43 1.1217769e-19 }
     XMM10 = 0x0000 0000 0000 0000 0000 0000 0046 eec8	v2={ 0 2.2967373e-317 }	v4={ 0 0 0 6.514143e-39 }
     XMM11 = 0x0000 0000 0000 0000 0000 0000 0000 0000	v2={ 0 0 }	v4={ 0 0 0 0 }
     XMM12 = 0x0000 0000 0000 0000 0000 0000 0000 0000	v2={ 0 0 }	v4={ 0 0 0 0 }
     XMM13 = 0x0000 00c4 2000 01a0 0000 0000 0000 0000	v2={ 4.161764247086e-312 0 }	v4={ 2.75e-43 1.084256e-19 0 0 }
     XMM14 = 0x0000 0000 0000 0000 0000 00c4 2000 01a0	v2={ 0 4.161764247086e-312 }	v4={ 0 0 2.75e-43 1.084256e-19 }
     XMM15 = 0x0000 0000 0000 0000 0000 0000 0044 c2a1	v2={ 0 2.2263947e-317 }	v4={ 0 0 0 6.314633e-39 }
```

(regiser setup [here](https://github.com/aarzilli/delve/blob/fpregs/_fixtures/fputest/fputest_amd64.s))