### PR TITLE
bugfix: wrong register used for CH

### DIFF
--- a/pkg/proc/registers_darwin_amd64.go
+++ b/pkg/proc/registers_darwin_amd64.go
@@ -134,7 +134,7 @@ func (r *Regs) Get(n int) (uint64, error) {
 	case x86asm.AH:
 		return (r.rax >> 8) & mask8, nil
 	case x86asm.CH:
-		return (r.rax >> 8) & mask8, nil
+		return (r.rcx >> 8) & mask8, nil
 	case x86asm.DH:
 		return (r.rdx >> 8) & mask8, nil
 	case x86asm.BH:

--- a/pkg/proc/registers_linux_amd64.go
+++ b/pkg/proc/registers_linux_amd64.go
@@ -112,7 +112,7 @@ func (r *Regs) Get(n int) (uint64, error) {
 	case x86asm.AH:
 		return (r.regs.Rax >> 8) & mask8, nil
 	case x86asm.CH:
-		return (r.regs.Rax >> 8) & mask8, nil
+		return (r.regs.Rcx >> 8) & mask8, nil
 	case x86asm.DH:
 		return (r.regs.Rdx >> 8) & mask8, nil
 	case x86asm.BH:

--- a/pkg/proc/registers_windows_amd64.go
+++ b/pkg/proc/registers_windows_amd64.go
@@ -159,7 +159,7 @@ func (r *Regs) Get(n int) (uint64, error) {
 	case x86asm.AH:
 		return (r.rax >> 8) & mask8, nil
 	case x86asm.CH:
-		return (r.rax >> 8) & mask8, nil
+		return (r.rcx >> 8) & mask8, nil
 	case x86asm.DH:
 		return (r.rdx >> 8) & mask8, nil
 	case x86asm.BH:


### PR DESCRIPTION
```
bugfix: wrong register used for CH

We only use Registers.Get besides for evaluating the argument of a CALL
instruction so this doesn't matter in practice, but it's still wrong.

```
