### PR TITLE
pkg/proc: fix struct methods to unexported name & format by goimports

### DIFF
--- a/pkg/proc/proc_darwin.go
+++ b/pkg/proc/proc_darwin.go
@@ -175,7 +175,7 @@ func (dbp *Process) Kill() (err error) {
 func (dbp *Process) requestManualStop() (err error) {
 	var (
 		task          = C.mach_port_t(dbp.os.task)
-		thread        = C.mach_port_t(dbp.CurrentThread.os.threadAct)
+		thread        = C.mach_port_t(dbp.currentThread.os.threadAct)
 		exceptionPort = C.mach_port_t(dbp.os.exceptionPort)
 	)
 	kret := C.raise_exception(task, thread, exceptionPort, C.EXC_BREAKPOINT)

--- a/pkg/proc/threads_darwin.go
+++ b/pkg/proc/threads_darwin.go
@@ -5,8 +5,9 @@ package proc
 import "C"
 import (
 	"fmt"
-	sys "golang.org/x/sys/unix"
 	"unsafe"
+
+	sys "golang.org/x/sys/unix"
 )
 
 // WaitStatus is a synonym for the platform-specific WaitStatus
@@ -35,7 +36,7 @@ func (t *Thread) halt() (err error) {
 			return
 		}
 
-		if _, ok := t.dbp.Threads[t.ID]; ok {
+		if _, ok := t.dbp.threads[t.ID]; ok {
 			err = fmt.Errorf("could not suspend thread %d %s", t.ID, errStr)
 			return
 		}
@@ -49,7 +50,7 @@ func (t *Thread) singleStep() error {
 		return fmt.Errorf("could not single step")
 	}
 	for {
-		twthread, err := t.dbp.trapWait(t.dbp.Pid)
+		twthread, err := t.dbp.trapWait(t.dbp.pid)
 		if err != nil {
 			return err
 		}
@@ -69,7 +70,7 @@ func (t *Thread) resume() error {
 	t.running = true
 	// TODO(dp) set flag for ptrace stops
 	var err error
-	t.dbp.execPtraceFunc(func() { err = PtraceCont(t.dbp.Pid, 0) })
+	t.dbp.execPtraceFunc(func() { err = PtraceCont(t.dbp.pid, 0) })
 	if err == nil {
 		return nil
 	}


### PR DESCRIPTION
Currently, can't compile on darwin.
Fixed some variable to unexported name.