### PR TITLE
proc: Make sure CurrentLoc of G returned by GetG is up to date

### DIFF
--- a/proc/threads.go
+++ b/proc/threads.go
@@ -396,6 +396,9 @@ func (thread *Thread) GetG() (g *G, err error) {
 	g, err = gaddr.parseG()
 	if err == nil {
 		g.thread = thread
+		if loc, err := thread.Location(); err == nil {
+			g.CurrentLoc = *loc
+		}
 	}
 	return
 }


### PR DESCRIPTION
```
proc: Make sure CurrentLoc of G returned by GetG is up to date

We are already doing this in GoroutinesInfo we should be doing it for
GetG. The main consequence of not doing this is that the CurrentLoc of
DebuggerState.SelectedGoroutine is out of date compared to the location
of the thread running it.

```
