### PR TITLE
proc: add test for attach/detach, fix detach

### DIFF
--- a/_fixtures/testnextnethttp.go
+++ b/_fixtures/testnextnethttp.go
@@ -12,5 +12,13 @@ func main() {
 		header := w.Header().Get("Content-Type")
 		w.Write([]byte(msg + header))
 	})
-	http.ListenAndServe(":9191", nil)
+	http.HandleFunc("/nobp", func(w http.ResponseWriter, req *http.Request) {
+		msg := "hello, world!"
+		header := w.Header().Get("Content-Type")
+		w.Write([]byte(msg + header))
+	})
+	err := http.ListenAndServe(":9191", nil)
+	if err != nil {
+		panic(err)
+	}
 }

--- a/pkg/proc/proc.go
+++ b/pkg/proc/proc.go
@@ -132,7 +132,7 @@ func (dbp *Process) Detach(kill bool) (err error) {
 		}
 	}
 	dbp.execPtraceFunc(func() {
-		err = PtraceDetach(dbp.pid, 0)
+		err = dbp.detach()
 		if err != nil {
 			return
 		}

--- a/pkg/proc/proc_darwin.go
+++ b/pkg/proc/proc_darwin.go
@@ -509,3 +509,7 @@ func (dbp *Process) resume() error {
 	}
 	return nil
 }
+
+func (dbp *Process) detach() error {
+	return PtraceDetach(dbp.pid, 0)
+}

--- a/pkg/proc/proc_windows.go
+++ b/pkg/proc/proc_windows.go
@@ -663,6 +663,16 @@ func (dbp *Process) resume() error {
 	return nil
 }
 
+func (dbp *Process) detach() error {
+	for _, thread := range dbp.threads {
+		_, err := _ResumeThread(thread.os.hThread)
+		if err != nil {
+			return err
+		}
+	}
+	return PtraceDetach(dbp.pid, 0)
+}
+
 func killProcess(pid int) error {
 	p, err := os.FindProcess(pid)
 	if err != nil {


### PR DESCRIPTION
Detach did not work for processes we attach to via PID.

Linux: we were only detaching from the main thread, all threads are
detached independently

Windows: we must resume all threads before detaching.

macOS: still broken.

Updates #772