### PR TITLE
proc/tests: use Detach(true) instead of Kill in tests

### DIFF
--- a/pkg/proc/proc.go
+++ b/pkg/proc/proc.go
@@ -112,6 +112,9 @@ func (pe ProcessExitedError) Error() string {
 
 // Detach from the process being debugged, optionally killing it.
 func (dbp *Process) Detach(kill bool) (err error) {
+	if dbp.exited {
+		return nil
+	}
 	if dbp.Running() {
 		if err = dbp.Halt(); err != nil {
 			return

--- a/pkg/proc/proc_test.go
+++ b/pkg/proc/proc_test.go
@@ -40,7 +40,7 @@ func withTestProcess(name string, t testing.TB, fn func(p *Process, fixture prot
 
 	defer func() {
 		p.Halt()
-		p.Kill()
+		p.Detach(true)
 	}()
 
 	fn(p, fixture)


### PR DESCRIPTION
```
proc/tests: use Detach(true) instead of Kill in tests

The rest of the code uses Detach to "close" a proc.Process, the tests
should do the same.
Any cleanup that proc.Process needs to do can then be put inside Detach
and the tests will run it.

```
