### PR TITLE
Trace optimizations

### DIFF
--- a/_fixtures/traceperf.go
+++ b/_fixtures/traceperf.go
@@ -1,0 +1,18 @@
+package main
+
+func PerfCheck(i, a, b, c int) {
+	x := a - b - c
+	_ = x
+}
+
+func main() {
+	a := 1
+	b := 1
+	c := 1
+	for i := 0; true; i++ {
+		a = a * 2
+		b = -b + i
+		c = i * b
+		PerfCheck(i, a, b, c)
+	}
+}

--- a/dwarf/reader/reader.go
+++ b/dwarf/reader/reader.go
@@ -4,8 +4,8 @@ import (
 	"errors"
 	"fmt"
 
-	"golang.org/x/debug/dwarf"
 	"github.com/derekparker/delve/dwarf/op"
+	"golang.org/x/debug/dwarf"
 )
 
 type Reader struct {

--- a/proc/proc.go
+++ b/proc/proc.go
@@ -534,13 +534,16 @@ func (dbp *Process) StepOut() error {
 
 	var deferpc uint64 = 0
 	if filepath.Ext(topframe.Current.File) == ".go" {
-		if dbp.SelectedGoroutine != nil && dbp.SelectedGoroutine.DeferPC != 0 {
-			_, _, deferfn := dbp.goSymTable.PCToLine(dbp.SelectedGoroutine.DeferPC)
-			deferpc, err = dbp.FirstPCAfterPrologue(deferfn, false)
-			if err != nil {
-				return err
+		if dbp.SelectedGoroutine != nil {
+			deferPCEntry := dbp.SelectedGoroutine.DeferPC()
+			if deferPCEntry != 0 {
+				_, _, deferfn := dbp.goSymTable.PCToLine(deferPCEntry)
+				deferpc, err = dbp.FirstPCAfterPrologue(deferfn, false)
+				if err != nil {
+					return err
+				}
+				pcs = append(pcs, deferpc)
 			}
-			pcs = append(pcs, deferpc)
 		}
 	}
 

--- a/proc/proc_linux.go
+++ b/proc/proc_linux.go
@@ -402,6 +402,13 @@ func status(pid int, comm string) rune {
 	return state
 }
 
+// waitFast is like wait but does not handle process-exit correctly
+func (dbp *Process) waitFast(pid int) (int, *sys.WaitStatus, error) {
+	var s sys.WaitStatus
+	wpid, err := sys.Wait4(pid, &s, sys.WALL, nil)
+	return wpid, &s, err
+}
+
 func (dbp *Process) wait(pid, options int) (int, *sys.WaitStatus, error) {
 	var s sys.WaitStatus
 	if (pid != dbp.Pid) || (options != 0) {

--- a/proc/proc_test.go
+++ b/proc/proc_test.go
@@ -2379,3 +2379,20 @@ func TestIssue683(t *testing.T) {
 		}
 	})
 }
+
+// Benchmarks (*Processs).Continue + (*Scope).FunctionArguments
+func BenchmarkTrace(b *testing.B) {
+	withTestProcess("traceperf", b, func(p *Process, fixture protest.Fixture) {
+		_, err := setFunctionBreakpoint(p, "main.PerfCheck")
+		assertNoError(err, b, "setFunctionBreakpoint()")
+		b.ResetTimer()
+		for i := 0; i < b.N; i++ {
+			assertNoError(p.Continue(), b, "Continue()")
+			s, err := p.CurrentThread.Scope()
+			assertNoError(err, b, "Scope()")
+			_, err = s.FunctionArguments(LoadConfig{false, 0, 64, 0, 3})
+			assertNoError(err, b, "FunctionArguments()")
+		}
+		b.StopTimer()
+	})
+}

--- a/proc/threads.go
+++ b/proc/threads.go
@@ -215,12 +215,15 @@ func (dbp *Process) next(stepInto bool) error {
 
 		// Set breakpoint on the most recently deferred function (if any)
 		var deferpc uint64 = 0
-		if dbp.SelectedGoroutine != nil && dbp.SelectedGoroutine.DeferPC != 0 {
-			_, _, deferfn := dbp.goSymTable.PCToLine(dbp.SelectedGoroutine.DeferPC)
-			var err error
-			deferpc, err = dbp.FirstPCAfterPrologue(deferfn, false)
-			if err != nil {
-				return err
+		if dbp.SelectedGoroutine != nil {
+			deferPCEntry := dbp.SelectedGoroutine.DeferPC()
+			if deferPCEntry != 0 {
+				_, _, deferfn := dbp.goSymTable.PCToLine(deferPCEntry)
+				var err error
+				deferpc, err = dbp.FirstPCAfterPrologue(deferfn, false)
+				if err != nil {
+					return err
+				}
 			}
 		}
 		if deferpc != 0 && deferpc != topframe.Current.PC {

--- a/proc/threads_linux.go
+++ b/proc/threads_linux.go
@@ -49,7 +49,7 @@ func (t *Thread) singleStep() (err error) {
 		if err != nil {
 			return err
 		}
-		wpid, status, err := t.dbp.wait(t.ID, 0)
+		wpid, status, err := t.dbp.waitFast(t.ID)
 		if err != nil {
 			return err
 		}

--- a/proc/types.go
+++ b/proc/types.go
@@ -227,10 +227,10 @@ func nameOfRuntimeType(_type *Variable) (typename string, kind int64, err error)
 
 	var tflag int64
 
-	if tflagField := _type.toFieldNamed("tflag"); tflagField != nil && tflagField.Value != nil {
+	if tflagField := _type.loadFieldNamed("tflag"); tflagField != nil && tflagField.Value != nil {
 		tflag, _ = constant.Int64Val(tflagField.Value)
 	}
-	if kindField := _type.toFieldNamed("kind"); kindField != nil && kindField.Value != nil {
+	if kindField := _type.loadFieldNamed("kind"); kindField != nil && kindField.Value != nil {
 		kind, _ = constant.Int64Val(kindField.Value)
 	}
 
@@ -267,7 +267,7 @@ func nameOfRuntimeType(_type *Variable) (typename string, kind int64, err error)
 // to a runtime.slicetype).
 func nameOfNamedRuntimeType(_type *Variable, kind, tflag int64) (typename string, err error) {
 	var strOff int64
-	if strField := _type.toFieldNamed("str"); strField != nil && strField.Value != nil {
+	if strField := _type.loadFieldNamed("str"); strField != nil && strField.Value != nil {
 		strOff, _ = constant.Int64Val(strField.Value)
 	} else {
 		return "", errors.New("could not find str field")
@@ -301,7 +301,7 @@ func nameOfNamedRuntimeType(_type *Variable, kind, tflag int64) (typename string
 	}
 
 	if ut := uncommon(_type, tflag); ut != nil {
-		if pkgPathField := ut.toFieldNamed("pkgpath"); pkgPathField != nil && pkgPathField.Value != nil {
+		if pkgPathField := ut.loadFieldNamed("pkgpath"); pkgPathField != nil && pkgPathField.Value != nil {
 			pkgPathOff, _ := constant.Int64Val(pkgPathField.Value)
 			pkgPath, _, _, err := _type.dbp.resolveNameOff(_type.Addr, uintptr(pkgPathOff))
 			if err != nil {
@@ -324,7 +324,7 @@ func nameOfUnnamedRuntimeType(_type *Variable, kind, tflag int64) (string, error
 	switch reflect.Kind(kind & kindMask) {
 	case reflect.Array:
 		var len int64
-		if lenField := _type.toFieldNamed("len"); lenField != nil && lenField.Value != nil {
+		if lenField := _type.loadFieldNamed("len"); lenField != nil && lenField.Value != nil {
 			len, _ = constant.Int64Val(lenField.Value)
 		}
 		elemname, err := fieldToType(_type, "elem")
@@ -388,10 +388,10 @@ func nameOfFuncRuntimeType(_type *Variable, tflag int64, anonymous bool) (string
 	}
 
 	var inCount, outCount int64
-	if inCountField := _type.toFieldNamed("inCount"); inCountField != nil && inCountField.Value != nil {
+	if inCountField := _type.loadFieldNamed("inCount"); inCountField != nil && inCountField.Value != nil {
 		inCount, _ = constant.Int64Val(inCountField.Value)
 	}
-	if outCountField := _type.toFieldNamed("outCount"); outCountField != nil && outCountField.Value != nil {
+	if outCountField := _type.loadFieldNamed("outCount"); outCountField != nil && outCountField.Value != nil {
 		outCount, _ = constant.Int64Val(outCountField.Value)
 		// only the lowest 15 bits of outCount are used, rest are flags
 		outCount = outCount & (1<<15 - 1)
@@ -489,7 +489,7 @@ func nameOfInterfaceRuntimeType(_type *Variable, kind, tflag int64) (string, err
 					return "", err
 				}
 				var tflag int64
-				if tflagField := typ.toFieldNamed("tflag"); tflagField != nil && tflagField.Value != nil {
+				if tflagField := typ.loadFieldNamed("tflag"); tflagField != nil && tflagField.Value != nil {
 					tflag, _ = constant.Int64Val(tflagField.Value)
 				}
 				methodtype, err = nameOfFuncRuntimeType(typ, tflag, false)


### PR DESCRIPTION
Following up from a mailing list discussion I took some measurements on where the time is spent on a simple Continue()+FunctionArguments() loop and made some optimizations taking the time spent on a single loop iteration from ~40ms to under 1ms.

The bulk of the improvement comes from skipping a time.Sleep in the linux implementation of singleStep, this sleep is needed to work around a quirk of the linux kernel but that particular quirk can not happen when we are stepping over a breakpoint, so it's unnecessary in that case.

The rest of the optimizations have a much smaller impact but cumulate to ~50% of the remaining time.

```
* proc: Added trace benchmark

Results:

BenchmarkTrace-4   	    5000	  36195899 ns/op

* proc/linux: faster single step implementation.

BenchmarkTrace-4   	    5000	   2093271 ns/op

* proc: Cache function debug_info entries to speed up variable lookup.

BenchmarkTrace-4   	    5000	   1864846 ns/op

* proc/variables: Optimize FunctionArguments by prefetching frame

BenchmarkTrace-4   	    5000	   1815795 ns/op

* proc/variables: optimized parseG

BenchmarkTrace-4   	   10000	    712767 ns/op
```