### PR TITLE
service/debugger: bugfix: error values can not be marshalled

### DIFF
--- a/service/api/types.go
+++ b/service/api/types.go
@@ -316,5 +316,5 @@ func (regs Registers) String() string {
 
 type DiscardedBreakpoint struct {
 	Breakpoint *Breakpoint
-	Reason error
+	Reason     string
 }

--- a/service/debugger/debugger.go
+++ b/service/debugger/debugger.go
@@ -135,7 +135,7 @@ func (d *Debugger) Restart() ([]api.DiscardedBreakpoint, error) {
 		if len(oldBp.File) > 0 {
 			oldBp.Addr, err = p.FindFileLocation(oldBp.File, oldBp.Line)
 			if err != nil {
-				discarded = append(discarded, api.DiscardedBreakpoint{oldBp, err})
+				discarded = append(discarded, api.DiscardedBreakpoint{oldBp, err.Error()})
 				continue
 			}
 		}


### PR DESCRIPTION
```
service/debugger: bugfix: error values can not be marshalled

```
