### PR TITLE
Two bugfixes regarding stale executable files, and executables changing between restarts

### DIFF
--- a/proc/proc_darwin.go
+++ b/proc/proc_darwin.go
@@ -336,22 +336,22 @@ func (dbp *Process) parseDebugLineInfo(exe *macho.File, wg *sync.WaitGroup) {
 
 var UnsupportedArchErr = errors.New("unsupported architecture - only darwin/amd64 is supported")
 
-func (dbp *Process) findExecutable(path string) (*macho.File, error) {
+func (dbp *Process) findExecutable(path string) (*macho.File, string, error) {
 	if path == "" {
 		path = C.GoString(C.find_executable(C.int(dbp.Pid)))
 	}
 	exe, err := macho.Open(path)
 	if err != nil {
-		return nil, err
+		return nil, path, err
 	}
 	if exe.Cpu != macho.CpuAmd64 {
-		return nil, UnsupportedArchErr
+		return nil, path, UnsupportedArchErr
 	}
 	dbp.dwarf, err = exe.DWARF()
 	if err != nil {
-		return nil, err
+		return nil, path, err
 	}
-	return exe, nil
+	return exe, path, nil
 }
 
 func (dbp *Process) trapWait(pid int) (*Thread, error) {

--- a/proc/proc_linux.go
+++ b/proc/proc_linux.go
@@ -173,26 +173,26 @@ func (dbp *Process) updateThreadList() error {
 
 var UnsupportedArchErr = errors.New("unsupported architecture - only linux/amd64 is supported")
 
-func (dbp *Process) findExecutable(path string) (*elf.File, error) {
+func (dbp *Process) findExecutable(path string) (*elf.File, string, error) {
 	if path == "" {
 		path = fmt.Sprintf("/proc/%d/exe", dbp.Pid)
 	}
 	f, err := os.OpenFile(path, 0, os.ModePerm)
 	if err != nil {
-		return nil, err
+		return nil, path, err
 	}
 	elfFile, err := elf.NewFile(f)
 	if err != nil {
-		return nil, err
+		return nil, path, err
 	}
 	if elfFile.Machine != elf.EM_X86_64 {
-		return nil, UnsupportedArchErr
+		return nil, path, UnsupportedArchErr
 	}
 	dbp.dwarf, err = elfFile.DWARF()
 	if err != nil {
-		return nil, err
+		return nil, path, err
 	}
-	return elfFile, nil
+	return elfFile, path, nil
 }
 
 func (dbp *Process) parseDebugFrame(exe *elf.File, wg *sync.WaitGroup) {

--- a/proc/proc_windows.go
+++ b/proc/proc_windows.go
@@ -390,19 +390,19 @@ func (dbp *Process) parseDebugLineInfo(exe *pe.File, wg *sync.WaitGroup) {
 
 var UnsupportedArchErr = errors.New("unsupported architecture of windows/386 - only windows/amd64 is supported")
 
-func (dbp *Process) findExecutable(path string) (*pe.File, error) {
+func (dbp *Process) findExecutable(path string) (*pe.File, string, error) {
 	peFile, err := openExecutablePath(path)
 	if err != nil {
-		return nil, err
+		return nil, path, err
 	}
 	if peFile.Machine != pe.IMAGE_FILE_MACHINE_AMD64 {
-		return nil, UnsupportedArchErr
+		return nil, path, UnsupportedArchErr
 	}
 	dbp.dwarf, err = dwarfFromPE(peFile)
 	if err != nil {
-		return nil, err
+		return nil, path, err
 	}
-	return peFile, nil
+	return peFile, path, nil
 }
 
 func openExecutablePath(path string) (*pe.File, error) {

--- a/service/api/types.go
+++ b/service/api/types.go
@@ -313,3 +313,8 @@ func (regs Registers) String() string {
 	}
 	return buf.String()
 }
+
+type DiscardedBreakpoint struct {
+	Breakpoint *Breakpoint
+	Reason error
+}

--- a/service/client.go
+++ b/service/client.go
@@ -1,6 +1,8 @@
 package service
 
 import (
+	"time"
+
 	"github.com/derekparker/delve/service/api"
 )
 
@@ -9,6 +11,9 @@ import (
 type Client interface {
 	// Returns the pid of the process we are debugging.
 	ProcessPid() int
+
+	// LastModified returns the time that the process' executable was modified.
+	LastModified() time.Time
 
 	// Detach detaches the debugger, optionally killing the process.
 	Detach(killProcess bool) error

--- a/service/client.go
+++ b/service/client.go
@@ -14,7 +14,7 @@ type Client interface {
 	Detach(killProcess bool) error
 
 	// Restarts program.
-	Restart() error
+	Restart() ([]api.DiscardedBreakpoint, error)
 
 	// GetState returns the current debugger state.
 	GetState() (*api.DebuggerState, error)

--- a/service/debugger/debugger.go
+++ b/service/debugger/debugger.go
@@ -11,6 +11,7 @@ import (
 	"runtime"
 	"strings"
 	"sync"
+	"time"
 
 	"github.com/derekparker/delve/proc"
 	"github.com/derekparker/delve/service/api"
@@ -79,6 +80,12 @@ func New(config *Config) (*Debugger, error) {
 // the debugger is debugging.
 func (d *Debugger) ProcessPid() int {
 	return d.process.Pid
+}
+
+// LastModified returns the time that the process' executable was last
+// modified.
+func (d *Debugger) LastModified() time.Time {
+	return d.process.LastModified
 }
 
 // Detach detaches from the target process.

--- a/service/rpc1/server.go
+++ b/service/rpc1/server.go
@@ -36,7 +36,8 @@ func (s *RPCServer) Restart(arg1 interface{}, arg2 *int) error {
 	if s.config.AttachPid != 0 {
 		return errors.New("cannot restart process Delve did not create")
 	}
-	return s.debugger.Restart()
+	_, err := s.debugger.Restart()
+	return err
 }
 
 func (s *RPCServer) State(arg interface{}, state *api.DebuggerState) error {

--- a/service/rpc2/client.go
+++ b/service/rpc2/client.go
@@ -5,6 +5,7 @@ import (
 	"log"
 	"net/rpc"
 	"net/rpc/jsonrpc"
+	"time"
 
 	"github.com/derekparker/delve/service"
 	"github.com/derekparker/delve/service/api"
@@ -35,6 +36,12 @@ func (c *RPCClient) ProcessPid() int {
 	out := new(ProcessPidOut)
 	c.call("ProcessPid", ProcessPidIn{}, out)
 	return out.Pid
+}
+
+func (c *RPCClient) LastModified() time.Time {
+	out := new(LastModifiedOut)
+	c.call("LastModified", LastModifiedIn{}, out)
+	return out.Time
 }
 
 func (c *RPCClient) Detach(kill bool) error {

--- a/service/rpc2/client.go
+++ b/service/rpc2/client.go
@@ -42,9 +42,10 @@ func (c *RPCClient) Detach(kill bool) error {
 	return c.call("Detach", DetachIn{kill}, out)
 }
 
-func (c *RPCClient) Restart() error {
+func (c *RPCClient) Restart() ([]api.DiscardedBreakpoint, error) {
 	out := new(RestartOut)
-	return c.call("Restart", RestartIn{}, out)
+	err := c.call("Restart", RestartIn{}, out)
+	return out.DiscardedBreakpoints, err
 }
 
 func (c *RPCClient) GetState() (*api.DebuggerState, error) {

--- a/service/rpc2/server.go
+++ b/service/rpc2/server.go
@@ -49,6 +49,7 @@ type RestartIn struct {
 }
 
 type RestartOut struct {
+	DiscardedBreakpoints []api.DiscardedBreakpoint
 }
 
 // Restart restarts program.
@@ -56,7 +57,9 @@ func (s *RPCServer) Restart(arg RestartIn, out *RestartOut) error {
 	if s.config.AttachPid != 0 {
 		return errors.New("cannot restart process Delve did not create")
 	}
-	return s.debugger.Restart()
+	var err error
+	out.DiscardedBreakpoints, err = s.debugger.Restart()
+	return err
 }
 
 type StateIn struct {

--- a/service/rpc2/server.go
+++ b/service/rpc2/server.go
@@ -3,6 +3,7 @@ package rpc2
 import (
 	"errors"
 	"fmt"
+	"time"
 
 	"github.com/derekparker/delve/service"
 	"github.com/derekparker/delve/service/api"
@@ -30,6 +31,18 @@ type ProcessPidOut struct {
 // ProcessPid returns the pid of the process we are debugging.
 func (s *RPCServer) ProcessPid(arg ProcessPidIn, out *ProcessPidOut) error {
 	out.Pid = s.debugger.ProcessPid()
+	return nil
+}
+
+type LastModifiedIn struct {
+}
+
+type LastModifiedOut struct {
+	Time time.Time
+}
+
+func (s *RPCServer) LastModified(arg LastModifiedIn, out *LastModifiedOut) error {
+	out.Time = s.debugger.LastModified()
 	return nil
 }
 

--- a/service/test/integration2_test.go
+++ b/service/test/integration2_test.go
@@ -71,7 +71,7 @@ func TestRestart_afterExit(t *testing.T) {
 		if !state.Exited {
 			t.Fatal("expected initial process to have exited")
 		}
-		if err := c.Restart(); err != nil {
+		if _, err := c.Restart(); err != nil {
 			t.Fatal(err)
 		}
 		if c.ProcessPid() == origPid {
@@ -124,7 +124,7 @@ func TestRestart_duringStop(t *testing.T) {
 		if state.CurrentThread.Breakpoint == nil {
 			t.Fatal("did not hit breakpoint")
 		}
-		if err := c.Restart(); err != nil {
+		if _, err := c.Restart(); err != nil {
 			t.Fatal(err)
 		}
 		if c.ProcessPid() == origPid {

--- a/terminal/command.go
+++ b/terminal/command.go
@@ -1270,6 +1270,12 @@ func printfile(t *Term, filename string, line int, showArrow bool) error {
 	}
 	defer file.Close()
 
+	fi, _ := file.Stat()
+	lastModExe := t.client.LastModified()
+	if fi.ModTime().After(lastModExe) {
+		fmt.Println("Warning: listing may not match stale executable")
+	}
+
 	buf := bufio.NewScanner(file)
 	l := line
 	for i := 1; i < l-5; i++ {

--- a/terminal/command.go
+++ b/terminal/command.go
@@ -568,10 +568,14 @@ func writeGoroutineLong(w io.Writer, g *api.Goroutine, prefix string) {
 }
 
 func restart(t *Term, ctx callContext, args string) error {
-	if err := t.client.Restart(); err != nil {
+	discarded, err := t.client.Restart()
+	if err != nil {
 		return err
 	}
 	fmt.Println("Process restarted with PID", t.client.ProcessPid())
+	for i := range discarded {
+		fmt.Println("Discarded %s at %s: %v\n", formatBreakpointName(discarded[i].Breakpoint, false), formatBreakpointLocation(discarded[i].Breakpoint), discarded[i].Reason)
+	}
 	return nil
 }
 


### PR DESCRIPTION
service/debugger: Restore breakpoints using file:line on restart

Restoring by address can cause the breakpoint to be inserted in the
middle of an instruction if the executable file has changed.

terminal: Warn of stale executable when printing source