### PR TITLE
Add an entry for Gogland

### DIFF
--- a/Documentation/EditorIntegration.md
+++ b/Documentation/EditorIntegration.md
@@ -1,6 +1,7 @@
 The following editor plugins for delve are available:
 
 * [Golang Plugin for IntelliJ IDEA](https://github.com/go-lang-plugin-org/go-lang-idea-plugin)
+* [JetBrains Gogland](https://www.jetbrains.com/go) - "early access" builds so far
 * [Go for Visual Studio Code](https://github.com/Microsoft/vscode-go)
 * [Emacs plugin](https://github.com/benma/go-dlv.el/)
 * [LiteIDE](https://github.com/visualfc/liteide)


### PR DESCRIPTION
Not sure if it's better to wait for the official release of Gogland, or point it out now so more people test it.

In near daily use for the past few weeks, it's been better than using the IntelliJ plugin version.  Which itself was pretty good.