### PR TITLE
Miscellaneous bug fixes on windows

### DIFF
--- a/cmd/dlv/dlv_test.go
+++ b/cmd/dlv/dlv_test.go
@@ -46,9 +46,12 @@ func TestBuild(t *testing.T) {
 	assertNoError(err, t, "stdout pipe")
 	cmd.Start()
 	defer func() {
-		cmd.Process.Signal(os.Interrupt)
 		if runtime.GOOS != "windows" {
+			cmd.Process.Signal(os.Interrupt)
 			cmd.Wait()
+		} else {
+			// sending os.Interrupt on windows is not supported
+			cmd.Process.Kill()
 		}
 	}()
 

--- a/pkg/proc/proc_test.go
+++ b/pkg/proc/proc_test.go
@@ -1861,11 +1861,21 @@ func TestStepParked(t *testing.T) {
 			assertNoError(err, t, "GoroutinesInfo()")
 
 			for _, g := range gs {
-				if g.thread == nil {
+				if g.thread == nil && g.CurrentLoc.Fn != nil && g.CurrentLoc.Fn.Name == "main.sayhi" {
 					parkedg = g
 					break LookForParkedG
 				}
 			}
+		}
+
+		t.Logf("Parked g is: %v\n", parkedg)
+		frames, _ := parkedg.Stacktrace(20)
+		for _, frame := range frames {
+			name := ""
+			if frame.Call.Fn != nil {
+				name = frame.Call.Fn.Name
+			}
+			t.Logf("\t%s:%d in %s (%#x)", frame.Call.File, frame.Call.Line, name, frame.Current.PC)
 		}
 
 		assertNoError(p.SwitchGoroutine(parkedg.ID), t, "SwitchGoroutine()")

--- a/pkg/proc/proc_test.go
+++ b/pkg/proc/proc_test.go
@@ -1119,7 +1119,10 @@ func TestFrameEvaluation(t *testing.T) {
 		for _, g := range gs {
 			frame := -1
 			frames, err := g.Stacktrace(10)
-			assertNoError(err, t, "GoroutineStacktrace()")
+			if err != nil {
+				t.Logf("could not stacktrace goroutine %d: %v\n", g.ID, err)
+				continue
+			}
 			for i := range frames {
 				if frames[i].Call.Fn != nil && frames[i].Call.Fn.Name == "main.agoroutine" {
 					frame = i

--- a/pkg/proc/registers.go
+++ b/pkg/proc/registers.go
@@ -17,6 +17,7 @@ import (
 type Registers interface {
 	PC() uint64
 	SP() uint64
+	BP() uint64
 	CX() uint64
 	TLS() uint64
 	Get(int) (uint64, error)

--- a/pkg/proc/registers_darwin_amd64.go
+++ b/pkg/proc/registers_darwin_amd64.go
@@ -88,6 +88,10 @@ func (r *Regs) SP() uint64 {
 	return r.rsp
 }
 
+func (r *Regs) BP() uint64 {
+	return r.rbp
+}
+
 // CX returns the value of the RCX register.
 func (r *Regs) CX() uint64 {
 	return r.rcx

--- a/pkg/proc/registers_linux_amd64.go
+++ b/pkg/proc/registers_linux_amd64.go
@@ -69,6 +69,10 @@ func (r *Regs) SP() uint64 {
 	return r.regs.Rsp
 }
 
+func (r *Regs) BP() uint64 {
+	return r.regs.Rbp
+}
+
 // CX returns the value of RCX register.
 func (r *Regs) CX() uint64 {
 	return r.regs.Rcx

--- a/pkg/proc/registers_windows_amd64.go
+++ b/pkg/proc/registers_windows_amd64.go
@@ -107,6 +107,10 @@ func (r *Regs) SP() uint64 {
 	return r.rsp
 }
 
+func (r *Regs) BP() uint64 {
+	return r.rbp
+}
+
 // CX returns the value of the RCX register.
 func (r *Regs) CX() uint64 {
 	return r.rcx

--- a/pkg/terminal/command_test.go
+++ b/pkg/terminal/command_test.go
@@ -458,7 +458,7 @@ func TestIssue387(t *testing.T) {
 					t.Fatalf("did not continue to expected position %d", pos)
 				}
 				pos++
-				if pos > 11 {
+				if pos >= 11 {
 					break
 				}
 			}

--- a/service/debugger/debugger.go
+++ b/service/debugger/debugger.go
@@ -13,8 +13,8 @@ import (
 	"sync"
 	"time"
 
-	"github.com/derekparker/delve/pkg/target"
 	"github.com/derekparker/delve/pkg/proc"
+	"github.com/derekparker/delve/pkg/target"
 	"github.com/derekparker/delve/service/api"
 )
 
@@ -750,7 +750,7 @@ func (d *Debugger) convertStacktrace(rawlocs []proc.Stackframe, cfg *proc.LoadCo
 	locations := make([]api.Stackframe, 0, len(rawlocs))
 	for i := range rawlocs {
 		frame := api.Stackframe{Location: api.ConvertLocation(rawlocs[i].Call)}
-		if cfg != nil {
+		if cfg != nil && rawlocs[i].Current.Fn != nil {
 			var err error
 			scope := rawlocs[i].Scope(d.target.CurrentThread())
 			locals, err := scope.LocalVariables(*cfg)

--- a/service/test/integration2_test.go
+++ b/service/test/integration2_test.go
@@ -763,7 +763,7 @@ func TestClientServer_FullStacktrace(t *testing.T) {
 					if arg.Name != "i" {
 						continue
 					}
-					t.Logf("frame %d, variable i is %v\n", arg)
+					t.Logf("frame %v, variable i is %v\n", frame, arg)
 					argn, err := strconv.Atoi(arg.Value)
 					if err == nil {
 						found[argn] = true


### PR DESCRIPTION
## proc/windows: handle delayed events
Sometimes windows will send us events about breakpoints we have
already removed from the code despite the fact that we go to great
lengths to avoid this already.

Change waitForDebugEvent to check that when we receive a breakpoint
event the corresponding memory actually contains an INT 3
instruction, if it doesn't ignore the event and restart the thread.

## proc/stack: use BP when FDE is not available
On Windows we can sometimes encounter threads stopped in locations for
which we do not have entries in debug_frame.

These cases seem to be due to calls to Windows API in the go runtime,
we can still produce a (partial) stack trace in this circumstance by
following frame pointers (starting with BP).

We still prefer debug_frame entries when available since go functions
do not have frame pointers before go1.8.

## proc/test: improve TestStepParked
It was possible for TestStepParked to pick a runtime goroutine and
attempt to step it. Nothing guarantees that a goroutine other than the
ones we are using to run the code would actually ever resume before the
end of the program.

This makes the test more discerning in its choice of goroutines.

## terminal/command_test: improved TestIssue387
The test in question tries to 'next' over a call to wg.Done, this is
not guaranteed to succeed, if the goroutine gets suspended after
wg.Done has notified the waiting group but before returning to
main.dostuff the program could quit before the goroutine is resumed.

*NOTE* this was developed on top of PR #735.