### PR TITLE
Add Go 1.8 to Travis test matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,8 +7,8 @@ os:
 
 go:
   - tip
+  - 1.8
   - 1.7
-  - 1.6
 
 matrix:
   allow_failures:


### PR DESCRIPTION
Dropping test coverage for Go 1.6.