### PR TITLE
proc: use original PC for Call position

### DIFF
--- a/pkg/proc/stack.go
+++ b/pkg/proc/stack.go
@@ -230,7 +230,7 @@ func (dbp *Process) frameInfo(pc, sp uint64, top bool) (Stackframe, error) {
 	r := Stackframe{Current: Location{PC: pc, File: f, Line: l, Fn: fn}, CFA: cfa, FDE: fde, Ret: binary.LittleEndian.Uint64(data), addrret: uint64(retaddr)}
 	if !top {
 		r.Call.File, r.Call.Line, r.Call.Fn = dbp.PCToLine(pc - 1)
-		r.Call.PC, _, _ = dbp.goSymTable.LineToPC(r.Call.File, r.Call.Line)
+		r.Call.PC = r.Current.PC
 	} else {
 		r.Call = r.Current
 	}


### PR DESCRIPTION
```
proc: use original PC for Call position

The PC we have is relative to the first instruction after the CALL
instruction currently being executed.

Anyone watching a disassembly will understand what's happening if we
report the return PC, but reporting the first PC of the current line is
useless and confusing.

```
