### PR TITLE
Fix variable evaluation in multiple packages and display of strings on Windows

### DIFF
--- a/pkg/proc/eval.go
+++ b/pkg/proc/eval.go
@@ -847,6 +847,9 @@ func (scope *EvalScope) evalBinary(node *ast.BinaryExpr) (*Variable, error) {
 
 		r := xv.newVariable("", 0, typ)
 		r.Value = rc
+		if r.Kind == reflect.String {
+			r.Len = xv.Len+yv.Len
+		}
 		return r, nil
 	}
 }

--- a/pkg/proc/variables.go
+++ b/pkg/proc/variables.go
@@ -680,7 +680,7 @@ func (scope *EvalScope) packageVarAddr(name string) (*Variable, error) {
 			continue
 		}
 
-		if n == name {
+		if n == name || strings.HasSuffix(n, "/"+name) {
 			return scope.extractVarInfoFromEntry(entry, reader)
 		}
 	}


### PR DESCRIPTION
Hi,


I've picked up this issue from a user of Gogland and reproduced locally, see: https://youtrack.jetbrains.com/issue/GO-3260
Fairly sure it needs some improvements as it's a major hack but I would need some guidance on the preferred way to continue with this.
Also, after fixing the issue in `variables.go` I've realized that the return value display was more than it needed and thus showing some empty memory. As such, I've added a change to `eval.go` but not sure about it either.

I'll try to improve my contributions in the future, still learning :)
Please let me know how to improve / get this merged.


Thank you.