### PR TITLE
terminal: trim space in interactive console

### DIFF
--- a/pkg/terminal/terminal.go
+++ b/pkg/terminal/terminal.go
@@ -128,7 +128,7 @@ func (t *Term) Run() (int, error) {
 			return 1, fmt.Errorf("Prompt for input failed.\n")
 		}
 
-		cmdstr, args := parseCommand(cmdstr)
+		cmdstr, args := parseCommand(strings.TrimSpace(cmdstr))
 		if err := t.cmds.Call(cmdstr, args, t); err != nil {
 			if _, ok := err.(ExitRequestError); ok {
 				return t.handleExit()


### PR DESCRIPTION
When running interactive command in gdb, it will remove beginning space,
so do the same for dlv, which will be more convient for user