### PR TITLE
pkg/proc: tolerate absence of stack barriers in Go 1.9

### DIFF
--- a/pkg/proc/proc_test.go
+++ b/pkg/proc/proc_test.go
@@ -2485,13 +2485,15 @@ func TestStacktraceWithBarriers(t *testing.T) {
 	// The original return address is saved into the stkbar slice inside the G
 	// struct.
 
+	// In Go 1.9 stack barriers have been removed and this test must be disabled.
+	if ver, _ := ParseVersionString(runtime.Version()); ver.Major < 0 || ver.AfterOrEqual(GoVersion{1, 9, -1, 0, 0}) {
+		return
+	}
+
 	// In Go 1.8 stack barriers are not inserted by default, this enables them.
 	godebugOld := os.Getenv("GODEBUG")
 	defer os.Setenv("GODEBUG", godebugOld)
 	os.Setenv("GODEBUG", "gcrescanstacks=1")
-
-	// TODO(aarzilli): in Go 1.9 stack barriers will be removed completely, therefore
-	// this test will have to be disabled
 
 	withTestProcess("binarytrees", t, func(p *Process, fixture protest.Fixture) {
 		// We want to get a user goroutine with a stack barrier, to get that we execute the program until runtime.gcInstallStackBarrier is executed AND the goroutine it was executed onto contains a call to main.bottomUpTree

--- a/pkg/proc/stack.go
+++ b/pkg/proc/stack.go
@@ -130,8 +130,10 @@ type savedLR struct {
 }
 
 func newStackIterator(dbp *Process, pc, sp, bp uint64, stkbar []savedLR, stkbarPos int) *stackIterator {
-	stackBarrierPC := dbp.goSymTable.LookupFunc(runtimeStackBarrier).Entry
-	if stkbar != nil {
+	stackBarrierFunc := dbp.goSymTable.LookupFunc(runtimeStackBarrier) // stack barriers were removed in Go 1.9
+	var stackBarrierPC uint64
+	if stackBarrierFunc != nil && stkbar != nil {
+		stackBarrierPC = stackBarrierFunc.Entry
 		fn := dbp.goSymTable.PCToFunc(pc)
 		if fn != nil && fn.Name == runtimeStackBarrier {
 			// We caught the goroutine as it's executing the stack barrier, we must


### PR DESCRIPTION
Stack barriers were removed in Go 1.9, and thus code that
expected various stack-barrier-related symbols to exist
does not find them.  Check for their absence and do not
crash when they are missing.
