### PR TITLE
proc refactor: split out BinaryInfo implementation

### DIFF
--- a/pkg/proc/arch.go
+++ b/pkg/proc/arch.go
@@ -1,7 +1,5 @@
 package proc
 
-import "runtime"
-
 // Arch defines an interface for representing a
 // CPU architecture.
 type Arch interface {
@@ -19,11 +17,12 @@ type AMD64 struct {
 	breakInstructionLen     int
 	gStructOffset           uint64
 	hardwareBreakpointUsage []bool
+	goos                    string
 }
 
 // AMD64Arch returns an initialized AMD64
 // struct.
-func AMD64Arch() *AMD64 {
+func AMD64Arch(goos string) *AMD64 {
 	var breakInstr = []byte{0xCC}
 
 	return &AMD64{
@@ -31,6 +30,7 @@ func AMD64Arch() *AMD64 {
 		breakInstruction:        breakInstr,
 		breakInstructionLen:     len(breakInstr),
 		hardwareBreakpointUsage: make([]bool, 4),
+		goos: goos,
 	}
 }
 
@@ -38,7 +38,7 @@ func AMD64Arch() *AMD64 {
 // arch struct. The offset is dependent on the Go compiler Version
 // and whether or not the target program was externally linked.
 func (a *AMD64) SetGStructOffset(ver GoVersion, isextld bool) {
-	switch runtime.GOOS {
+	switch a.goos {
 	case "darwin":
 		a.gStructOffset = 0x8a0
 	case "linux":

--- a/pkg/proc/bininfo.go
+++ b/pkg/proc/bininfo.go
@@ -1,0 +1,513 @@
+package proc
+
+import (
+	"debug/gosym"
+	"debug/pe"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"sync"
+	"time"
+
+	"github.com/derekparker/delve/pkg/dwarf/frame"
+	"github.com/derekparker/delve/pkg/dwarf/line"
+	"github.com/derekparker/delve/pkg/dwarf/reader"
+
+	"golang.org/x/debug/dwarf"
+	"golang.org/x/debug/elf"
+	"golang.org/x/debug/macho"
+)
+
+type BinaryInfo struct {
+	lastModified time.Time // Time the executable of this process was last modified
+
+	goos   string
+	closer io.Closer
+
+	// Maps package names to package paths, needed to lookup types inside DWARF info
+	packageMap map[string]string
+
+	arch         Arch
+	dwarf        *dwarf.Data
+	frameEntries frame.FrameDescriptionEntries
+	lineInfo     line.DebugLines
+	goSymTable   *gosym.Table
+	types        map[string]dwarf.Offset
+	functions    []functionDebugInfo
+
+	loadModuleDataOnce sync.Once
+	moduleData         []moduleData
+	nameOfRuntimeType  map[uintptr]nameOfRuntimeTypeEntry
+}
+
+var UnsupportedLinuxArchErr = errors.New("unsupported architecture - only linux/amd64 is supported")
+var UnsupportedWindowsArchErr = errors.New("unsupported architecture of windows/386 - only windows/amd64 is supported")
+var UnsupportedDarwinArchErr = errors.New("unsupported architecture - only darwin/amd64 is supported")
+
+func NewBinaryInfo(goos, goarch string) BinaryInfo {
+	r := BinaryInfo{goos: goos, nameOfRuntimeType: make(map[uintptr]nameOfRuntimeTypeEntry)}
+
+	// TODO: find better way to determine proc arch (perhaps use executable file info)
+	switch goarch {
+	case "amd64":
+		r.arch = AMD64Arch(goos)
+	}
+
+	return r
+}
+
+func (bininfo *BinaryInfo) LoadBinaryInfo(path string, wg *sync.WaitGroup) error {
+	fi, err := os.Stat(path)
+	if err == nil {
+		bininfo.lastModified = fi.ModTime()
+	}
+
+	switch bininfo.goos {
+	case "linux":
+		return bininfo.LoadBinaryInfoElf(path, wg)
+	case "windows":
+		return bininfo.LoadBinaryInfoPE(path, wg)
+	case "darwin":
+		return bininfo.LoadBinaryInfoMacho(path, wg)
+	}
+	return errors.New("unsupported operating system")
+}
+
+func (bi *BinaryInfo) LastModified() time.Time {
+	return bi.lastModified
+}
+
+// DwarfReader returns a reader for the dwarf data
+func (bi *BinaryInfo) DwarfReader() *reader.Reader {
+	return reader.New(bi.dwarf)
+}
+
+// Sources returns list of source files that comprise the debugged binary.
+func (bi *BinaryInfo) Sources() map[string]*gosym.Obj {
+	return bi.goSymTable.Files
+}
+
+// Funcs returns list of functions present in the debugged program.
+func (bi *BinaryInfo) Funcs() []gosym.Func {
+	return bi.goSymTable.Funcs
+}
+
+// Types returns list of types present in the debugged program.
+func (bi *BinaryInfo) Types() ([]string, error) {
+	types := make([]string, 0, len(bi.types))
+	for k := range bi.types {
+		types = append(types, k)
+	}
+	return types, nil
+}
+
+// PCToLine converts an instruction address to a file/line/function.
+func (bi *BinaryInfo) PCToLine(pc uint64) (string, int, *gosym.Func) {
+	return bi.goSymTable.PCToLine(pc)
+}
+
+func (bi *BinaryInfo) Close() error {
+	return bi.closer.Close()
+}
+
+// ELF ///////////////////////////////////////////////////////////////
+
+func (bi *BinaryInfo) LoadBinaryInfoElf(path string, wg *sync.WaitGroup) error {
+	exe, err := os.OpenFile(path, 0, os.ModePerm)
+	if err != nil {
+		return err
+	}
+	bi.closer = exe
+	elfFile, err := elf.NewFile(exe)
+	if err != nil {
+		return err
+	}
+	if elfFile.Machine != elf.EM_X86_64 {
+		return UnsupportedLinuxArchErr
+	}
+	bi.dwarf, err = elfFile.DWARF()
+	if err != nil {
+		return err
+	}
+
+	wg.Add(4)
+	go bi.parseDebugFrameElf(elfFile, wg)
+	go bi.obtainGoSymbolsElf(elfFile, wg)
+	go bi.parseDebugLineInfoElf(elfFile, wg)
+	go bi.loadDebugInfoMaps(wg)
+	return nil
+}
+
+func (bi *BinaryInfo) parseDebugFrameElf(exe *elf.File, wg *sync.WaitGroup) {
+	defer wg.Done()
+
+	debugFrameSec := exe.Section(".debug_frame")
+	debugInfoSec := exe.Section(".debug_info")
+
+	if debugFrameSec != nil && debugInfoSec != nil {
+		debugFrame, err := exe.Section(".debug_frame").Data()
+		if err != nil {
+			fmt.Println("could not get .debug_frame section", err)
+			os.Exit(1)
+		}
+		dat, err := debugInfoSec.Data()
+		if err != nil {
+			fmt.Println("could not get .debug_info section", err)
+			os.Exit(1)
+		}
+		bi.frameEntries = frame.Parse(debugFrame, frame.DwarfEndian(dat))
+	} else {
+		fmt.Println("could not find .debug_frame section in binary")
+		os.Exit(1)
+	}
+}
+
+func (bi *BinaryInfo) obtainGoSymbolsElf(exe *elf.File, wg *sync.WaitGroup) {
+	defer wg.Done()
+
+	var (
+		symdat  []byte
+		pclndat []byte
+		err     error
+	)
+
+	if sec := exe.Section(".gosymtab"); sec != nil {
+		symdat, err = sec.Data()
+		if err != nil {
+			fmt.Println("could not get .gosymtab section", err)
+			os.Exit(1)
+		}
+	}
+
+	if sec := exe.Section(".gopclntab"); sec != nil {
+		pclndat, err = sec.Data()
+		if err != nil {
+			fmt.Println("could not get .gopclntab section", err)
+			os.Exit(1)
+		}
+	}
+
+	pcln := gosym.NewLineTable(pclndat, exe.Section(".text").Addr)
+	tab, err := gosym.NewTable(symdat, pcln)
+	if err != nil {
+		fmt.Println("could not get initialize line table", err)
+		os.Exit(1)
+	}
+
+	bi.goSymTable = tab
+}
+
+func (bi *BinaryInfo) parseDebugLineInfoElf(exe *elf.File, wg *sync.WaitGroup) {
+	defer wg.Done()
+
+	if sec := exe.Section(".debug_line"); sec != nil {
+		debugLine, err := exe.Section(".debug_line").Data()
+		if err != nil {
+			fmt.Println("could not get .debug_line section", err)
+			os.Exit(1)
+		}
+		bi.lineInfo = line.Parse(debugLine)
+	} else {
+		fmt.Println("could not find .debug_line section in binary")
+		os.Exit(1)
+	}
+}
+
+// PE ////////////////////////////////////////////////////////////////
+
+func (bi *BinaryInfo) LoadBinaryInfoPE(path string, wg *sync.WaitGroup) error {
+	peFile, closer, err := openExecutablePathPE(path)
+	if err != nil {
+		return err
+	}
+	bi.closer = closer
+	if peFile.Machine != pe.IMAGE_FILE_MACHINE_AMD64 {
+		return UnsupportedWindowsArchErr
+	}
+	bi.dwarf, err = dwarfFromPE(peFile)
+	if err != nil {
+		return err
+	}
+
+	wg.Add(4)
+	go bi.parseDebugFramePE(peFile, wg)
+	go bi.obtainGoSymbolsPE(peFile, wg)
+	go bi.parseDebugLineInfoPE(peFile, wg)
+	go bi.loadDebugInfoMaps(wg)
+	return nil
+}
+
+func openExecutablePathPE(path string) (*pe.File, io.Closer, error) {
+	f, err := os.OpenFile(path, 0, os.ModePerm)
+	if err != nil {
+		return nil, nil, err
+	}
+	peFile, err := pe.NewFile(f)
+	if err != nil {
+		f.Close()
+		return nil, nil, err
+	}
+	return peFile, f, nil
+}
+
+// Adapted from src/debug/pe/file.go: pe.(*File).DWARF()
+func dwarfFromPE(f *pe.File) (*dwarf.Data, error) {
+	// There are many other DWARF sections, but these
+	// are the ones the debug/dwarf package uses.
+	// Don't bother loading others.
+	var names = [...]string{"abbrev", "info", "line", "str"}
+	var dat [len(names)][]byte
+	for i, name := range names {
+		name = ".debug_" + name
+		s := f.Section(name)
+		if s == nil {
+			continue
+		}
+		b, err := s.Data()
+		if err != nil && uint32(len(b)) < s.Size {
+			return nil, err
+		}
+		if 0 < s.VirtualSize && s.VirtualSize < s.Size {
+			b = b[:s.VirtualSize]
+		}
+		dat[i] = b
+	}
+
+	abbrev, info, line, str := dat[0], dat[1], dat[2], dat[3]
+	return dwarf.New(abbrev, nil, nil, info, line, nil, nil, str)
+}
+
+func (bi *BinaryInfo) parseDebugFramePE(exe *pe.File, wg *sync.WaitGroup) {
+	defer wg.Done()
+
+	debugFrameSec := exe.Section(".debug_frame")
+	debugInfoSec := exe.Section(".debug_info")
+
+	if debugFrameSec != nil && debugInfoSec != nil {
+		debugFrame, err := debugFrameSec.Data()
+		if err != nil && uint32(len(debugFrame)) < debugFrameSec.Size {
+			fmt.Println("could not get .debug_frame section", err)
+			os.Exit(1)
+		}
+		if 0 < debugFrameSec.VirtualSize && debugFrameSec.VirtualSize < debugFrameSec.Size {
+			debugFrame = debugFrame[:debugFrameSec.VirtualSize]
+		}
+		dat, err := debugInfoSec.Data()
+		if err != nil {
+			fmt.Println("could not get .debug_info section", err)
+			os.Exit(1)
+		}
+		bi.frameEntries = frame.Parse(debugFrame, frame.DwarfEndian(dat))
+	} else {
+		fmt.Println("could not find .debug_frame section in binary")
+		os.Exit(1)
+	}
+}
+
+func (dbp *BinaryInfo) obtainGoSymbolsPE(exe *pe.File, wg *sync.WaitGroup) {
+	defer wg.Done()
+
+	_, symdat, pclndat, err := pclnPE(exe)
+	if err != nil {
+		fmt.Println("could not get Go symbols", err)
+		os.Exit(1)
+	}
+
+	pcln := gosym.NewLineTable(pclndat, uint64(exe.Section(".text").Offset))
+	tab, err := gosym.NewTable(symdat, pcln)
+	if err != nil {
+		fmt.Println("could not get initialize line table", err)
+		os.Exit(1)
+	}
+
+	dbp.goSymTable = tab
+}
+
+// Borrowed from https://golang.org/src/cmd/internal/objfile/pe.go
+func findPESymbol(f *pe.File, name string) (*pe.Symbol, error) {
+	for _, s := range f.Symbols {
+		if s.Name != name {
+			continue
+		}
+		if s.SectionNumber <= 0 {
+			return nil, fmt.Errorf("symbol %s: invalid section number %d", name, s.SectionNumber)
+		}
+		if len(f.Sections) < int(s.SectionNumber) {
+			return nil, fmt.Errorf("symbol %s: section number %d is larger than max %d", name, s.SectionNumber, len(f.Sections))
+		}
+		return s, nil
+	}
+	return nil, fmt.Errorf("no %s symbol found", name)
+}
+
+// Borrowed from https://golang.org/src/cmd/internal/objfile/pe.go
+func loadPETable(f *pe.File, sname, ename string) ([]byte, error) {
+	ssym, err := findPESymbol(f, sname)
+	if err != nil {
+		return nil, err
+	}
+	esym, err := findPESymbol(f, ename)
+	if err != nil {
+		return nil, err
+	}
+	if ssym.SectionNumber != esym.SectionNumber {
+		return nil, fmt.Errorf("%s and %s symbols must be in the same section", sname, ename)
+	}
+	sect := f.Sections[ssym.SectionNumber-1]
+	data, err := sect.Data()
+	if err != nil {
+		return nil, err
+	}
+	return data[ssym.Value:esym.Value], nil
+}
+
+// Borrowed from https://golang.org/src/cmd/internal/objfile/pe.go
+func pclnPE(exe *pe.File) (textStart uint64, symtab, pclntab []byte, err error) {
+	var imageBase uint64
+	switch oh := exe.OptionalHeader.(type) {
+	case *pe.OptionalHeader32:
+		imageBase = uint64(oh.ImageBase)
+	case *pe.OptionalHeader64:
+		imageBase = oh.ImageBase
+	default:
+		return 0, nil, nil, fmt.Errorf("pe file format not recognized")
+	}
+	if sect := exe.Section(".text"); sect != nil {
+		textStart = imageBase + uint64(sect.VirtualAddress)
+	}
+	if pclntab, err = loadPETable(exe, "runtime.pclntab", "runtime.epclntab"); err != nil {
+		// We didn't find the symbols, so look for the names used in 1.3 and earlier.
+		// TODO: Remove code looking for the old symbols when we no longer care about 1.3.
+		var err2 error
+		if pclntab, err2 = loadPETable(exe, "pclntab", "epclntab"); err2 != nil {
+			return 0, nil, nil, err
+		}
+	}
+	if symtab, err = loadPETable(exe, "runtime.symtab", "runtime.esymtab"); err != nil {
+		// Same as above.
+		var err2 error
+		if symtab, err2 = loadPETable(exe, "symtab", "esymtab"); err2 != nil {
+			return 0, nil, nil, err
+		}
+	}
+	return textStart, symtab, pclntab, nil
+}
+
+func (bi *BinaryInfo) parseDebugLineInfoPE(exe *pe.File, wg *sync.WaitGroup) {
+	defer wg.Done()
+
+	if sec := exe.Section(".debug_line"); sec != nil {
+		debugLine, err := sec.Data()
+		if err != nil && uint32(len(debugLine)) < sec.Size {
+			fmt.Println("could not get .debug_line section", err)
+			os.Exit(1)
+		}
+		if 0 < sec.VirtualSize && sec.VirtualSize < sec.Size {
+			debugLine = debugLine[:sec.VirtualSize]
+		}
+		bi.lineInfo = line.Parse(debugLine)
+	} else {
+		fmt.Println("could not find .debug_line section in binary")
+		os.Exit(1)
+	}
+}
+
+// MACH-O ////////////////////////////////////////////////////////////
+
+func (bi *BinaryInfo) LoadBinaryInfoMacho(path string, wg *sync.WaitGroup) error {
+	exe, err := macho.Open(path)
+	if err != nil {
+		return err
+	}
+	bi.closer = exe
+	if exe.Cpu != macho.CpuAmd64 {
+		return UnsupportedDarwinArchErr
+	}
+	bi.dwarf, err = exe.DWARF()
+	if err != nil {
+		return err
+	}
+
+	wg.Add(4)
+	go bi.parseDebugFrameMacho(exe, wg)
+	go bi.obtainGoSymbolsMacho(exe, wg)
+	go bi.parseDebugLineInfoMacho(exe, wg)
+	go bi.loadDebugInfoMaps(wg)
+	return nil
+}
+
+func (bi *BinaryInfo) parseDebugFrameMacho(exe *macho.File, wg *sync.WaitGroup) {
+	defer wg.Done()
+
+	debugFrameSec := exe.Section("__debug_frame")
+	debugInfoSec := exe.Section("__debug_info")
+
+	if debugFrameSec != nil && debugInfoSec != nil {
+		debugFrame, err := exe.Section("__debug_frame").Data()
+		if err != nil {
+			fmt.Println("could not get __debug_frame section", err)
+			os.Exit(1)
+		}
+		dat, err := debugInfoSec.Data()
+		if err != nil {
+			fmt.Println("could not get .debug_info section", err)
+			os.Exit(1)
+		}
+		bi.frameEntries = frame.Parse(debugFrame, frame.DwarfEndian(dat))
+	} else {
+		fmt.Println("could not find __debug_frame section in binary")
+		os.Exit(1)
+	}
+}
+
+func (bi *BinaryInfo) obtainGoSymbolsMacho(exe *macho.File, wg *sync.WaitGroup) {
+	defer wg.Done()
+
+	var (
+		symdat  []byte
+		pclndat []byte
+		err     error
+	)
+
+	if sec := exe.Section("__gosymtab"); sec != nil {
+		symdat, err = sec.Data()
+		if err != nil {
+			fmt.Println("could not get .gosymtab section", err)
+			os.Exit(1)
+		}
+	}
+
+	if sec := exe.Section("__gopclntab"); sec != nil {
+		pclndat, err = sec.Data()
+		if err != nil {
+			fmt.Println("could not get .gopclntab section", err)
+			os.Exit(1)
+		}
+	}
+
+	pcln := gosym.NewLineTable(pclndat, exe.Section("__text").Addr)
+	tab, err := gosym.NewTable(symdat, pcln)
+	if err != nil {
+		fmt.Println("could not get initialize line table", err)
+		os.Exit(1)
+	}
+
+	bi.goSymTable = tab
+}
+
+func (bi *BinaryInfo) parseDebugLineInfoMacho(exe *macho.File, wg *sync.WaitGroup) {
+	defer wg.Done()
+
+	if sec := exe.Section("__debug_line"); sec != nil {
+		debugLine, err := exe.Section("__debug_line").Data()
+		if err != nil {
+			fmt.Println("could not get __debug_line section", err)
+			os.Exit(1)
+		}
+		bi.lineInfo = line.Parse(debugLine)
+	} else {
+		fmt.Println("could not find __debug_line section in binary")
+		os.Exit(1)
+	}
+}

--- a/pkg/proc/breakpoints.go
+++ b/pkg/proc/breakpoints.go
@@ -104,7 +104,7 @@ func (iae InvalidAddressError) Error() string {
 }
 
 func (dbp *Process) writeSoftwareBreakpoint(thread *Thread, addr uint64) error {
-	_, err := thread.writeMemory(uintptr(addr), dbp.arch.BreakpointInstruction())
+	_, err := thread.writeMemory(uintptr(addr), dbp.bi.arch.BreakpointInstruction())
 	return err
 }
 

--- a/pkg/proc/disasm.go
+++ b/pkg/proc/disasm.go
@@ -47,7 +47,7 @@ func (thread *Thread) Disassemble(startPC, endPC uint64, currentGoroutine bool) 
 				mem[i] = bp.OriginalData[i]
 			}
 		}
-		file, line, fn := thread.dbp.PCToLine(pc)
+		file, line, fn := thread.dbp.bi.PCToLine(pc)
 		loc := Location{PC: pc, File: file, Line: line, Fn: fn}
 		inst, err := asmDecode(mem, pc)
 		if err == nil {

--- a/pkg/proc/disasm_amd64.go
+++ b/pkg/proc/disasm_amd64.go
@@ -109,7 +109,7 @@ func (thread *Thread) resolveCallArg(inst *ArchInst, currentGoroutine bool, regs
 		return nil
 	}
 
-	file, line, fn := thread.dbp.PCToLine(pc)
+	file, line, fn := thread.dbp.bi.PCToLine(pc)
 	if fn == nil {
 		return nil
 	}

--- a/pkg/proc/eval.go
+++ b/pkg/proc/eval.go
@@ -141,7 +141,7 @@ func (scope *EvalScope) evalTypeCast(node *ast.CallExpr) (*Variable, error) {
 		fnnode = p.X
 	}
 
-	styp, err := scope.Thread.dbp.findTypeExpr(fnnode)
+	styp, err := scope.Thread.dbp.bi.findTypeExpr(fnnode)
 	if err != nil {
 		return nil, err
 	}
@@ -454,7 +454,7 @@ func (scope *EvalScope) evalIdent(node *ast.Ident) (*Variable, error) {
 		return v, nil
 	}
 	// if it's not a local variable then it could be a package variable w/o explicit package name
-	_, _, fn := scope.Thread.dbp.PCToLine(scope.PC)
+	_, _, fn := scope.Thread.dbp.bi.PCToLine(scope.PC)
 	if fn != nil {
 		if v, err = scope.packageVarAddr(fn.PackageName() + "." + node.Name); err == nil {
 			v.Name = node.Name
@@ -492,7 +492,7 @@ func (scope *EvalScope) evalTypeAssert(node *ast.TypeAssertExpr) (*Variable, err
 	if xv.Children[0].Addr == 0 {
 		return nil, fmt.Errorf("interface conversion: %s is nil, not %s", xv.DwarfType.String(), exprToString(node.Type))
 	}
-	typ, err := scope.Thread.dbp.findTypeExpr(node.Type)
+	typ, err := scope.Thread.dbp.bi.findTypeExpr(node.Type)
 	if err != nil {
 		return nil, err
 	}
@@ -637,7 +637,7 @@ func (scope *EvalScope) evalAddrOf(node *ast.UnaryExpr) (*Variable, error) {
 	xev.OnlyAddr = true
 
 	typename := "*" + xev.DwarfType.Common().Name
-	rv := scope.newVariable("", 0, &dwarf.PtrType{CommonType: dwarf.CommonType{ByteSize: int64(scope.Thread.dbp.arch.PtrSize()), Name: typename}, Type: xev.DwarfType})
+	rv := scope.newVariable("", 0, &dwarf.PtrType{CommonType: dwarf.CommonType{ByteSize: int64(scope.Thread.dbp.bi.arch.PtrSize()), Name: typename}, Type: xev.DwarfType})
 	rv.Children = []Variable{*xev}
 	rv.loaded = true
 

--- a/pkg/proc/moduledata.go
+++ b/pkg/proc/moduledata.go
@@ -11,9 +11,9 @@ type moduleData struct {
 	typemapVar    *Variable
 }
 
-func (dbp *Process) loadModuleData() (err error) {
+func (dbp *BinaryInfo) loadModuleData(thread *Thread) (err error) {
 	dbp.loadModuleDataOnce.Do(func() {
-		scope := &EvalScope{Thread: dbp.currentThread, PC: 0, CFA: 0}
+		scope, _ := thread.Scope()
 		var md *Variable
 		md, err = scope.packageVarAddr("runtime.firstmoduledata")
 		if err != nil {
@@ -56,9 +56,10 @@ func (dbp *Process) loadModuleData() (err error) {
 	return
 }
 
-func (dbp *Process) resolveTypeOff(typeAddr uintptr, off uintptr) (*Variable, error) {
+func (dbp *BinaryInfo) resolveTypeOff(typeAddr uintptr, off uintptr, thread *Thread) (*Variable, error) {
+	var mem memoryReadWriter = thread
 	// See runtime.(*_type).typeOff in $GOROOT/src/runtime/type.go
-	if err := dbp.loadModuleData(); err != nil {
+	if err := dbp.loadModuleData(thread); err != nil {
 		return nil, err
 	}
 
@@ -75,7 +76,7 @@ func (dbp *Process) resolveTypeOff(typeAddr uintptr, off uintptr) (*Variable, er
 	}
 
 	if md == nil {
-		v, err := dbp.reflectOffsMapAccess(off)
+		v, err := dbp.reflectOffsMapAccess(off, thread)
 		if err != nil {
 			return nil, err
 		}
@@ -84,28 +85,29 @@ func (dbp *Process) resolveTypeOff(typeAddr uintptr, off uintptr) (*Variable, er
 		return v.newVariable(v.Name, uintptr(addr), rtyp), nil
 	}
 
-	if t, _ := md.typemapVar.mapAccess(newConstant(constant.MakeUint64(uint64(off)), dbp.currentThread)); t != nil {
+	if t, _ := md.typemapVar.mapAccess(newConstant(constant.MakeUint64(uint64(off)), mem)); t != nil {
 		return t, nil
 	}
 
 	res := md.types + uintptr(off)
 
-	return dbp.currentThread.newVariable("", res, rtyp), nil
+	return newVariable("", res, rtyp, thread.dbp, thread), nil
 }
 
-func (dbp *Process) resolveNameOff(typeAddr uintptr, off uintptr) (name, tag string, pkgpathoff int32, err error) {
+func (dbp *BinaryInfo) resolveNameOff(typeAddr uintptr, off uintptr, thread *Thread) (name, tag string, pkgpathoff int32, err error) {
+	var mem memoryReadWriter = thread
 	// See runtime.resolveNameOff in $GOROOT/src/runtime/type.go
-	if err = dbp.loadModuleData(); err != nil {
+	if err = dbp.loadModuleData(thread); err != nil {
 		return "", "", 0, err
 	}
 
 	for _, md := range dbp.moduleData {
 		if typeAddr >= md.types && typeAddr < md.etypes {
-			return dbp.loadName(md.types + off)
+			return dbp.loadName(md.types+off, mem)
 		}
 	}
 
-	v, err := dbp.reflectOffsMapAccess(off)
+	v, err := dbp.reflectOffsMapAccess(off, thread)
 	if err != nil {
 		return "", "", 0, err
 	}
@@ -115,11 +117,11 @@ func (dbp *Process) resolveNameOff(typeAddr uintptr, off uintptr) (name, tag str
 		return "", "", 0, resv.Unreadable
 	}
 
-	return dbp.loadName(resv.Addr)
+	return dbp.loadName(resv.Addr, mem)
 }
 
-func (dbp *Process) reflectOffsMapAccess(off uintptr) (*Variable, error) {
-	scope := &EvalScope{Thread: dbp.currentThread, PC: 0, CFA: 0}
+func (dbp *BinaryInfo) reflectOffsMapAccess(off uintptr, thread *Thread) (*Variable, error) {
+	scope, _ := thread.Scope()
 	reflectOffs, err := scope.packageVarAddr("runtime.reflectOffs")
 	if err != nil {
 		return nil, err
@@ -130,7 +132,7 @@ func (dbp *Process) reflectOffsMapAccess(off uintptr) (*Variable, error) {
 		return nil, err
 	}
 
-	return reflectOffsm.mapAccess(newConstant(constant.MakeUint64(uint64(off)), dbp.currentThread))
+	return reflectOffsm.mapAccess(newConstant(constant.MakeUint64(uint64(off)), thread))
 }
 
 const (
@@ -140,9 +142,9 @@ const (
 	nameflagHasPkg   = 1 << 2
 )
 
-func (dbp *Process) loadName(addr uintptr) (name, tag string, pkgpathoff int32, err error) {
+func (dbp *BinaryInfo) loadName(addr uintptr, mem memoryReadWriter) (name, tag string, pkgpathoff int32, err error) {
 	off := addr
-	namedata, err := dbp.currentThread.readMemory(off, 3)
+	namedata, err := mem.readMemory(off, 3)
 	off += 3
 	if err != nil {
 		return "", "", 0, err
@@ -150,7 +152,7 @@ func (dbp *Process) loadName(addr uintptr) (name, tag string, pkgpathoff int32, 
 
 	namelen := uint16(namedata[1]<<8) | uint16(namedata[2])
 
-	rawstr, err := dbp.currentThread.readMemory(off, int(namelen))
+	rawstr, err := mem.readMemory(off, int(namelen))
 	off += uintptr(namelen)
 	if err != nil {
 		return "", "", 0, err
@@ -159,14 +161,14 @@ func (dbp *Process) loadName(addr uintptr) (name, tag string, pkgpathoff int32, 
 	name = string(rawstr)
 
 	if namedata[0]&nameflagHasTag != 0 {
-		taglendata, err := dbp.currentThread.readMemory(off, 2)
+		taglendata, err := mem.readMemory(off, 2)
 		off += 2
 		if err != nil {
 			return "", "", 0, err
 		}
 		taglen := uint16(taglendata[0]<<8) | uint16(taglendata[1])
 
-		rawstr, err := dbp.currentThread.readMemory(off, int(taglen))
+		rawstr, err := mem.readMemory(off, int(taglen))
 		off += uintptr(taglen)
 		if err != nil {
 			return "", "", 0, err
@@ -176,7 +178,7 @@ func (dbp *Process) loadName(addr uintptr) (name, tag string, pkgpathoff int32, 
 	}
 
 	if namedata[0]&nameflagHasPkg != 0 {
-		pkgdata, err := dbp.currentThread.readMemory(off, 4)
+		pkgdata, err := mem.readMemory(off, 4)
 		if err != nil {
 			return "", "", 0, err
 		}

--- a/pkg/proc/proc.go
+++ b/pkg/proc/proc.go
@@ -108,7 +108,7 @@ func (dbp *Process) Detach(kill bool) (err error) {
 		}
 	}
 	dbp.execPtraceFunc(func() {
-		err = dbp.detach()
+		err = dbp.detach(kill)
 		if err != nil {
 			return
 		}

--- a/pkg/proc/proc_darwin.go
+++ b/pkg/proc/proc_darwin.go
@@ -259,7 +259,7 @@ func (dbp *Process) addThread(port int, attach bool) (*Thread, error) {
 	return thread, nil
 }
 
-func (dbp *Process) parseDebugFrame(exe *macho.File, wg *sync.WaitGroup) {
+func (dbp *BinaryInfo) parseDebugFrame(exe *macho.File, wg *sync.WaitGroup) {
 	defer wg.Done()
 
 	debugFrameSec := exe.Section("__debug_frame")
@@ -283,7 +283,7 @@ func (dbp *Process) parseDebugFrame(exe *macho.File, wg *sync.WaitGroup) {
 	}
 }
 
-func (dbp *Process) obtainGoSymbols(exe *macho.File, wg *sync.WaitGroup) {
+func (dbp *BinaryInfo) obtainGoSymbols(exe *macho.File, wg *sync.WaitGroup) {
 	defer wg.Done()
 
 	var (
@@ -318,7 +318,7 @@ func (dbp *Process) obtainGoSymbols(exe *macho.File, wg *sync.WaitGroup) {
 	dbp.goSymTable = tab
 }
 
-func (dbp *Process) parseDebugLineInfo(exe *macho.File, wg *sync.WaitGroup) {
+func (dbp *BinaryInfo) parseDebugLineInfo(exe *macho.File, wg *sync.WaitGroup) {
 	defer wg.Done()
 
 	if sec := exe.Section("__debug_line"); sec != nil {
@@ -336,9 +336,9 @@ func (dbp *Process) parseDebugLineInfo(exe *macho.File, wg *sync.WaitGroup) {
 
 var UnsupportedArchErr = errors.New("unsupported architecture - only darwin/amd64 is supported")
 
-func (dbp *Process) findExecutable(path string) (*macho.File, string, error) {
+func (dbp *BinaryInfo) findExecutable(path string, pid int) (*macho.File, string, error) {
 	if path == "" {
-		path = C.GoString(C.find_executable(C.int(dbp.pid)))
+		path = C.GoString(C.find_executable(C.int(pid)))
 	}
 	exe, err := macho.Open(path)
 	if err != nil {

--- a/pkg/proc/proc_darwin.go
+++ b/pkg/proc/proc_darwin.go
@@ -417,6 +417,6 @@ func (dbp *Process) resume() error {
 	return nil
 }
 
-func (dbp *Process) detach() error {
+func (dbp *Process) detach(kill bool) error {
 	return PtraceDetach(dbp.pid, 0)
 }

--- a/pkg/proc/proc_darwin.go
+++ b/pkg/proc/proc_darwin.go
@@ -6,7 +6,6 @@ package proc
 // #include <stdlib.h>
 import "C"
 import (
-	"debug/gosym"
 	"errors"
 	"fmt"
 	"os"
@@ -15,10 +14,6 @@ import (
 	"sync"
 	"unsafe"
 
-	"golang.org/x/debug/macho"
-
-	"github.com/derekparker/delve/pkg/dwarf/frame"
-	"github.com/derekparker/delve/pkg/dwarf/line"
 	sys "golang.org/x/sys/unix"
 )
 
@@ -259,99 +254,11 @@ func (dbp *Process) addThread(port int, attach bool) (*Thread, error) {
 	return thread, nil
 }
 
-func (dbp *BinaryInfo) parseDebugFrame(exe *macho.File, wg *sync.WaitGroup) {
-	defer wg.Done()
-
-	debugFrameSec := exe.Section("__debug_frame")
-	debugInfoSec := exe.Section("__debug_info")
-
-	if debugFrameSec != nil && debugInfoSec != nil {
-		debugFrame, err := exe.Section("__debug_frame").Data()
-		if err != nil {
-			fmt.Println("could not get __debug_frame section", err)
-			os.Exit(1)
-		}
-		dat, err := debugInfoSec.Data()
-		if err != nil {
-			fmt.Println("could not get .debug_info section", err)
-			os.Exit(1)
-		}
-		dbp.frameEntries = frame.Parse(debugFrame, frame.DwarfEndian(dat))
-	} else {
-		fmt.Println("could not find __debug_frame section in binary")
-		os.Exit(1)
-	}
-}
-
-func (dbp *BinaryInfo) obtainGoSymbols(exe *macho.File, wg *sync.WaitGroup) {
-	defer wg.Done()
-
-	var (
-		symdat  []byte
-		pclndat []byte
-		err     error
-	)
-
-	if sec := exe.Section("__gosymtab"); sec != nil {
-		symdat, err = sec.Data()
-		if err != nil {
-			fmt.Println("could not get .gosymtab section", err)
-			os.Exit(1)
-		}
-	}
-
-	if sec := exe.Section("__gopclntab"); sec != nil {
-		pclndat, err = sec.Data()
-		if err != nil {
-			fmt.Println("could not get .gopclntab section", err)
-			os.Exit(1)
-		}
-	}
-
-	pcln := gosym.NewLineTable(pclndat, exe.Section("__text").Addr)
-	tab, err := gosym.NewTable(symdat, pcln)
-	if err != nil {
-		fmt.Println("could not get initialize line table", err)
-		os.Exit(1)
-	}
-
-	dbp.goSymTable = tab
-}
-
-func (dbp *BinaryInfo) parseDebugLineInfo(exe *macho.File, wg *sync.WaitGroup) {
-	defer wg.Done()
-
-	if sec := exe.Section("__debug_line"); sec != nil {
-		debugLine, err := exe.Section("__debug_line").Data()
-		if err != nil {
-			fmt.Println("could not get __debug_line section", err)
-			os.Exit(1)
-		}
-		dbp.lineInfo = line.Parse(debugLine)
-	} else {
-		fmt.Println("could not find __debug_line section in binary")
-		os.Exit(1)
-	}
-}
-
-var UnsupportedArchErr = errors.New("unsupported architecture - only darwin/amd64 is supported")
-
-func (dbp *BinaryInfo) findExecutable(path string, pid int) (*macho.File, string, error) {
+func findExecutable(path string, pid int) string {
 	if path == "" {
 		path = C.GoString(C.find_executable(C.int(pid)))
 	}
-	exe, err := macho.Open(path)
-	if err != nil {
-		return nil, path, err
-	}
-	if exe.Cpu != macho.CpuAmd64 {
-		return nil, path, UnsupportedArchErr
-	}
-	dbp.dwarf, err = exe.DWARF()
-	if err != nil {
-		return nil, path, err
-	}
-	return exe, path, nil
+	return path
 }
 
 func (dbp *Process) trapWait(pid int) (*Thread, error) {

--- a/pkg/proc/proc_linux.go
+++ b/pkg/proc/proc_linux.go
@@ -387,12 +387,15 @@ func (dbp *Process) resume() error {
 	return nil
 }
 
-func (dbp *Process) detach() error {
+func (dbp *Process) detach(kill bool) error {
 	for threadID := range dbp.threads {
 		err := PtraceDetach(threadID, 0)
 		if err != nil {
 			return err
 		}
+	}
+	if kill {
+		return nil
 	}
 	// For some reason the process will sometimes enter stopped state after a
 	// detach, this doesn't happen immediately either.

--- a/pkg/proc/proc_linux.go
+++ b/pkg/proc/proc_linux.go
@@ -2,7 +2,6 @@ package proc
 
 import (
 	"bytes"
-	"debug/gosym"
 	"errors"
 	"fmt"
 	"io/ioutil"
@@ -17,10 +16,6 @@ import (
 	"time"
 
 	sys "golang.org/x/sys/unix"
-
-	"github.com/derekparker/delve/pkg/dwarf/frame"
-	"github.com/derekparker/delve/pkg/dwarf/line"
-	"golang.org/x/debug/elf"
 )
 
 // Process statuses
@@ -171,103 +166,11 @@ func (dbp *Process) updateThreadList() error {
 	return nil
 }
 
-var UnsupportedArchErr = errors.New("unsupported architecture - only linux/amd64 is supported")
-
-func (dbp *BinaryInfo) findExecutable(path string, pid int) (*elf.File, string, error) {
+func findExecutable(path string, pid int) string {
 	if path == "" {
 		path = fmt.Sprintf("/proc/%d/exe", pid)
 	}
-	f, err := os.OpenFile(path, 0, os.ModePerm)
-	if err != nil {
-		return nil, path, err
-	}
-	elfFile, err := elf.NewFile(f)
-	if err != nil {
-		return nil, path, err
-	}
-	if elfFile.Machine != elf.EM_X86_64 {
-		return nil, path, UnsupportedArchErr
-	}
-	dbp.dwarf, err = elfFile.DWARF()
-	if err != nil {
-		return nil, path, err
-	}
-	return elfFile, path, nil
-}
-
-func (dbp *BinaryInfo) parseDebugFrame(exe *elf.File, wg *sync.WaitGroup) {
-	defer wg.Done()
-
-	debugFrameSec := exe.Section(".debug_frame")
-	debugInfoSec := exe.Section(".debug_info")
-
-	if debugFrameSec != nil && debugInfoSec != nil {
-		debugFrame, err := exe.Section(".debug_frame").Data()
-		if err != nil {
-			fmt.Println("could not get .debug_frame section", err)
-			os.Exit(1)
-		}
-		dat, err := debugInfoSec.Data()
-		if err != nil {
-			fmt.Println("could not get .debug_info section", err)
-			os.Exit(1)
-		}
-		dbp.frameEntries = frame.Parse(debugFrame, frame.DwarfEndian(dat))
-	} else {
-		fmt.Println("could not find .debug_frame section in binary")
-		os.Exit(1)
-	}
-}
-
-func (dbp *BinaryInfo) obtainGoSymbols(exe *elf.File, wg *sync.WaitGroup) {
-	defer wg.Done()
-
-	var (
-		symdat  []byte
-		pclndat []byte
-		err     error
-	)
-
-	if sec := exe.Section(".gosymtab"); sec != nil {
-		symdat, err = sec.Data()
-		if err != nil {
-			fmt.Println("could not get .gosymtab section", err)
-			os.Exit(1)
-		}
-	}
-
-	if sec := exe.Section(".gopclntab"); sec != nil {
-		pclndat, err = sec.Data()
-		if err != nil {
-			fmt.Println("could not get .gopclntab section", err)
-			os.Exit(1)
-		}
-	}
-
-	pcln := gosym.NewLineTable(pclndat, exe.Section(".text").Addr)
-	tab, err := gosym.NewTable(symdat, pcln)
-	if err != nil {
-		fmt.Println("could not get initialize line table", err)
-		os.Exit(1)
-	}
-
-	dbp.goSymTable = tab
-}
-
-func (dbp *BinaryInfo) parseDebugLineInfo(exe *elf.File, wg *sync.WaitGroup) {
-	defer wg.Done()
-
-	if sec := exe.Section(".debug_line"); sec != nil {
-		debugLine, err := exe.Section(".debug_line").Data()
-		if err != nil {
-			fmt.Println("could not get .debug_line section", err)
-			os.Exit(1)
-		}
-		dbp.lineInfo = line.Parse(debugLine)
-	} else {
-		fmt.Println("could not find .debug_line section in binary")
-		os.Exit(1)
-	}
+	return path
 }
 
 func (dbp *Process) trapWait(pid int) (*Thread, error) {

--- a/pkg/proc/proc_linux.go
+++ b/pkg/proc/proc_linux.go
@@ -173,9 +173,9 @@ func (dbp *Process) updateThreadList() error {
 
 var UnsupportedArchErr = errors.New("unsupported architecture - only linux/amd64 is supported")
 
-func (dbp *Process) findExecutable(path string) (*elf.File, string, error) {
+func (dbp *BinaryInfo) findExecutable(path string, pid int) (*elf.File, string, error) {
 	if path == "" {
-		path = fmt.Sprintf("/proc/%d/exe", dbp.pid)
+		path = fmt.Sprintf("/proc/%d/exe", pid)
 	}
 	f, err := os.OpenFile(path, 0, os.ModePerm)
 	if err != nil {
@@ -195,7 +195,7 @@ func (dbp *Process) findExecutable(path string) (*elf.File, string, error) {
 	return elfFile, path, nil
 }
 
-func (dbp *Process) parseDebugFrame(exe *elf.File, wg *sync.WaitGroup) {
+func (dbp *BinaryInfo) parseDebugFrame(exe *elf.File, wg *sync.WaitGroup) {
 	defer wg.Done()
 
 	debugFrameSec := exe.Section(".debug_frame")
@@ -219,7 +219,7 @@ func (dbp *Process) parseDebugFrame(exe *elf.File, wg *sync.WaitGroup) {
 	}
 }
 
-func (dbp *Process) obtainGoSymbols(exe *elf.File, wg *sync.WaitGroup) {
+func (dbp *BinaryInfo) obtainGoSymbols(exe *elf.File, wg *sync.WaitGroup) {
 	defer wg.Done()
 
 	var (
@@ -254,7 +254,7 @@ func (dbp *Process) obtainGoSymbols(exe *elf.File, wg *sync.WaitGroup) {
 	dbp.goSymTable = tab
 }
 
-func (dbp *Process) parseDebugLineInfo(exe *elf.File, wg *sync.WaitGroup) {
+func (dbp *BinaryInfo) parseDebugLineInfo(exe *elf.File, wg *sync.WaitGroup) {
 	defer wg.Done()
 
 	if sec := exe.Section(".debug_line"); sec != nil {

--- a/pkg/proc/proc_test.go
+++ b/pkg/proc/proc_test.go
@@ -1936,7 +1936,7 @@ func TestUnsupportedArch(t *testing.T) {
 
 	p, err := Launch([]string{outfile}, ".")
 	switch err {
-	case UnsupportedArchErr:
+	case UnsupportedLinuxArchErr, UnsupportedWindowsArchErr, UnsupportedDarwinArchErr:
 		// all good
 	case nil:
 		p.Halt()

--- a/pkg/proc/proc_test.go
+++ b/pkg/proc/proc_test.go
@@ -94,7 +94,7 @@ func currentPC(p *Process, t *testing.T) uint64 {
 
 func currentLineNumber(p *Process, t *testing.T) (string, int) {
 	pc := currentPC(p, t)
-	f, l, _ := p.goSymTable.PCToLine(pc)
+	f, l, _ := p.BinInfo().goSymTable.PCToLine(pc)
 
 	return f, l
 }
@@ -198,7 +198,7 @@ func TestHalt(t *testing.T) {
 
 func TestStep(t *testing.T) {
 	withTestProcess("testprog", t, func(p *Process, fixture protest.Fixture) {
-		helloworldfunc := p.goSymTable.LookupFunc("main.helloworld")
+		helloworldfunc := p.BinInfo().goSymTable.LookupFunc("main.helloworld")
 		helloworldaddr := helloworldfunc.Entry
 
 		_, err := p.SetBreakpoint(helloworldaddr, UserBreakpoint, nil)
@@ -220,7 +220,7 @@ func TestStep(t *testing.T) {
 
 func TestBreakpoint(t *testing.T) {
 	withTestProcess("testprog", t, func(p *Process, fixture protest.Fixture) {
-		helloworldfunc := p.goSymTable.LookupFunc("main.helloworld")
+		helloworldfunc := p.BinInfo().goSymTable.LookupFunc("main.helloworld")
 		helloworldaddr := helloworldfunc.Entry
 
 		bp, err := p.SetBreakpoint(helloworldaddr, UserBreakpoint, nil)
@@ -237,7 +237,7 @@ func TestBreakpoint(t *testing.T) {
 		}
 
 		if pc-1 != bp.Addr && pc != bp.Addr {
-			f, l, _ := p.goSymTable.PCToLine(pc)
+			f, l, _ := p.BinInfo().goSymTable.PCToLine(pc)
 			t.Fatalf("Break not respected:\nPC:%#v %s:%d\nFN:%#v \n", pc, f, l, bp.Addr)
 		}
 	})
@@ -245,7 +245,7 @@ func TestBreakpoint(t *testing.T) {
 
 func TestBreakpointInSeperateGoRoutine(t *testing.T) {
 	withTestProcess("testthreads", t, func(p *Process, fixture protest.Fixture) {
-		fn := p.goSymTable.LookupFunc("main.anotherthread")
+		fn := p.BinInfo().goSymTable.LookupFunc("main.anotherthread")
 		if fn == nil {
 			t.Fatal("No fn exists")
 		}
@@ -265,7 +265,7 @@ func TestBreakpointInSeperateGoRoutine(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		f, l, _ := p.goSymTable.PCToLine(pc)
+		f, l, _ := p.BinInfo().goSymTable.PCToLine(pc)
 		if f != "testthreads.go" && l != 8 {
 			t.Fatal("Program did not hit breakpoint")
 		}
@@ -283,7 +283,7 @@ func TestBreakpointWithNonExistantFunction(t *testing.T) {
 
 func TestClearBreakpointBreakpoint(t *testing.T) {
 	withTestProcess("testprog", t, func(p *Process, fixture protest.Fixture) {
-		fn := p.goSymTable.LookupFunc("main.sleepytime")
+		fn := p.BinInfo().goSymTable.LookupFunc("main.sleepytime")
 		bp, err := p.SetBreakpoint(fn.Entry, UserBreakpoint, nil)
 		assertNoError(err, t, "SetBreakpoint()")
 
@@ -579,7 +579,7 @@ func TestRuntimeBreakpoint(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		_, l, _ := p.PCToLine(pc)
+		_, l, _ := p.BinInfo().PCToLine(pc)
 		if l != 10 {
 			t.Fatal("did not respect breakpoint")
 		}
@@ -588,7 +588,7 @@ func TestRuntimeBreakpoint(t *testing.T) {
 
 func TestFindReturnAddress(t *testing.T) {
 	withTestProcess("testnextprog", t, func(p *Process, fixture protest.Fixture) {
-		start, _, err := p.goSymTable.LineToPC(fixture.Source, 24)
+		start, _, err := p.BinInfo().goSymTable.LineToPC(fixture.Source, 24)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -604,7 +604,7 @@ func TestFindReturnAddress(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		_, l, _ := p.goSymTable.PCToLine(addr)
+		_, l, _ := p.BinInfo().goSymTable.PCToLine(addr)
 		if l != 40 {
 			t.Fatalf("return address not found correctly, expected line 40")
 		}
@@ -614,7 +614,7 @@ func TestFindReturnAddress(t *testing.T) {
 func TestFindReturnAddressTopOfStackFn(t *testing.T) {
 	withTestProcess("testreturnaddress", t, func(p *Process, fixture protest.Fixture) {
 		fnName := "runtime.rt0_go"
-		fn := p.goSymTable.LookupFunc(fnName)
+		fn := p.BinInfo().goSymTable.LookupFunc(fnName)
 		if fn == nil {
 			t.Fatalf("could not find function %s", fnName)
 		}
@@ -1002,7 +1002,7 @@ func TestProcessReceivesSIGCHLD(t *testing.T) {
 
 func TestIssue239(t *testing.T) {
 	withTestProcess("is sue239", t, func(p *Process, fixture protest.Fixture) {
-		pos, _, err := p.goSymTable.LineToPC(fixture.Source, 17)
+		pos, _, err := p.BinInfo().goSymTable.LineToPC(fixture.Source, 17)
 		assertNoError(err, t, "LineToPC()")
 		_, err = p.SetBreakpoint(pos, UserBreakpoint, nil)
 		assertNoError(err, t, fmt.Sprintf("SetBreakpoint(%d)", pos))
@@ -1266,7 +1266,7 @@ func TestIssue325(t *testing.T) {
 
 func TestBreakpointCounts(t *testing.T) {
 	withTestProcess("bpcountstest", t, func(p *Process, fixture protest.Fixture) {
-		addr, _, err := p.goSymTable.LineToPC(fixture.Source, 12)
+		addr, _, err := p.BinInfo().goSymTable.LineToPC(fixture.Source, 12)
 		assertNoError(err, t, "LineToPC")
 		bp, err := p.SetBreakpoint(addr, UserBreakpoint, nil)
 		assertNoError(err, t, "SetBreakpoint()")
@@ -1317,7 +1317,7 @@ func TestBreakpointCountsWithDetection(t *testing.T) {
 	}
 	m := map[int64]int64{}
 	withTestProcess("bpcountstest", t, func(p *Process, fixture protest.Fixture) {
-		addr, _, err := p.goSymTable.LineToPC(fixture.Source, 12)
+		addr, _, err := p.BinInfo().goSymTable.LineToPC(fixture.Source, 12)
 		assertNoError(err, t, "LineToPC")
 		bp, err := p.SetBreakpoint(addr, UserBreakpoint, nil)
 		assertNoError(err, t, "SetBreakpoint()")
@@ -1412,7 +1412,7 @@ func BenchmarkGoroutinesInfo(b *testing.B) {
 func TestIssue262(t *testing.T) {
 	// Continue does not work when the current breakpoint is set on a NOP instruction
 	withTestProcess("issue262", t, func(p *Process, fixture protest.Fixture) {
-		addr, _, err := p.goSymTable.LineToPC(fixture.Source, 11)
+		addr, _, err := p.BinInfo().goSymTable.LineToPC(fixture.Source, 11)
 		assertNoError(err, t, "LineToPC")
 		_, err = p.SetBreakpoint(addr, UserBreakpoint, nil)
 		assertNoError(err, t, "SetBreakpoint()")
@@ -1434,7 +1434,7 @@ func TestIssue305(t *testing.T) {
 	// the internal breakpoints aren't cleared preventing further use of
 	// 'next' command
 	withTestProcess("issue305", t, func(p *Process, fixture protest.Fixture) {
-		addr, _, err := p.goSymTable.LineToPC(fixture.Source, 5)
+		addr, _, err := p.BinInfo().goSymTable.LineToPC(fixture.Source, 5)
 		assertNoError(err, t, "LineToPC()")
 		_, err = p.SetBreakpoint(addr, UserBreakpoint, nil)
 		assertNoError(err, t, "SetBreakpoint()")
@@ -1477,7 +1477,7 @@ func BenchmarkLocalVariables(b *testing.B) {
 
 func TestCondBreakpoint(t *testing.T) {
 	withTestProcess("parallel_next", t, func(p *Process, fixture protest.Fixture) {
-		addr, _, err := p.goSymTable.LineToPC(fixture.Source, 9)
+		addr, _, err := p.BinInfo().goSymTable.LineToPC(fixture.Source, 9)
 		assertNoError(err, t, "LineToPC")
 		bp, err := p.SetBreakpoint(addr, UserBreakpoint, nil)
 		assertNoError(err, t, "SetBreakpoint()")
@@ -1501,7 +1501,7 @@ func TestCondBreakpoint(t *testing.T) {
 
 func TestCondBreakpointError(t *testing.T) {
 	withTestProcess("parallel_next", t, func(p *Process, fixture protest.Fixture) {
-		addr, _, err := p.goSymTable.LineToPC(fixture.Source, 9)
+		addr, _, err := p.BinInfo().goSymTable.LineToPC(fixture.Source, 9)
 		assertNoError(err, t, "LineToPC")
 		bp, err := p.SetBreakpoint(addr, UserBreakpoint, nil)
 		assertNoError(err, t, "SetBreakpoint()")
@@ -1581,7 +1581,7 @@ func TestStepIntoFunction(t *testing.T) {
 func TestIssue384(t *testing.T) {
 	// Crash related to reading uninitialized memory, introduced by the memory prefetching optimization
 	withTestProcess("issue384", t, func(p *Process, fixture protest.Fixture) {
-		start, _, err := p.goSymTable.LineToPC(fixture.Source, 13)
+		start, _, err := p.BinInfo().goSymTable.LineToPC(fixture.Source, 13)
 		assertNoError(err, t, "LineToPC()")
 		_, err = p.SetBreakpoint(start, UserBreakpoint, nil)
 		assertNoError(err, t, "SetBreakpoint()")
@@ -1594,7 +1594,7 @@ func TestIssue384(t *testing.T) {
 func TestIssue332_Part1(t *testing.T) {
 	// Next shouldn't step inside a function call
 	withTestProcess("issue332", t, func(p *Process, fixture protest.Fixture) {
-		start, _, err := p.goSymTable.LineToPC(fixture.Source, 8)
+		start, _, err := p.BinInfo().goSymTable.LineToPC(fixture.Source, 8)
 		assertNoError(err, t, "LineToPC()")
 		_, err = p.SetBreakpoint(start, UserBreakpoint, nil)
 		assertNoError(err, t, "SetBreakpoint()")
@@ -1620,7 +1620,7 @@ func TestIssue332_Part2(t *testing.T) {
 	// which leads to 'next' and 'stack' failing with error "could not find FDE for PC: <garbage>"
 	// because the incorrect FDE data leads to reading the wrong stack address as the return address
 	withTestProcess("issue332", t, func(p *Process, fixture protest.Fixture) {
-		start, _, err := p.goSymTable.LineToPC(fixture.Source, 8)
+		start, _, err := p.BinInfo().goSymTable.LineToPC(fixture.Source, 8)
 		assertNoError(err, t, "LineToPC()")
 		_, err = p.SetBreakpoint(start, UserBreakpoint, nil)
 		assertNoError(err, t, "SetBreakpoint()")
@@ -1671,7 +1671,7 @@ func TestIssue396(t *testing.T) {
 func TestIssue414(t *testing.T) {
 	// Stepping until the program exits
 	withTestProcess("math", t, func(p *Process, fixture protest.Fixture) {
-		start, _, err := p.goSymTable.LineToPC(fixture.Source, 9)
+		start, _, err := p.BinInfo().goSymTable.LineToPC(fixture.Source, 9)
 		assertNoError(err, t, "LineToPC()")
 		_, err = p.SetBreakpoint(start, UserBreakpoint, nil)
 		assertNoError(err, t, "SetBreakpoint()")
@@ -1951,7 +1951,7 @@ func TestIssue573(t *testing.T) {
 	// calls to runtime.duffzero and runtime.duffcopy jump directly into the middle
 	// of the function and the internal breakpoint set by StepInto may be missed.
 	withTestProcess("issue573", t, func(p *Process, fixture protest.Fixture) {
-		f := p.goSymTable.LookupFunc("main.foo")
+		f := p.BinInfo().goSymTable.LookupFunc("main.foo")
 		_, err := p.SetBreakpoint(f.Entry, UserBreakpoint, nil)
 		assertNoError(err, t, "SetBreakpoint()")
 		assertNoError(p.Continue(), t, "Continue()")
@@ -2271,7 +2271,7 @@ func TestStepOutDefer(t *testing.T) {
 
 		assertNoError(p.StepOut(), t, "StepOut()")
 
-		f, l, _ := p.goSymTable.PCToLine(currentPC(p, t))
+		f, l, _ := p.BinInfo().goSymTable.PCToLine(currentPC(p, t))
 		if f == fixture.Source || l == 6 {
 			t.Fatalf("wrong location %s:%d, expected to end somewhere in runtime", f, l)
 		}
@@ -2375,7 +2375,7 @@ func TestWorkDir(t *testing.T) {
 		wd = "/private/tmp"
 	}
 	withTestProcessArgs("workdir", t, wd, func(p *Process, fixture protest.Fixture) {
-		addr, _, err := p.goSymTable.LineToPC(fixture.Source, 14)
+		addr, _, err := p.BinInfo().goSymTable.LineToPC(fixture.Source, 14)
 		assertNoError(err, t, "LineToPC")
 		p.SetBreakpoint(addr, UserBreakpoint, nil)
 		p.Continue()

--- a/pkg/proc/proc_windows.go
+++ b/pkg/proc/proc_windows.go
@@ -474,11 +474,13 @@ func (dbp *Process) resume() error {
 	return nil
 }
 
-func (dbp *Process) detach() error {
-	for _, thread := range dbp.threads {
-		_, err := _ResumeThread(thread.os.hThread)
-		if err != nil {
-			return err
+func (dbp *Process) detach(kill bool) error {
+	if !kill {
+		for _, thread := range dbp.threads {
+			_, err := _ResumeThread(thread.os.hThread)
+			if err != nil {
+				return err
+			}
 		}
 	}
 	return PtraceDetach(dbp.pid, 0)

--- a/pkg/proc/proc_windows.go
+++ b/pkg/proc/proc_windows.go
@@ -253,7 +253,7 @@ func (dbp *Process) addThread(hThread syscall.Handle, threadID int, attach, susp
 	return thread, nil
 }
 
-func (dbp *Process) parseDebugFrame(exe *pe.File, wg *sync.WaitGroup) {
+func (dbp *BinaryInfo) parseDebugFrame(exe *pe.File, wg *sync.WaitGroup) {
 	defer wg.Done()
 
 	debugFrameSec := exe.Section(".debug_frame")
@@ -350,7 +350,7 @@ func pcln(exe *pe.File) (textStart uint64, symtab, pclntab []byte, err error) {
 	return textStart, symtab, pclntab, nil
 }
 
-func (dbp *Process) obtainGoSymbols(exe *pe.File, wg *sync.WaitGroup) {
+func (dbp *BinaryInfo) obtainGoSymbols(exe *pe.File, wg *sync.WaitGroup) {
 	defer wg.Done()
 
 	_, symdat, pclndat, err := pcln(exe)
@@ -369,7 +369,7 @@ func (dbp *Process) obtainGoSymbols(exe *pe.File, wg *sync.WaitGroup) {
 	dbp.goSymTable = tab
 }
 
-func (dbp *Process) parseDebugLineInfo(exe *pe.File, wg *sync.WaitGroup) {
+func (dbp *BinaryInfo) parseDebugLineInfo(exe *pe.File, wg *sync.WaitGroup) {
 	defer wg.Done()
 
 	if sec := exe.Section(".debug_line"); sec != nil {
@@ -390,7 +390,7 @@ func (dbp *Process) parseDebugLineInfo(exe *pe.File, wg *sync.WaitGroup) {
 
 var UnsupportedArchErr = errors.New("unsupported architecture of windows/386 - only windows/amd64 is supported")
 
-func (dbp *Process) findExecutable(path string) (*pe.File, string, error) {
+func (dbp *BinaryInfo) findExecutable(path string, pid int) (*pe.File, string, error) {
 	peFile, err := openExecutablePath(path)
 	if err != nil {
 		return nil, path, err

--- a/pkg/proc/proc_windows.go
+++ b/pkg/proc/proc_windows.go
@@ -1,8 +1,6 @@
 package proc
 
 import (
-	"debug/gosym"
-	"debug/pe"
 	"errors"
 	"fmt"
 	"os"
@@ -13,10 +11,6 @@ import (
 	"unsafe"
 
 	sys "golang.org/x/sys/windows"
-
-	"github.com/derekparker/delve/pkg/dwarf/frame"
-	"github.com/derekparker/delve/pkg/dwarf/line"
-	"golang.org/x/debug/dwarf"
 )
 
 // OSProcessDetails holds Windows specific information.
@@ -39,11 +33,11 @@ func Launch(cmd []string, wd string) (*Process, error) {
 		}
 	}
 
-	peFile, err := openExecutablePath(argv0Go)
+	_, closer, err := openExecutablePathPE(argv0Go)
 	if err != nil {
 		return nil, NotExecutableErr
 	}
-	peFile.Close()
+	closer.Close()
 
 	// Duplicate the stdin/stdout/stderr handles
 	files := []uintptr{uintptr(syscall.Stdin), uintptr(syscall.Stdout), uintptr(syscall.Stderr)}
@@ -253,191 +247,8 @@ func (dbp *Process) addThread(hThread syscall.Handle, threadID int, attach, susp
 	return thread, nil
 }
 
-func (dbp *BinaryInfo) parseDebugFrame(exe *pe.File, wg *sync.WaitGroup) {
-	defer wg.Done()
-
-	debugFrameSec := exe.Section(".debug_frame")
-	debugInfoSec := exe.Section(".debug_info")
-
-	if debugFrameSec != nil && debugInfoSec != nil {
-		debugFrame, err := debugFrameSec.Data()
-		if err != nil && uint32(len(debugFrame)) < debugFrameSec.Size {
-			fmt.Println("could not get .debug_frame section", err)
-			os.Exit(1)
-		}
-		if 0 < debugFrameSec.VirtualSize && debugFrameSec.VirtualSize < debugFrameSec.Size {
-			debugFrame = debugFrame[:debugFrameSec.VirtualSize]
-		}
-		dat, err := debugInfoSec.Data()
-		if err != nil {
-			fmt.Println("could not get .debug_info section", err)
-			os.Exit(1)
-		}
-		dbp.frameEntries = frame.Parse(debugFrame, frame.DwarfEndian(dat))
-	} else {
-		fmt.Println("could not find .debug_frame section in binary")
-		os.Exit(1)
-	}
-}
-
-// Borrowed from https://golang.org/src/cmd/internal/objfile/pe.go
-func findPESymbol(f *pe.File, name string) (*pe.Symbol, error) {
-	for _, s := range f.Symbols {
-		if s.Name != name {
-			continue
-		}
-		if s.SectionNumber <= 0 {
-			return nil, fmt.Errorf("symbol %s: invalid section number %d", name, s.SectionNumber)
-		}
-		if len(f.Sections) < int(s.SectionNumber) {
-			return nil, fmt.Errorf("symbol %s: section number %d is larger than max %d", name, s.SectionNumber, len(f.Sections))
-		}
-		return s, nil
-	}
-	return nil, fmt.Errorf("no %s symbol found", name)
-}
-
-// Borrowed from https://golang.org/src/cmd/internal/objfile/pe.go
-func loadPETable(f *pe.File, sname, ename string) ([]byte, error) {
-	ssym, err := findPESymbol(f, sname)
-	if err != nil {
-		return nil, err
-	}
-	esym, err := findPESymbol(f, ename)
-	if err != nil {
-		return nil, err
-	}
-	if ssym.SectionNumber != esym.SectionNumber {
-		return nil, fmt.Errorf("%s and %s symbols must be in the same section", sname, ename)
-	}
-	sect := f.Sections[ssym.SectionNumber-1]
-	data, err := sect.Data()
-	if err != nil {
-		return nil, err
-	}
-	return data[ssym.Value:esym.Value], nil
-}
-
-// Borrowed from https://golang.org/src/cmd/internal/objfile/pe.go
-func pcln(exe *pe.File) (textStart uint64, symtab, pclntab []byte, err error) {
-	var imageBase uint64
-	switch oh := exe.OptionalHeader.(type) {
-	case *pe.OptionalHeader32:
-		imageBase = uint64(oh.ImageBase)
-	case *pe.OptionalHeader64:
-		imageBase = oh.ImageBase
-	default:
-		return 0, nil, nil, fmt.Errorf("pe file format not recognized")
-	}
-	if sect := exe.Section(".text"); sect != nil {
-		textStart = imageBase + uint64(sect.VirtualAddress)
-	}
-	if pclntab, err = loadPETable(exe, "runtime.pclntab", "runtime.epclntab"); err != nil {
-		// We didn't find the symbols, so look for the names used in 1.3 and earlier.
-		// TODO: Remove code looking for the old symbols when we no longer care about 1.3.
-		var err2 error
-		if pclntab, err2 = loadPETable(exe, "pclntab", "epclntab"); err2 != nil {
-			return 0, nil, nil, err
-		}
-	}
-	if symtab, err = loadPETable(exe, "runtime.symtab", "runtime.esymtab"); err != nil {
-		// Same as above.
-		var err2 error
-		if symtab, err2 = loadPETable(exe, "symtab", "esymtab"); err2 != nil {
-			return 0, nil, nil, err
-		}
-	}
-	return textStart, symtab, pclntab, nil
-}
-
-func (dbp *BinaryInfo) obtainGoSymbols(exe *pe.File, wg *sync.WaitGroup) {
-	defer wg.Done()
-
-	_, symdat, pclndat, err := pcln(exe)
-	if err != nil {
-		fmt.Println("could not get Go symbols", err)
-		os.Exit(1)
-	}
-
-	pcln := gosym.NewLineTable(pclndat, uint64(exe.Section(".text").Offset))
-	tab, err := gosym.NewTable(symdat, pcln)
-	if err != nil {
-		fmt.Println("could not get initialize line table", err)
-		os.Exit(1)
-	}
-
-	dbp.goSymTable = tab
-}
-
-func (dbp *BinaryInfo) parseDebugLineInfo(exe *pe.File, wg *sync.WaitGroup) {
-	defer wg.Done()
-
-	if sec := exe.Section(".debug_line"); sec != nil {
-		debugLine, err := sec.Data()
-		if err != nil && uint32(len(debugLine)) < sec.Size {
-			fmt.Println("could not get .debug_line section", err)
-			os.Exit(1)
-		}
-		if 0 < sec.VirtualSize && sec.VirtualSize < sec.Size {
-			debugLine = debugLine[:sec.VirtualSize]
-		}
-		dbp.lineInfo = line.Parse(debugLine)
-	} else {
-		fmt.Println("could not find .debug_line section in binary")
-		os.Exit(1)
-	}
-}
-
-var UnsupportedArchErr = errors.New("unsupported architecture of windows/386 - only windows/amd64 is supported")
-
-func (dbp *BinaryInfo) findExecutable(path string, pid int) (*pe.File, string, error) {
-	peFile, err := openExecutablePath(path)
-	if err != nil {
-		return nil, path, err
-	}
-	if peFile.Machine != pe.IMAGE_FILE_MACHINE_AMD64 {
-		return nil, path, UnsupportedArchErr
-	}
-	dbp.dwarf, err = dwarfFromPE(peFile)
-	if err != nil {
-		return nil, path, err
-	}
-	return peFile, path, nil
-}
-
-func openExecutablePath(path string) (*pe.File, error) {
-	f, err := os.OpenFile(path, 0, os.ModePerm)
-	if err != nil {
-		return nil, err
-	}
-	return pe.NewFile(f)
-}
-
-// Adapted from src/debug/pe/file.go: pe.(*File).DWARF()
-func dwarfFromPE(f *pe.File) (*dwarf.Data, error) {
-	// There are many other DWARF sections, but these
-	// are the ones the debug/dwarf package uses.
-	// Don't bother loading others.
-	var names = [...]string{"abbrev", "info", "line", "str"}
-	var dat [len(names)][]byte
-	for i, name := range names {
-		name = ".debug_" + name
-		s := f.Section(name)
-		if s == nil {
-			continue
-		}
-		b, err := s.Data()
-		if err != nil && uint32(len(b)) < s.Size {
-			return nil, err
-		}
-		if 0 < s.VirtualSize && s.VirtualSize < s.Size {
-			b = b[:s.VirtualSize]
-		}
-		dat[i] = b
-	}
-
-	abbrev, info, line, str := dat[0], dat[1], dat[2], dat[3]
-	return dwarf.New(abbrev, nil, nil, info, line, nil, nil, str)
+func findExecutable(path string, pid int) string {
+	return path
 }
 
 type waitForDebugEventFlags int

--- a/pkg/proc/proc_windows.go
+++ b/pkg/proc/proc_windows.go
@@ -330,8 +330,8 @@ func (dbp *Process) waitForDebugEvent(flags waitForDebugEventFlags) (threadID, e
 				// this exception anymore.
 				atbp := true
 				if thread, found := dbp.threads[tid]; found {
-					if data, err := thread.readMemory(exception.ExceptionRecord.ExceptionAddress, dbp.arch.BreakpointSize()); err == nil {
-						instr := dbp.arch.BreakpointInstruction()
+					if data, err := thread.readMemory(exception.ExceptionRecord.ExceptionAddress, dbp.bi.arch.BreakpointSize()); err == nil {
+						instr := dbp.bi.arch.BreakpointInstruction()
 						for i := range instr {
 							if data[i] != instr[i] {
 								atbp = false

--- a/pkg/proc/threads_darwin.go
+++ b/pkg/proc/threads_darwin.go
@@ -87,7 +87,7 @@ func (t *Thread) blocked() bool {
 	if err != nil {
 		return false
 	}
-	fn := t.dbp.goSymTable.PCToFunc(pc)
+	fn := t.dbp.bi.goSymTable.PCToFunc(pc)
 	if fn == nil {
 		return false
 	}

--- a/pkg/proc/threads_linux.go
+++ b/pkg/proc/threads_linux.go
@@ -69,7 +69,7 @@ func (t *Thread) singleStep() (err error) {
 
 func (t *Thread) blocked() bool {
 	pc, _ := t.PC()
-	fn := t.dbp.goSymTable.PCToFunc(pc)
+	fn := t.dbp.bi.goSymTable.PCToFunc(pc)
 	if fn != nil && ((fn.Name == "runtime.futex") || (fn.Name == "runtime.usleep") || (fn.Name == "runtime.clone")) {
 		return true
 	}

--- a/pkg/proc/threads_windows.go
+++ b/pkg/proc/threads_windows.go
@@ -110,7 +110,7 @@ func (t *Thread) blocked() bool {
 	if err != nil {
 		return false
 	}
-	fn := t.dbp.goSymTable.PCToFunc(pc)
+	fn := t.dbp.bi.goSymTable.PCToFunc(pc)
 	if fn == nil {
 		return false
 	}

--- a/pkg/proc/types.go
+++ b/pkg/proc/types.go
@@ -221,7 +221,7 @@ type nameOfRuntimeTypeEntry struct {
 // _type is a non-loaded Variable pointing to runtime._type struct in the target.
 // The returned string is in the format that's used in DWARF data
 func nameOfRuntimeType(_type *Variable) (typename string, kind int64, err error) {
-	if e, ok := _type.dbp.nameOfRuntimeType[_type.Addr]; ok {
+	if e, ok := _type.dbp.bi.nameOfRuntimeType[_type.Addr]; ok {
 		return e.typename, e.kind, nil
 	}
 
@@ -244,7 +244,7 @@ func nameOfRuntimeType(_type *Variable) (typename string, kind int64, err error)
 		return typename, kind, err
 	}
 
-	_type.dbp.nameOfRuntimeType[_type.Addr] = nameOfRuntimeTypeEntry{typename, kind}
+	_type.dbp.bi.nameOfRuntimeType[_type.Addr] = nameOfRuntimeTypeEntry{typename, kind}
 
 	return typename, kind, nil
 }
@@ -277,7 +277,7 @@ func nameOfNamedRuntimeType(_type *Variable, kind, tflag int64) (typename string
 	// For a description of how memory is organized for type names read
 	// the comment to 'type name struct' in $GOROOT/src/reflect/type.go
 
-	typename, _, _, err = _type.dbp.resolveNameOff(_type.Addr, uintptr(strOff), _type.dbp.currentThread)
+	typename, _, _, err = _type.dbp.bi.resolveNameOff(_type.Addr, uintptr(strOff), _type.dbp.currentThread)
 	if err != nil {
 		return "", err
 	}
@@ -303,7 +303,7 @@ func nameOfNamedRuntimeType(_type *Variable, kind, tflag int64) (typename string
 	if ut := uncommon(_type, tflag); ut != nil {
 		if pkgPathField := ut.loadFieldNamed("pkgpath"); pkgPathField != nil && pkgPathField.Value != nil {
 			pkgPathOff, _ := constant.Int64Val(pkgPathField.Value)
-			pkgPath, _, _, err := _type.dbp.resolveNameOff(_type.Addr, uintptr(pkgPathOff), _type.dbp.currentThread)
+			pkgPath, _, _, err := _type.dbp.bi.resolveNameOff(_type.Addr, uintptr(pkgPathOff), _type.dbp.currentThread)
 			if err != nil {
 				return "", err
 			}
@@ -376,11 +376,11 @@ func nameOfUnnamedRuntimeType(_type *Variable, kind, tflag int64) (string, error
 // (optional) and then by an array of pointers to runtime._type,
 // one for each input and output argument.
 func nameOfFuncRuntimeType(_type *Variable, tflag int64, anonymous bool) (string, error) {
-	rtyp, err := _type.dbp.findType("runtime._type")
+	rtyp, err := _type.dbp.bi.findType("runtime._type")
 	if err != nil {
 		return "", err
 	}
-	prtyp := pointerTo(rtyp, _type.dbp.arch)
+	prtyp := pointerTo(rtyp, _type.dbp.bi.arch)
 
 	uadd := _type.RealType.Common().ByteSize
 	if ut := uncommon(_type, tflag); ut != nil {
@@ -407,7 +407,7 @@ func nameOfFuncRuntimeType(_type *Variable, tflag int64, anonymous bool) (string
 
 	for i := int64(0); i < inCount; i++ {
 		argtype := cursortyp.maybeDereference()
-		cursortyp.Addr += uintptr(_type.dbp.arch.PtrSize())
+		cursortyp.Addr += uintptr(_type.dbp.bi.arch.PtrSize())
 		argtypename, _, err := nameOfRuntimeType(argtype)
 		if err != nil {
 			return "", err
@@ -434,7 +434,7 @@ func nameOfFuncRuntimeType(_type *Variable, tflag int64, anonymous bool) (string
 		buf.WriteString(" (")
 		for i := int64(0); i < outCount; i++ {
 			argtype := cursortyp.maybeDereference()
-			cursortyp.Addr += uintptr(_type.dbp.arch.PtrSize())
+			cursortyp.Addr += uintptr(_type.dbp.bi.arch.PtrSize())
 			argtypename, _, err := nameOfRuntimeType(argtype)
 			if err != nil {
 				return "", err
@@ -473,14 +473,14 @@ func nameOfInterfaceRuntimeType(_type *Variable, kind, tflag int64) (string, err
 			case "name":
 				nameoff, _ := constant.Int64Val(im.Children[i].Value)
 				var err error
-				methodname, _, _, err = _type.dbp.resolveNameOff(_type.Addr, uintptr(nameoff), _type.dbp.currentThread)
+				methodname, _, _, err = _type.dbp.bi.resolveNameOff(_type.Addr, uintptr(nameoff), _type.dbp.currentThread)
 				if err != nil {
 					return "", err
 				}
 
 			case "typ":
 				typeoff, _ := constant.Int64Val(im.Children[i].Value)
-				typ, err := _type.dbp.resolveTypeOff(_type.Addr, uintptr(typeoff), _type.dbp.currentThread)
+				typ, err := _type.dbp.bi.resolveTypeOff(_type.Addr, uintptr(typeoff), _type.dbp.currentThread)
 				if err != nil {
 					return "", err
 				}
@@ -536,7 +536,7 @@ func nameOfStructRuntimeType(_type *Variable, kind, tflag int64) (string, error)
 			case "name":
 				nameoff, _ := constant.Int64Val(field.Children[i].Value)
 				var err error
-				fieldname, _, _, err = _type.dbp.loadName(uintptr(nameoff), _type.mem)
+				fieldname, _, _, err = _type.dbp.bi.loadName(uintptr(nameoff), _type.mem)
 				if err != nil {
 					return "", err
 				}
@@ -578,13 +578,13 @@ func fieldToType(_type *Variable, fieldName string) (string, error) {
 }
 
 func specificRuntimeType(_type *Variable, kind int64) (*Variable, error) {
-	rtyp, err := _type.dbp.findType("runtime._type")
+	rtyp, err := _type.dbp.bi.findType("runtime._type")
 	if err != nil {
 		return nil, err
 	}
-	prtyp := pointerTo(rtyp, _type.dbp.arch)
+	prtyp := pointerTo(rtyp, _type.dbp.bi.arch)
 
-	uintptrtyp, err := _type.dbp.findType("uintptr")
+	uintptrtyp, err := _type.dbp.bi.findType("uintptr")
 	if err != nil {
 		return nil, err
 	}
@@ -602,7 +602,7 @@ func specificRuntimeType(_type *Variable, kind int64) (*Variable, error) {
 
 	newSliceType := func(elemtype dwarf.Type) *dwarf.SliceType {
 		r := newStructType("[]"+elemtype.Common().Name, uintptr(3*uintptrtyp.Size()))
-		appendField(r, "array", pointerTo(elemtype, _type.dbp.arch), 0)
+		appendField(r, "array", pointerTo(elemtype, _type.dbp.bi.arch), 0)
 		appendField(r, "len", uintptrtyp, uintptr(uintptrtyp.Size()))
 		appendField(r, "cap", uintptrtyp, uintptr(2*uintptrtyp.Size()))
 		return &dwarf.SliceType{StructType: *r, ElemType: elemtype}
@@ -746,7 +746,7 @@ func uncommon(_type *Variable, tflag int64) *Variable {
 		return nil
 	}
 
-	typ, err := _type.dbp.findType("runtime.uncommontype")
+	typ, err := _type.dbp.bi.findType("runtime.uncommontype")
 	if err != nil {
 		return nil
 	}

--- a/pkg/proc/variables.go
+++ b/pkg/proc/variables.go
@@ -1637,7 +1637,7 @@ func (v *Variable) loadInterface(recurseLevel int, loadData bool, cfg LoadConfig
 	if kind&kindDirectIface == 0 {
 		realtyp := resolveTypedef(typ)
 		if _, isptr := realtyp.(*dwarf.PtrType); !isptr {
-			typ = v.dbp.pointerTo(typ)
+			typ = pointerTo(typ, v.dbp.arch)
 		}
 	}
 

--- a/pkg/target/target.go
+++ b/pkg/target/target.go
@@ -3,7 +3,6 @@ package target
 import (
 	"debug/gosym"
 	"go/ast"
-	"time"
 
 	"github.com/derekparker/delve/pkg/proc"
 )
@@ -22,24 +21,14 @@ type Info interface {
 	Pid() int
 	Exited() bool
 	Running() bool
+	BinInfo() *proc.BinaryInfo
 
-	BinaryInfo
 	ThreadInfo
 	GoroutineInfo
 
 	FindFileLocation(fileName string, lineNumber int) (uint64, error)
 	FirstPCAfterPrologue(fn *gosym.Func, sameline bool) (uint64, error)
 	FindFunctionLocation(funcName string, firstLine bool, lineOffset int) (uint64, error)
-}
-
-// BinaryInfo is an interface for accessing information on the binary file
-// and the contents of binary sections.
-type BinaryInfo interface {
-	LastModified() time.Time
-	Sources() map[string]*gosym.Obj
-	Funcs() []gosym.Func
-	Types() ([]string, error)
-	PCToLine(uint64) (string, int, *gosym.Func)
 }
 
 // ThreadInfo is an interface for getting information on active threads
@@ -84,5 +73,4 @@ type VariableEval interface {
 	ConvertEvalScope(gid, frame int) (*proc.EvalScope, error)
 }
 
-var _ BinaryInfo = &proc.BinaryInfo{}
 var _ Interface = &proc.Process{}

--- a/pkg/target/target.go
+++ b/pkg/target/target.go
@@ -26,6 +26,10 @@ type Info interface {
 	BinaryInfo
 	ThreadInfo
 	GoroutineInfo
+
+	FindFileLocation(fileName string, lineNumber int) (uint64, error)
+	FirstPCAfterPrologue(fn *gosym.Func, sameline bool) (uint64, error)
+	FindFunctionLocation(funcName string, firstLine bool, lineOffset int) (uint64, error)
 }
 
 // BinaryInfo is an interface for accessing information on the binary file
@@ -33,12 +37,9 @@ type Info interface {
 type BinaryInfo interface {
 	LastModified() time.Time
 	Sources() map[string]*gosym.Obj
-	FindFileLocation(fileName string, lineNumber int) (uint64, error)
-	FindFunctionLocation(funcName string, firstLine bool, lineOffset int) (uint64, error)
 	Funcs() []gosym.Func
 	Types() ([]string, error)
 	PCToLine(uint64) (string, int, *gosym.Func)
-	FirstPCAfterPrologue(fn *gosym.Func, sameline bool) (uint64, error)
 }
 
 // ThreadInfo is an interface for getting information on active threads
@@ -82,3 +83,6 @@ type BreakpointManipulation interface {
 type VariableEval interface {
 	ConvertEvalScope(gid, frame int) (*proc.EvalScope, error)
 }
+
+var _ BinaryInfo = &proc.BinaryInfo{}
+var _ Interface = &proc.Process{}

--- a/service/debugger/debugger.go
+++ b/service/debugger/debugger.go
@@ -68,7 +68,7 @@ func New(config *Config) (*Debugger, error) {
 		log.Printf("launching process with args: %v", d.config.ProcessArgs)
 		p, err := proc.Launch(d.config.ProcessArgs, d.config.WorkingDir)
 		if err != nil {
-			if err != proc.NotExecutableErr && err != proc.UnsupportedArchErr {
+			if err != proc.NotExecutableErr && err != proc.UnsupportedLinuxArchErr && err != proc.UnsupportedWindowsArchErr && err != proc.UnsupportedDarwinArchErr {
 				err = fmt.Errorf("could not launch process: %s", err)
 			}
 			return nil, err

--- a/service/debugger/locations.go
+++ b/service/debugger/locations.go
@@ -243,7 +243,7 @@ func (spec *FuncLocationSpec) Match(sym *gosym.Sym) bool {
 }
 
 func (loc *RegexLocationSpec) Find(d *Debugger, scope *proc.EvalScope, locStr string) ([]api.Location, error) {
-	funcs := d.target.Funcs()
+	funcs := d.target.BinInfo().Funcs()
 	matches, err := regexFilterFuncs(loc.FuncRegex, funcs)
 	if err != nil {
 		return nil, err
@@ -278,7 +278,7 @@ func (loc *AddrLocationSpec) Find(d *Debugger, scope *proc.EvalScope, locStr str
 			addr, _ := constant.Uint64Val(v.Value)
 			return []api.Location{{PC: addr}}, nil
 		case reflect.Func:
-			_, _, fn := d.target.PCToLine(uint64(v.Base))
+			_, _, fn := d.target.BinInfo().PCToLine(uint64(v.Base))
 			pc, err := d.target.FirstPCAfterPrologue(fn, false)
 			if err != nil {
 				return nil, err
@@ -327,8 +327,8 @@ func (ale AmbiguousLocationError) Error() string {
 }
 
 func (loc *NormalLocationSpec) Find(d *Debugger, scope *proc.EvalScope, locStr string) ([]api.Location, error) {
-	funcs := d.target.Funcs()
-	files := d.target.Sources()
+	funcs := d.target.BinInfo().Funcs()
+	files := d.target.BinInfo().Sources()
 
 	candidates := []string{}
 	for file := range files {
@@ -390,7 +390,7 @@ func (loc *OffsetLocationSpec) Find(d *Debugger, scope *proc.EvalScope, locStr s
 	if scope == nil {
 		return nil, fmt.Errorf("could not determine current location (scope is nil)")
 	}
-	file, line, fn := d.target.PCToLine(scope.PC)
+	file, line, fn := d.target.BinInfo().PCToLine(scope.PC)
 	if fn == nil {
 		return nil, fmt.Errorf("could not determine current location")
 	}
@@ -402,7 +402,7 @@ func (loc *LineLocationSpec) Find(d *Debugger, scope *proc.EvalScope, locStr str
 	if scope == nil {
 		return nil, fmt.Errorf("could not determine current location (scope is nil)")
 	}
-	file, _, fn := d.target.PCToLine(scope.PC)
+	file, _, fn := d.target.BinInfo().PCToLine(scope.PC)
 	if fn == nil {
 		return nil, fmt.Errorf("could not determine current location")
 	}


### PR DESCRIPTION
```
proc: compile support for all executable formats unconditionally

So far we only compiled in support for loading the executable format
supported by the host operating system.
Once support for core files is introduced it is however useful to
support loading in all executable formats, there is no reason why it
shouldn't be possible to examine a linux coredump on windows, or
viceversa.

proc: refactor BinaryInfo part of proc.Process to own type

The data structures and associated code used by proc.Process
to implement target.BinaryInfo will also be useful to support a
backend for examining core dumps, split this part of proc.Process
to a different type.

```
