### PR TITLE
More refactoring + core integration + debugserver backend

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ This project adheres to Semantic Versioning.
 
 All changes mention the author, unless contributed by me (@derekparker).
 
+## [NEWEST VERSION] RELEASE DATE
+
+### Added
+
+- Added support for core files (@heschik)
+- Added support for lldb-server and debugserver as backend, using debugserver by default on macOS (@aarzilli)
+
 ## [0.12.2] 2017-04-13
 
 ### Fixed

--- a/_fixtures/panic.go
+++ b/_fixtures/panic.go
@@ -1,5 +1,6 @@
 package main
 
 func main() {
-	panic("BOOM!")
+	msg := "BOOM!"
+	panic(msg)
 }

--- a/cmd/dlv/dlv_test.go
+++ b/cmd/dlv/dlv_test.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"bufio"
+	"flag"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -12,6 +13,20 @@ import (
 	protest "github.com/derekparker/delve/pkg/proc/test"
 	"github.com/derekparker/delve/service/rpc2"
 )
+
+var testBackend string
+
+func TestMain(m *testing.M) {
+	flag.StringVar(&testBackend, "backend", "", "selects backend")
+	flag.Parse()
+	if testBackend == "" {
+		testBackend = os.Getenv("PROCTEST")
+		if testBackend == "" {
+			testBackend = "native"
+		}
+	}
+	os.Exit(m.Run())
+}
 
 func assertNoError(err error, t testing.TB, s string) {
 	if err != nil {
@@ -52,7 +67,7 @@ func TestBuild(t *testing.T) {
 
 	buildtestdir := filepath.Join(fixtures, "buildtest")
 
-	cmd := exec.Command(dlvbin, "debug", "--headless=true", "--listen="+listenAddr, "--api-version=2")
+	cmd := exec.Command(dlvbin, "debug", "--headless=true", "--listen="+listenAddr, "--api-version=2", "--backend="+testBackend)
 	cmd.Dir = buildtestdir
 	stdout, err := cmd.StdoutPipe()
 	assertNoError(err, t, "stdout pipe")

--- a/pkg/proc/arch.go
+++ b/pkg/proc/arch.go
@@ -8,6 +8,7 @@ type Arch interface {
 	BreakpointInstruction() []byte
 	BreakpointSize() int
 	GStructOffset() uint64
+	DerefTLS() bool
 }
 
 // AMD64 represents the AMD64 CPU architecture.
@@ -76,4 +77,10 @@ func (a *AMD64) BreakpointSize() int {
 // struct in thread local storage.
 func (a *AMD64) GStructOffset() uint64 {
 	return a.gStructOffset
+}
+
+// If DerefTLS returns true the value of regs.TLS()+GStructOffset() is a
+// pointer to the G struct
+func (a *AMD64) DerefTLS() bool {
+	return a.goos == "windows"
 }

--- a/pkg/proc/bininfo.go
+++ b/pkg/proc/bininfo.go
@@ -107,6 +107,11 @@ func (bi *BinaryInfo) PCToLine(pc uint64) (string, int, *gosym.Func) {
 	return bi.goSymTable.PCToLine(pc)
 }
 
+// LineToPC converts a file:line into a memory address.
+func (bi *BinaryInfo) LineToPC(filename string, lineno int) (pc uint64, fn *gosym.Func, err error) {
+	return bi.goSymTable.LineToPC(filename, lineno)
+}
+
 func (bi *BinaryInfo) Close() error {
 	return bi.closer.Close()
 }

--- a/pkg/proc/breakpoints.go
+++ b/pkg/proc/breakpoints.go
@@ -107,7 +107,7 @@ func (dbp *Process) writeSoftwareBreakpoint(thread *Thread, addr uint64) error {
 	return err
 }
 
-func (bp *Breakpoint) checkCondition(thread *Thread) (bool, error) {
+func (bp *Breakpoint) checkCondition(thread IThread) (bool, error) {
 	if bp.Cond == nil {
 		return true, nil
 	}

--- a/pkg/proc/breakpoints.go
+++ b/pkg/proc/breakpoints.go
@@ -112,7 +112,7 @@ func (bp *Breakpoint) checkCondition(thread *Thread) (bool, error) {
 		return true, nil
 	}
 	if bp.Kind == NextDeferBreakpoint {
-		frames, err := thread.Stacktrace(2)
+		frames, err := ThreadStacktrace(thread, 2)
 		if err == nil {
 			ispanic := len(frames) >= 3 && frames[2].Current.Fn != nil && frames[2].Current.Fn.Name == "runtime.gopanic"
 			isdeferreturn := false
@@ -129,7 +129,7 @@ func (bp *Breakpoint) checkCondition(thread *Thread) (bool, error) {
 			}
 		}
 	}
-	scope, err := thread.GoroutineScope()
+	scope, err := GoroutineScope(thread)
 	if err != nil {
 		return true, err
 	}

--- a/pkg/proc/breakpoints.go
+++ b/pkg/proc/breakpoints.go
@@ -72,9 +72,8 @@ func (bp *Breakpoint) String() string {
 	return fmt.Sprintf("Breakpoint %d at %#v %s:%d (%d)", bp.ID, bp.Addr, bp.File, bp.Line, bp.TotalHitCount)
 }
 
-// Clear this breakpoint appropriately depending on whether it is a
-// hardware or software breakpoint.
-func (bp *Breakpoint) Clear(thread *Thread) (*Breakpoint, error) {
+// ClearBreakpoint clears the specified breakpoint.
+func (thread *Thread) ClearBreakpoint(bp *Breakpoint) (*Breakpoint, error) {
 	if _, err := thread.writeMemory(uintptr(bp.Addr), bp.OriginalData); err != nil {
 		return nil, fmt.Errorf("could not clear breakpoint %s", err)
 	}

--- a/pkg/proc/core.go
+++ b/pkg/proc/core.go
@@ -9,15 +9,6 @@ import (
 	"sync"
 )
 
-// MemoryReader is like io.ReaderAt, but the offset is a uintptr so that it
-// can address all of 64-bit memory.
-// Redundant with memoryReadWriter but more easily suited to working with
-// the standard io package.
-type MemoryReader interface {
-	// ReadMemory is just like io.ReaderAt.ReadAt.
-	ReadMemory(buf []byte, addr uintptr) (n int, err error)
-}
-
 // A SplicedMemory represents a memory space formed from multiple regions,
 // each of which may override previously regions. For example, in the following
 // core, the program text was loaded at 0x400000:
@@ -203,13 +194,12 @@ func (p *CoreProcess) BinInfo() *BinaryInfo {
 	return &p.bi
 }
 
-func (thread *CoreThread) readMemory(addr uintptr, size int) (data []byte, err error) {
-	data = make([]byte, size)
-	n, err := thread.p.core.ReadMemory(data, addr)
+func (thread *CoreThread) ReadMemory(data []byte, addr uintptr) (n int, err error) {
+	n, err = thread.p.core.ReadMemory(data, addr)
 	if err == nil && n != len(data) {
 		err = ErrShortRead
 	}
-	return data, err
+	return n, err
 }
 
 func (thread *CoreThread) writeMemory(addr uintptr, data []byte) (int, error) {

--- a/pkg/proc/core.go
+++ b/pkg/proc/core.go
@@ -1,0 +1,146 @@
+package proc
+
+import (
+	"fmt"
+	"io"
+)
+
+// MemoryReader is like io.ReaderAt, but the offset is a uintptr so that it
+// can address all of 64-bit memory.
+// Redundant with memoryReadWriter but more easily suited to working with
+// the standard io package.
+type MemoryReader interface {
+	// ReadMemory is just like io.ReaderAt.ReadAt.
+	ReadMemory(buf []byte, addr uintptr) (n int, err error)
+}
+
+// A SplicedMemory represents a memory space formed from multiple regions,
+// each of which may override previously regions. For example, in the following
+// core, the program text was loaded at 0x400000:
+// Start               End                 Page Offset
+// 0x0000000000400000  0x000000000044f000  0x0000000000000000
+// but then it's partially overwritten with an RW mapping whose data is stored
+// in the core file:
+// Type           Offset             VirtAddr           PhysAddr
+//                FileSiz            MemSiz              Flags  Align
+// LOAD           0x0000000000004000 0x000000000049a000 0x0000000000000000
+//                0x0000000000002000 0x0000000000002000  RW     1000
+// This can be represented in a SplicedMemory by adding the original region,
+// then putting the RW mapping on top of it.
+type SplicedMemory struct {
+	readers []readerEntry
+}
+
+type readerEntry struct {
+	offset uintptr
+	length uintptr
+	reader MemoryReader
+}
+
+// Add adds a new region to the SplicedMemory, which may override existing regions.
+func (r *SplicedMemory) Add(reader MemoryReader, off, length uintptr) {
+	if length == 0 {
+		return
+	}
+	end := off + length - 1
+	newReaders := make([]readerEntry, 0, len(r.readers))
+	add := func(e readerEntry) {
+		if e.length == 0 {
+			return
+		}
+		newReaders = append(newReaders, e)
+	}
+	inserted := false
+	// Walk through the list of regions, fixing up any that overlap and inserting the new one.
+	for _, entry := range r.readers {
+		entryEnd := entry.offset + entry.length - 1
+		switch {
+		case entryEnd < off:
+			// Entry is completely before the new region.
+			add(entry)
+		case end < entry.offset:
+			// Entry is completely after the new region.
+			if !inserted {
+				add(readerEntry{off, length, reader})
+				inserted = true
+			}
+			add(entry)
+		case off <= entry.offset && entryEnd <= end:
+			// Entry is completely overwritten by the new region. Drop.
+		case entry.offset < off && entryEnd <= end:
+			// New region overwrites the end of the entry.
+			entry.length = off - entry.offset
+			add(entry)
+		case off <= entry.offset && end < entryEnd:
+			// New reader overwrites the beginning of the entry.
+			if !inserted {
+				add(readerEntry{off, length, reader})
+				inserted = true
+			}
+			overlap := entry.offset - off
+			entry.offset += overlap
+			entry.length -= overlap
+			add(entry)
+		case entry.offset < off && end < entryEnd:
+			// New region punches a hole in the entry. Split it in two and put the new region in the middle.
+			add(readerEntry{entry.offset, off - entry.offset, entry.reader})
+			add(readerEntry{off, length, reader})
+			add(readerEntry{end + 1, entryEnd - end, entry.reader})
+			inserted = true
+		default:
+			panic(fmt.Sprintf("Unhandled case: existing entry is %v len %v, new is %v len %v", entry.offset, entry.length, off, length))
+		}
+	}
+	if !inserted {
+		newReaders = append(newReaders, readerEntry{off, length, reader})
+	}
+	r.readers = newReaders
+}
+
+// ReadMemory implements MemoryReader.ReadMemory.
+func (r *SplicedMemory) ReadMemory(buf []byte, addr uintptr) (n int, err error) {
+	started := false
+	for _, entry := range r.readers {
+		if entry.offset+entry.length < addr {
+			if !started {
+				continue
+			}
+			return n, fmt.Errorf("hit unmapped area at %v after %v bytes", addr, n)
+		}
+
+		// Don't go past the region.
+		pb := buf
+		if addr+uintptr(len(buf)) > entry.offset+entry.length {
+			pb = pb[:entry.offset+entry.length-addr]
+		}
+		pn, err := entry.reader.ReadMemory(pb, addr)
+		n += pn
+		if err != nil || pn != len(pb) {
+			return n, err
+		}
+		buf = buf[pn:]
+		addr += uintptr(pn)
+		if len(buf) == 0 {
+			// Done, don't bother scanning the rest.
+			return n, nil
+		}
+	}
+	if n == 0 {
+		return 0, fmt.Errorf("offset %v did not match any regions", addr)
+	}
+	return n, nil
+}
+
+// OffsetReaderAt wraps a ReaderAt into a MemoryReader, subtracting a fixed
+// offset from the address. This is useful to represent a mapping in an address
+// space. For example, if program text is mapped in at 0x400000, an
+// OffsetReaderAt with offset 0x400000 can be wrapped around file.Open(program)
+// to return the results of a read in that part of the address space.
+type OffsetReaderAt struct {
+	reader io.ReaderAt
+	offset uintptr
+}
+
+func (r *OffsetReaderAt) ReadMemory(buf []byte, addr uintptr) (n int, err error) {
+	return r.reader.ReadAt(buf, int64(addr-r.offset))
+}

--- a/pkg/proc/core_linux_amd64.go
+++ b/pkg/proc/core_linux_amd64.go
@@ -1,0 +1,269 @@
+package proc
+
+import (
+	"bytes"
+	"encoding/binary"
+	"fmt"
+	"io"
+	"os"
+
+	"golang.org/x/debug/elf"
+	"golang.org/x/sys/unix"
+)
+
+const NT_FILE elf.NType = 0x46494c45 // "FILE".
+
+// readCore reads a core file from corePath corresponding to the executable at
+// exePath. For details on the Linux ELF core format, see:
+// http://www.gabriel.urdhr.fr/2015/05/29/core-file/,
+// http://uhlo.blogspot.fr/2012/05/brief-look-into-core-dumps.html,
+// elf_core_dump in http://lxr.free-electrons.com/source/fs/binfmt_elf.c,
+// and, if absolutely desperate, readelf.c from the binutils source.
+func readCore(corePath, exePath string) (*Core, error) {
+	core, err := elf.Open(corePath)
+	if err != nil {
+		return nil, err
+	}
+	exe, err := os.Open(exePath)
+	if err != nil {
+		return nil, err
+	}
+
+	if core.Type != elf.ET_CORE {
+		return nil, fmt.Errorf("%v is not a core file", core)
+	}
+
+	notes, err := readNotes(core)
+	if err != nil {
+		return nil, err
+	}
+	memory := buildMemory(core, exe, notes)
+
+	threads := map[int]*LinuxPrStatus{}
+	pid := 0
+	for _, note := range notes {
+		switch note.Type {
+		case elf.NT_PRSTATUS:
+			t := note.Desc.(*LinuxPrStatus)
+			threads[int(t.Pid)] = t
+		case elf.NT_PRPSINFO:
+			pid = int(note.Desc.(*LinuxPrPsInfo).Pid)
+		}
+	}
+	return &Core{
+		MemoryReader: memory,
+		Threads:      threads,
+		Pid:          pid,
+	}, nil
+}
+
+type Core struct {
+	MemoryReader
+	Threads map[int]*LinuxPrStatus
+	Pid     int
+}
+
+// Note is a note from the PT_NOTE prog.
+// Relevant types:
+// - NT_FILE: File mapping information, e.g. program text mappings. Desc is a LinuxNTFile.
+// - NT_PRPSINFO: Information about a process, including PID and signal. Desc is a LinuxPrPsInfo.
+// - NT_PRSTATUS: Information about a thread, including base registers, state, etc. Desc is a LinuxPrStatus.
+// - NT_FPREGSET (Not implemented): x87 floating point registers.
+// - NT_X86_XSTATE (Not implemented): Other registers, including AVX and such.
+type Note struct {
+	Type elf.NType
+	Name string
+	Desc interface{} // Decoded Desc from the
+}
+
+// readNotes reads all the notes from the notes prog in core.
+func readNotes(core *elf.File) ([]*Note, error) {
+	var notesProg *elf.Prog
+	for _, prog := range core.Progs {
+		if prog.Type == elf.PT_NOTE {
+			notesProg = prog
+			break
+		}
+	}
+
+	r := notesProg.Open()
+	notes := []*Note{}
+	for {
+		note, err := readNote(r)
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			return nil, err
+		}
+		notes = append(notes, note)
+	}
+
+	return notes, nil
+}
+
+// readNote reads a single note from r, decoding the descriptor if possible.
+func readNote(r io.ReadSeeker) (*Note, error) {
+	// Notes are laid out as described in the SysV ABI:
+	// http://www.sco.com/developers/gabi/latest/ch5.pheader.html#note_section
+	note := &Note{}
+	hdr := &ELFNotesHdr{}
+
+	err := binary.Read(r, binary.LittleEndian, hdr)
+	if err != nil {
+		return nil, err // don't wrap so readNotes sees EOF.
+	}
+	note.Type = elf.NType(hdr.Type)
+
+	name := make([]byte, hdr.Namesz)
+	if _, err := r.Read(name); err != nil {
+		return nil, fmt.Errorf("reading name: %v", err)
+	}
+	note.Name = string(name)
+	if err := skipPadding(r, 4); err != nil {
+		return nil, fmt.Errorf("aligning after name: %v", err)
+	}
+	desc := make([]byte, hdr.Descsz)
+	if _, err := r.Read(desc); err != nil {
+		return nil, fmt.Errorf("reading desc: %v", err)
+	}
+	descReader := bytes.NewReader(desc)
+	switch note.Type {
+	case elf.NT_PRSTATUS:
+		note.Desc = &LinuxPrStatus{}
+		if err := binary.Read(descReader, binary.LittleEndian, note.Desc); err != nil {
+			return nil, fmt.Errorf("reading NT_PRSTATUS: %v", err)
+		}
+	case elf.NT_PRPSINFO:
+		note.Desc = &LinuxPrPsInfo{}
+		if err := binary.Read(descReader, binary.LittleEndian, note.Desc); err != nil {
+			return nil, fmt.Errorf("reading NT_PRPSINFO: %v", err)
+		}
+	case NT_FILE:
+		// No good documentation reference, but the structure is
+		// simply a header, including entry count, followed by that
+		// many entries, and then the file name of each entry,
+		// null-delimited. Not reading the names here.
+		data := &LinuxNTFile{}
+		if err := binary.Read(descReader, binary.LittleEndian, &data.LinuxNTFileHdr); err != nil {
+			return nil, fmt.Errorf("reading NT_FILE header: %v", err)
+		}
+		for i := 0; i < int(data.Count); i++ {
+			entry := &LinuxNTFileEntry{}
+			if err := binary.Read(descReader, binary.LittleEndian, entry); err != nil {
+				return nil, fmt.Errorf("reading NT_PRPSINFO entry %v: %v", i, err)
+			}
+			data.entries = append(data.entries, entry)
+		}
+		note.Desc = data
+	}
+	if err := skipPadding(r, 4); err != nil {
+		return nil, fmt.Errorf("aligning after desc: %v", err)
+	}
+	return note, nil
+}
+
+// skipPadding moves r to the next multiple of pad.
+func skipPadding(r io.ReadSeeker, pad int64) error {
+	pos, err := r.Seek(0, io.SeekCurrent)
+	if err != nil {
+		return err
+	}
+	if pos%pad == 0 {
+		return nil
+	}
+	if _, err := r.Seek(pad-(pos%pad), io.SeekCurrent); err != nil {
+		return err
+	}
+	return nil
+}
+
+func buildMemory(core *elf.File, exe io.ReaderAt, notes []*Note) MemoryReader {
+	memory := &SplicedMemory{}
+
+	// For now, assume all file mappings are to the exe.
+	for _, note := range notes {
+		if note.Type == NT_FILE {
+			fileNote := note.Desc.(*LinuxNTFile)
+			for _, entry := range fileNote.entries {
+				r := &OffsetReaderAt{
+					reader: exe,
+					offset: uintptr(entry.Start - (entry.FileOfs * fileNote.PageSize)),
+				}
+				memory.Add(r, uintptr(entry.Start), uintptr(entry.End-entry.Start))
+			}
+
+		}
+	}
+	for _, prog := range core.Progs {
+		if prog.Type == elf.PT_LOAD {
+			if prog.Filesz == 0 {
+				continue
+			}
+			r := &OffsetReaderAt{
+				reader: prog.ReaderAt,
+				offset: uintptr(prog.Vaddr),
+			}
+			memory.Add(r, uintptr(prog.Vaddr), uintptr(prog.Filesz))
+		}
+	}
+	return memory
+}
+
+// Various structures from the ELF spec and the Linux kernel.
+// AMD64 specific primarily because of unix.PtraceRegs, but also
+// because some of the fields are word sized.
+// See http://lxr.free-electrons.com/source/include/uapi/linux/elfcore.h
+type LinuxPrPsInfo struct {
+	State                uint8
+	Sname                int8
+	Zomb                 uint8
+	Nice                 int8
+	_                    [4]uint8
+	Flag                 uint64
+	Uid, Gid             uint32
+	Pid, Ppid, Pgrp, Sid int32
+	Fname                [16]uint8
+	Args                 [80]uint8
+}
+
+type LinuxPrStatus struct {
+	Siginfo                      LinuxSiginfo
+	Cursig                       uint16
+	_                            [2]uint8
+	Sigpend                      uint64
+	Sighold                      uint64
+	Pid, Ppid, Pgrp, Sid         int32
+	Utime, Stime, CUtime, CStime unix.Timeval
+	Reg                          unix.PtraceRegs
+	Fpvalid                      int32
+}
+
+type LinuxSiginfo struct {
+	Signo int32
+	Code  int32
+	Errno int32
+}
+
+type LinuxNTFile struct {
+	LinuxNTFileHdr
+	entries []*LinuxNTFileEntry
+}
+
+type LinuxNTFileHdr struct {
+	Count    uint64
+	PageSize uint64
+}
+
+type LinuxNTFileEntry struct {
+	Start   uint64
+	End     uint64
+	FileOfs uint64
+}
+
+// ELF Notes header. Same size on 64 and 32-bit machines.
+type ELFNotesHdr struct {
+	Namesz uint32
+	Descsz uint32
+	Type   uint32
+}

--- a/pkg/proc/core_linux_amd64_test.go
+++ b/pkg/proc/core_linux_amd64_test.go
@@ -1,0 +1,151 @@
+package proc
+
+import (
+	"bytes"
+	"io/ioutil"
+	"os/exec"
+	"reflect"
+	"testing"
+
+	"fmt"
+
+	"path"
+
+	"github.com/derekparker/delve/pkg/proc/test"
+)
+
+func TestSplicedReader(t *testing.T) {
+	data := []byte{}
+	data2 := []byte{}
+	for i := 0; i < 100; i++ {
+		data = append(data, byte(i))
+		data2 = append(data2, byte(i+100))
+	}
+
+	type region struct {
+		data   []byte
+		off    uintptr
+		length uintptr
+	}
+	tests := []struct {
+		name     string
+		regions  []region
+		readAddr uintptr
+		readLen  int
+		want     []byte
+	}{
+		{
+			"Insert after",
+			[]region{
+				{data, 0, 1},
+				{data2, 1, 1},
+			},
+			0,
+			2,
+			[]byte{0, 101},
+		},
+		{
+			"Insert before",
+			[]region{
+				{data, 1, 1},
+				{data2, 0, 1},
+			},
+			0,
+			2,
+			[]byte{100, 1},
+		},
+		{
+			"Completely overwrite",
+			[]region{
+				{data, 1, 1},
+				{data2, 0, 3},
+			},
+			0,
+			3,
+			[]byte{100, 101, 102},
+		},
+		{
+			"Overwrite end",
+			[]region{
+				{data, 0, 2},
+				{data2, 1, 2},
+			},
+			0,
+			3,
+			[]byte{0, 101, 102},
+		},
+		{
+			"Overwrite start",
+			[]region{
+				{data, 0, 3},
+				{data2, 0, 2},
+			},
+			0,
+			3,
+			[]byte{100, 101, 2},
+		},
+		{
+			"Punch hole",
+			[]region{
+				{data, 0, 5},
+				{data2, 1, 3},
+			},
+			0,
+			5,
+			[]byte{0, 101, 102, 103, 4},
+		},
+		{
+			"Overlap two",
+			[]region{
+				{data, 10, 4},
+				{data, 14, 4},
+				{data2, 12, 4},
+			},
+			10,
+			8,
+			[]byte{10, 11, 112, 113, 114, 115, 16, 17},
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			mem := &SplicedMemory{}
+			for _, region := range test.regions {
+				r := bytes.NewReader(region.data)
+				mem.Add(&OffsetReaderAt{r, 0}, region.off, region.length)
+			}
+			got := make([]byte, test.readLen)
+			n, err := mem.ReadMemory(got, test.readAddr)
+			if n != test.readLen || err != nil || !reflect.DeepEqual(got, test.want) {
+				t.Errorf("ReadAt = %v, %v, %v, want %v, %v, %v", n, err, got, test.readLen, nil, test.want)
+			}
+		})
+	}
+}
+
+func TestReadCore(t *testing.T) {
+	// This is all very fragile and won't work on hosts with non-default core patterns.
+	// Might be better to check in the core?
+	tempDir, err := ioutil.TempDir("", "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	fix := test.BuildFixture("panic")
+	bashCmd := fmt.Sprintf("cd %v && ulimit -c unlimited && GOTRACEBACK=crash %v", tempDir, fix.Path)
+	exec.Command("bash", "-c", bashCmd).Run()
+	corePath := path.Join(tempDir, "core")
+
+	core, err := readCore(corePath, fix.Path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(core.Threads) == 0 {
+		t.Error("expected at least one thread")
+	}
+	// Punch through the abstraction to verify that we got some mappings.
+	spliced := core.MemoryReader.(*SplicedMemory)
+	// There should be at least an RO section, RW section, RX section, the heap, and a thread stack.
+	if len(spliced.readers) < 5 {
+		t.Errorf("expected at least 5 memory regions, got only %v", len(spliced.readers))
+	}
+	// Would be good to test more stuff but not sure what without reading debug information, etc.
+}

--- a/pkg/proc/disasm.go
+++ b/pkg/proc/disasm.go
@@ -45,7 +45,8 @@ func Disassemble(dbp DisassembleInfo, g *G, startPC, endPC uint64) ([]AsmInstruc
 }
 
 func disassemble(memrw memoryReadWriter, regs Registers, breakpoints map[uint64]*Breakpoint, bi *BinaryInfo, startPC, endPC uint64) ([]AsmInstruction, error) {
-	mem, err := memrw.readMemory(uintptr(startPC), int(endPC-startPC))
+	mem := make([]byte, int(endPC-startPC))
+	_, err := memrw.ReadMemory(mem, uintptr(startPC))
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/proc/disasm_amd64.go
+++ b/pkg/proc/disasm_amd64.go
@@ -96,7 +96,8 @@ func resolveCallArg(inst *ArchInst, currentGoroutine bool, regs Registers, mem m
 		}
 		addr := uintptr(int64(base) + int64(index*uint64(arg.Scale)) + arg.Disp)
 		//TODO: should this always be 64 bits instead of inst.MemBytes?
-		pcbytes, err := mem.readMemory(addr, inst.MemBytes)
+		pcbytes := make([]byte, inst.MemBytes)
+		_, err := mem.ReadMemory(pcbytes, addr)
 		if err != nil {
 			return nil
 		}

--- a/pkg/proc/disasm_amd64.go
+++ b/pkg/proc/disasm_amd64.go
@@ -146,7 +146,7 @@ func (dbp *Process) FirstPCAfterPrologue(fn *gosym.Func, sameline bool) (uint64,
 // FirstPCAfterPrologue returns the address of the first instruction after the prologue for function fn
 // If sameline is set FirstPCAfterPrologue will always return an address associated with the same line as fn.Entry
 func FirstPCAfterPrologue(mem memoryReadWriter, breakpoints map[uint64]*Breakpoint, bi *BinaryInfo, fn *gosym.Func, sameline bool) (uint64, error) {
-	text, err := Disassemble(mem, nil, breakpoints, bi, fn.Entry, fn.End)
+	text, err := disassemble(mem, nil, breakpoints, bi, fn.Entry, fn.End)
 	if err != nil {
 		return fn.Entry, err
 	}

--- a/pkg/proc/gdbserver.go
+++ b/pkg/proc/gdbserver.go
@@ -1,0 +1,1416 @@
+// This file and its companion gdbserver_conn implement a target.Interface
+// backed by a connection to a debugger speaking the "Gdb Remote Serial
+// Protocol".
+//
+// The "Gdb Remote Serial Protocol" is a low level debugging protocol
+// originally designed so that gdb could be used to debug programs running
+// in embedded environments but it was later extended to support programs
+// running on any environment and a variety of debuggers support it:
+// gdbserver, lldb-server, macOS's debugserver and rr.
+//
+// The protocol is specified at:
+//   https://sourceware.org/gdb/onlinedocs/gdb/Remote-Protocol.html
+// with additional documentation for lldb specific extensions described at:
+//   https://github.com/llvm-mirror/lldb/blob/master/docs/lldb-gdb-remote.txt
+//
+// Terminology:
+//  * inferior: the program we are trying to debug
+//  * stub: the debugger on the other side of the protocol's connection (for
+//    example lldb-server)
+//  * gdbserver: stub version of gdb
+//  * lldb-server: stub version of lldb
+//  * debugserver: a different stub version of lldb, installed with lldb on
+//    macOS.
+//  * mozilla rr: a stub that records the full execution of a program
+//    and can then play it back.
+//
+// Implementations of the protocol vary wildly between stubs, while there is
+// a command to query the stub about supported features (qSupported) this
+// only covers *some* of the more recent additions to the protocol and most
+// of the older packets are optional and *not* implemented by all stubs.
+// For example gdbserver implements 'g' (read all registers) but not 'p'
+// (read single register) while lldb-server implements 'p' but not 'g'.
+//
+// The protocol is also underspecified with regards to how the stub should
+// handle a multithreaded inferior. Its default mode of operation is
+// "all-stop mode", when a thread hits a breakpoint all other threads are
+// also stopped. But the protocol doesn't say what happens if a second
+// thread hits a breakpoint while the stub is in the process of stopping all
+// other threads.
+//
+// In practice the stub is allowed to swallow the second breakpoint hit or
+// to return it at a later time. If the stub chooses the latter behavior
+// (like gdbserver does) it is allowed to return delayed events on *any*
+// vCont packet. This is incredibly inconvenient since if we get notified
+// about a delayed breakpoint while we are trying to singlestep another
+// thread it's impossible to know when the singlestep we requested ended.
+//
+// What this means is that gdbserver can only be supported for multithreaded
+// inferiors by selecting non-stop mode, which behaves in a markedly
+// different way from all-stop mode and isn't supported by anything except
+// gdbserver.
+//
+// lldb-server/debugserver takes a different approach, only the first stop
+// event is reported, if any other event happens "simultaneously" they are
+// suppressed by the stub and the debugger can query for them using
+// qThreadStopInfo. This is much easier for us to implement and the
+// implementation gracefully degrates to the case where qThreadStopInfo is
+// unavailable but the inferior is run in single threaded mode.
+//
+// Therefore the following code will assume lldb-server-like behavior.
+
+package proc
+
+import (
+	"debug/gosym"
+	"encoding/binary"
+	"errors"
+	"fmt"
+	"go/ast"
+	"net"
+	"os"
+	"os/exec"
+	"runtime"
+	"strconv"
+	"strings"
+	"sync"
+	"time"
+
+	"golang.org/x/arch/x86/x86asm"
+)
+
+const (
+	logGdbWire               = false
+	logGdbWireFullStopPacket = false
+	showLldbServerOutput     = false
+	logGdbWireMaxLen         = 120
+
+	maxTransmitAttempts    = 3    // number of retransmission attempts on failed checksum
+	initialInputBufferSize = 2048 // size of the input buffer for gdbConn
+)
+
+const heartbeatInterval = 10 * time.Second
+
+// GdbserverProcess implements target.Interface using a connection to a
+// debugger stub that understands Gdb Remote Serial Protocol.
+type GdbserverProcess struct {
+	bi   BinaryInfo
+	conn gdbConn
+
+	threads           map[int]*GdbserverThread
+	currentThread     *GdbserverThread
+	selectedGoroutine *G
+
+	exited bool
+	ctrlC  bool // ctrl-c was sent to stop inferior
+
+	breakpoints                 map[uint64]*Breakpoint
+	breakpointIDCounter         int
+	internalBreakpointIDCounter int
+
+	gcmdok         bool // true if the stub supports g and G commands
+	threadStopInfo bool // true if the stub supports qThreadStopInfo
+
+	loadGInstrAddr uint64 // address of the g loading instruction, zero if we couldn't allocate it
+
+	process *exec.Cmd
+
+	allGCache []*G
+}
+
+// GdbserverThread is a thread of GdbserverProcess.
+type GdbserverThread struct {
+	ID                       int
+	strID                    string
+	regs                     gdbRegisters
+	CurrentBreakpoint        *Breakpoint
+	BreakpointConditionMet   bool
+	BreakpointConditionError error
+	p                        *GdbserverProcess
+	setbp                    bool // thread was stopped because of a breakpoint
+}
+
+// gdbRegisters represents the current value of the registers of a thread.
+// The storage space for all the registers is allocated as a single memory
+// block in buf, the value field inside an individual gdbRegister will be a
+// slice of the global buf field.
+type gdbRegisters struct {
+	regs     map[string]gdbRegister
+	regsInfo []gdbRegisterInfo
+	tls      uint64
+	gaddr    uint64
+	hasgaddr bool
+	buf      []byte
+}
+
+type gdbRegister struct {
+	value  []byte
+	regnum int
+}
+
+// GdbserverConnect creates a GdbserverProcess connected to address addr.
+// Path and pid are, respectively, the path to the executable of the target
+// program and the PID of the target process, both are optional, however
+// some stubs do not provide ways to determine path and pid automatically
+// and GdbserverConnect will be unable to function without knowing them.
+func GdbserverConnect(addr string, path string, pid int, attempts int) (*GdbserverProcess, error) {
+	var conn net.Conn
+	var err error
+	for i := 0; i < attempts; i++ {
+		conn, err = net.Dial("tcp", addr)
+		if err == nil {
+			break
+		}
+		time.Sleep(time.Second)
+	}
+	if err != nil {
+		return nil, err
+	}
+
+	p := &GdbserverProcess{
+		conn: gdbConn{
+			conn:                conn,
+			maxTransmitAttempts: maxTransmitAttempts,
+			inbuf:               make([]byte, 0, initialInputBufferSize),
+		},
+
+		threads:        make(map[int]*GdbserverThread),
+		bi:             NewBinaryInfo(runtime.GOOS, runtime.GOARCH),
+		breakpoints:    make(map[uint64]*Breakpoint),
+		gcmdok:         true,
+		threadStopInfo: true,
+	}
+
+	p.conn.pid = pid
+	err = p.conn.handshake()
+	if err != nil {
+		conn.Close()
+		return nil, err
+	}
+
+	if path == "" {
+		// If we are attaching to a running process and the user didn't specify
+		// the executable file manually we must ask the stub for it.
+		// We support both qXfer:exec-file:read:: (the gdb way) and calling
+		// qProcessInfo (the lldb way).
+		// Unfortunately debugserver on macOS supports neither.
+		path, err = p.conn.readExecFile()
+		if err != nil {
+			if isProtocolErrorUnsupported(err) {
+				_, path, err = p.loadProcessInfo(pid)
+				if err != nil {
+					conn.Close()
+					return nil, err
+				}
+			} else {
+				conn.Close()
+				return nil, fmt.Errorf("could not determine executable path: %v", err)
+			}
+		}
+	}
+
+	// None of the stubs we support returns the value of fs_base or gs_base
+	// along with the registers, therefore we have to resort to executing a MOV
+	// instruction on the inferior to find out where the G struct of a given
+	// thread is located.
+	// Here we try to allocate some memory on the inferior which we will use to
+	// store the MOV instruction.
+	// If the stub doesn't support memory allocation reloadRegisters will
+	// overwrite some existing memory to store the MOV.
+	if addr, err := p.conn.allocMemory(256); err == nil {
+		if _, err := p.conn.writeMemory(uintptr(addr), p.loadGInstr()); err == nil {
+			p.loadGInstrAddr = addr
+		}
+	}
+
+	var wg sync.WaitGroup
+	err = p.bi.LoadBinaryInfo(path, &wg)
+	if err != nil {
+		conn.Close()
+		return nil, err
+	}
+	wg.Wait()
+
+	err = p.updateThreadList(&threadUpdater{p: p})
+	if err != nil {
+		conn.Close()
+		p.bi.Close()
+		return nil, err
+	}
+
+	if p.conn.pid <= 0 {
+		p.conn.pid, _, err = p.loadProcessInfo(0)
+		if err != nil {
+			conn.Close()
+			p.bi.Close()
+			return nil, err
+		}
+	}
+
+	scope := &EvalScope{0, 0, p.CurrentThread(), nil, &p.bi}
+	ver, isextld, err := scope.getGoInformation()
+	if err != nil {
+		conn.Close()
+		p.bi.Close()
+		return nil, err
+	}
+
+	p.bi.arch.SetGStructOffset(ver, isextld)
+	p.selectedGoroutine, _ = GetG(p.CurrentThread())
+
+	panicpc, err := p.FindFunctionLocation("runtime.startpanic", true, 0)
+	if err == nil {
+		bp, err := p.SetBreakpoint(panicpc, UserBreakpoint, nil)
+		if err == nil {
+			bp.Name = "unrecovered-panic"
+			bp.ID = -1
+			p.breakpointIDCounter--
+		}
+	}
+
+	return p, nil
+}
+
+// unusedPort returns an unused tcp port
+// This is a hack and subject to a race condition with other running
+// programs, but most (all?) OS will cycle through all ephemeral ports
+// before reassigning one port they just assigned, unless there's heavy
+// churn in the ephemeral range this should work.
+func unusedPort() string {
+	addr, err := net.ResolveTCPAddr("tcp", "localhost:0")
+	if err != nil {
+		return ":8081"
+	}
+	listener, err := net.ListenTCP("tcp", addr)
+	if err != nil {
+		return ":8081"
+	}
+	port := listener.Addr().(*net.TCPAddr).Port
+	listener.Close()
+	return fmt.Sprintf(":%d", port)
+}
+
+const debugserverExecutable = "/Library/Developer/CommandLineTools/Library/PrivateFrameworks/LLDB.framework/Versions/A/Resources/debugserver"
+
+// LLDBLaunch starts an instance of lldb-server and connects to it, asking
+// it to launch the specified target program with the specified arguments
+// (cmd) on the specified directory wd.
+func LLDBLaunch(cmd []string, wd string) (*GdbserverProcess, error) {
+	// check that the argument to Launch is an executable file
+	if fi, staterr := os.Stat(cmd[0]); staterr == nil && (fi.Mode()&0111) == 0 {
+		return nil, NotExecutableErr
+	}
+
+	port := unusedPort()
+	isDebugserver := false
+
+	var proc *exec.Cmd
+	if _, err := os.Stat(debugserverExecutable); err == nil {
+		args := make([]string, 0, len(cmd)+1)
+		args = append(args, "127.0.0.1"+port)
+		args = append(args, cmd...)
+
+		isDebugserver = true
+
+		proc = exec.Command(debugserverExecutable, args...)
+	} else {
+		args := make([]string, 0, len(cmd)+3)
+		args = append(args, "gdbserver")
+		args = append(args, port, "--")
+		args = append(args, cmd...)
+
+		proc = exec.Command("lldb-server", args...)
+	}
+
+	if showLldbServerOutput || logGdbWire {
+		proc.Stdout = os.Stdout
+		proc.Stderr = os.Stderr
+	}
+	if wd != "" {
+		proc.Dir = wd
+	}
+
+	proc.SysProcAttr = backgroundSysProcAttr()
+
+	err := proc.Start()
+	if err != nil {
+		return nil, err
+	}
+
+	p, err := GdbserverConnect(port, cmd[0], 0, 10)
+	if err != nil {
+		return nil, err
+	}
+
+	p.conn.isDebugserver = isDebugserver
+	p.process = proc
+
+	return p, nil
+}
+
+// LLDBAttach starts an instance of lldb-server and connects to it, asking
+// it to attach to the specified pid.
+// Path is path to the target's executable, path only needs to be specified
+// for some stubs that do not provide an automated way of determining it
+// (for example debugserver).
+func LLDBAttach(pid int, path string) (*GdbserverProcess, error) {
+	port := unusedPort()
+	isDebugserver := false
+	var proc *exec.Cmd
+	if _, err := os.Stat(debugserverExecutable); err == nil {
+		isDebugserver = true
+		proc = exec.Command(debugserverExecutable, "127.0.0.1"+port, "--attach="+strconv.Itoa(pid))
+	} else {
+		proc = exec.Command("lldb-server", "gdbserver", "--attach", strconv.Itoa(pid), port)
+	}
+
+	proc.Stdout = os.Stdout
+	proc.Stderr = os.Stderr
+
+	proc.SysProcAttr = backgroundSysProcAttr()
+
+	err := proc.Start()
+	if err != nil {
+		return nil, err
+	}
+
+	p, err := GdbserverConnect(port, path, pid, 10)
+	if err != nil {
+		return nil, err
+	}
+
+	p.conn.isDebugserver = isDebugserver
+	p.process = proc
+
+	return p, nil
+}
+
+// loadProcessInfo uses qProcessInfo to load the inferior's PID and
+// executable path. This command is not supported by all stubs and not all
+// stubs will report both the PID and executable path.
+func (p *GdbserverProcess) loadProcessInfo(pid int) (int, string, error) {
+	pi, err := p.conn.queryProcessInfo(pid)
+	if err != nil {
+		return 0, "", err
+	}
+	if pid == 0 {
+		n, _ := strconv.ParseUint(pi["pid"], 16, 64)
+		pid = int(n)
+	}
+	return pid, pi["name"], nil
+}
+
+func (p *GdbserverProcess) BinInfo() *BinaryInfo {
+	return &p.bi
+}
+
+func (p *GdbserverProcess) Pid() int {
+	return int(p.conn.pid)
+}
+
+func (p *GdbserverProcess) Exited() bool {
+	return p.exited
+}
+
+func (p *GdbserverProcess) Running() bool {
+	return p.conn.running
+}
+
+func (p *GdbserverProcess) FindFileLocation(fileName string, lineNumber int) (uint64, error) {
+	return FindFileLocation(p.CurrentThread(), p.breakpoints, &p.bi, fileName, lineNumber)
+}
+
+func (p *GdbserverProcess) FirstPCAfterPrologue(fn *gosym.Func, sameline bool) (uint64, error) {
+	return FirstPCAfterPrologue(p.CurrentThread(), p.breakpoints, &p.bi, fn, sameline)
+}
+
+func (p *GdbserverProcess) FindFunctionLocation(funcName string, firstLine bool, lineOffset int) (uint64, error) {
+	return FindFunctionLocation(p.CurrentThread(), p.breakpoints, &p.bi, funcName, firstLine, lineOffset)
+}
+
+func (p *GdbserverProcess) FindThread(threadID int) (IThread, bool) {
+	thread, ok := p.threads[threadID]
+	return thread, ok
+}
+
+func (p *GdbserverProcess) ThreadList() []IThread {
+	r := make([]IThread, 0, len(p.threads))
+	for _, thread := range p.threads {
+		r = append(r, thread)
+	}
+	return r
+}
+
+func (p *GdbserverProcess) CurrentThread() IThread {
+	return p.currentThread
+}
+
+func (p *GdbserverProcess) AllGCache() *[]*G {
+	return &p.allGCache
+}
+
+func (p *GdbserverProcess) SelectedGoroutine() *G {
+	return p.selectedGoroutine
+}
+
+const (
+	interruptSignal  = 0x2
+	breakpointSignal = 0x5
+	childSignal      = 0x11
+	stopSignal       = 0x13
+)
+
+func (p *GdbserverProcess) ContinueOnce() (IThread, error) {
+	if p.exited {
+		return nil, &ProcessExitedError{Pid: p.conn.pid}
+	}
+
+	// step threads stopped at any breakpoint over their breakpoint
+	for _, thread := range p.threads {
+		if thread.CurrentBreakpoint != nil {
+			if err := thread.stepInstruction(&threadUpdater{p: p}); err != nil {
+				return nil, err
+			}
+		}
+	}
+
+	p.allGCache = nil
+	for _, th := range p.threads {
+		th.clearBreakpointState()
+	}
+
+	p.ctrlC = false
+
+	// resume all threads
+	var threadID string
+	var sig uint8 = 0
+	var tu = threadUpdater{p: p}
+	var err error
+continueLoop:
+	for {
+		tu.done = false
+		threadID, sig, err = p.conn.resume(sig, &tu)
+		if err != nil {
+			if _, exited := err.(ProcessExitedError); exited {
+				p.exited = true
+			}
+			return nil, err
+		}
+
+		// 0x5 is always a breakpoint, a manual stop either manifests as 0x13
+		// (lldb), 0x11 (debugserver) or 0x2 (gdbserver).
+		// Since 0x2 could also be produced by the user
+		// pressing ^C (in which case it should be passed to the inferior) we need
+		// the ctrlC flag to know that we are the originators.
+		switch sig {
+		case interruptSignal: // interrupt
+			if p.ctrlC {
+				break continueLoop
+			}
+		case breakpointSignal: // breakpoint
+			break continueLoop
+		case childSignal: // stop on debugserver but SIGCHLD on lldb-server/linux
+			if p.conn.isDebugserver {
+				break continueLoop
+			}
+		case stopSignal: // stop
+			break continueLoop
+
+		// The following are fake BSD-style signals sent by debugserver
+		// Unfortunately debugserver can not convert them into signals for the
+		// process so we must stop here.
+		case 0x91, 0x92, 0x93, 0x94, 0x95, 0x96: /* TARGET_EXC_BAD_ACCESS */
+			break continueLoop
+		default:
+			// any other signal is always propagated to inferior
+		}
+	}
+
+	if err := p.updateThreadList(&tu); err != nil {
+		return nil, err
+	}
+
+	if err := p.setCurrentBreakpoints(); err != nil {
+		return nil, err
+	}
+
+	for _, thread := range p.threads {
+		if thread.strID == threadID {
+			return thread, nil
+		}
+	}
+
+	return nil, fmt.Errorf("could not find thread %s", threadID)
+}
+
+func (p *GdbserverProcess) StepInstruction() error {
+	if p.selectedGoroutine == nil {
+		return errors.New("cannot single step: no selected goroutine")
+	}
+	if p.selectedGoroutine.thread == nil {
+		if _, err := p.SetBreakpoint(p.selectedGoroutine.PC, NextBreakpoint, sameGoroutineCondition(p.selectedGoroutine)); err != nil {
+			return err
+		}
+		return Continue(p)
+	}
+	p.allGCache = nil
+	if p.exited {
+		return &ProcessExitedError{Pid: p.conn.pid}
+	}
+	p.selectedGoroutine.thread.(*GdbserverThread).clearBreakpointState()
+	err := p.selectedGoroutine.thread.(*GdbserverThread).StepInstruction()
+	if err != nil {
+		return err
+	}
+	return p.selectedGoroutine.thread.(*GdbserverThread).SetCurrentBreakpoint()
+}
+
+func (p *GdbserverProcess) SwitchThread(tid int) error {
+	if th, ok := p.threads[tid]; ok {
+		p.currentThread = th
+		p.selectedGoroutine, _ = GetG(p.CurrentThread())
+		return nil
+	}
+	return fmt.Errorf("thread %d does not exist", tid)
+}
+
+func (p *GdbserverProcess) SwitchGoroutine(gid int) error {
+	g, err := FindGoroutine(p, gid)
+	if err != nil {
+		return err
+	}
+	if g == nil {
+		// user specified -1 and selectedGoroutine is nil
+		return nil
+	}
+	if g.thread != nil {
+		return p.SwitchThread(g.thread.ThreadID())
+	}
+	p.selectedGoroutine = g
+	return nil
+}
+
+func (p *GdbserverProcess) RequestManualStop() error {
+	p.ctrlC = true
+	return p.conn.sendCtrlC()
+}
+
+func (p *GdbserverProcess) Halt() error {
+	p.ctrlC = true
+	return p.conn.sendCtrlC()
+}
+
+func (p *GdbserverProcess) Kill() error {
+	if p.exited {
+		return nil
+	}
+	err := p.conn.kill()
+	if _, exited := err.(ProcessExitedError); exited {
+		p.exited = true
+		return nil
+	}
+	return err
+}
+
+func (p *GdbserverProcess) Detach(kill bool) error {
+	if kill {
+		if err := p.Kill(); err != nil {
+			if _, exited := err.(ProcessExitedError); !exited {
+				return err
+			}
+		}
+	}
+	if !p.exited {
+		if err := p.conn.detach(); err != nil {
+			return err
+		}
+	}
+	if p.process != nil {
+		p.process.Process.Kill()
+		p.process.Wait()
+	}
+	return p.bi.Close()
+}
+
+func (p *GdbserverProcess) Breakpoints() map[uint64]*Breakpoint {
+	return p.breakpoints
+}
+
+func (p *GdbserverProcess) FindBreakpoint(pc uint64) (*Breakpoint, bool) {
+	// Check to see if address is past the breakpoint, (i.e. breakpoint was hit).
+	if bp, ok := p.breakpoints[pc-uint64(p.bi.arch.BreakpointSize())]; ok {
+		return bp, true
+	}
+	// Directly use addr to lookup breakpoint.
+	if bp, ok := p.breakpoints[pc]; ok {
+		return bp, true
+	}
+	return nil, false
+}
+
+func (p *GdbserverProcess) SetBreakpoint(addr uint64, kind BreakpointKind, cond ast.Expr) (*Breakpoint, error) {
+	if bp, ok := p.breakpoints[addr]; ok {
+		return nil, BreakpointExistsError{bp.File, bp.Line, bp.Addr}
+	}
+	f, l, fn := p.bi.PCToLine(uint64(addr))
+	if fn == nil {
+		return nil, InvalidAddressError{address: addr}
+	}
+
+	newBreakpoint := &Breakpoint{
+		FunctionName: fn.Name,
+		File:         f,
+		Line:         l,
+		Addr:         addr,
+		Kind:         kind,
+		Cond:         cond,
+		HitCount:     map[int]uint64{},
+	}
+
+	if kind != UserBreakpoint {
+		p.internalBreakpointIDCounter++
+		newBreakpoint.ID = p.internalBreakpointIDCounter
+	} else {
+		p.breakpointIDCounter++
+		newBreakpoint.ID = p.breakpointIDCounter
+	}
+
+	if err := p.conn.setBreakpoint(addr); err != nil {
+		return nil, err
+	}
+	p.breakpoints[addr] = newBreakpoint
+	return newBreakpoint, nil
+}
+
+func (p *GdbserverProcess) ClearBreakpoint(addr uint64) (*Breakpoint, error) {
+	if p.exited {
+		return nil, &ProcessExitedError{Pid: p.conn.pid}
+	}
+	bp := p.breakpoints[addr]
+	if bp == nil {
+		return nil, NoBreakpointError{addr: addr}
+	}
+
+	if err := p.conn.clearBreakpoint(addr); err != nil {
+		return nil, err
+	}
+
+	delete(p.breakpoints, addr)
+
+	return bp, nil
+}
+
+func (p *GdbserverProcess) ClearInternalBreakpoints() error {
+	for _, bp := range p.breakpoints {
+		if !bp.Internal() {
+			continue
+		}
+		if _, err := p.ClearBreakpoint(bp.Addr); err != nil {
+			return err
+		}
+	}
+	for i := range p.threads {
+		if p.threads[i].CurrentBreakpoint != nil && p.threads[i].CurrentBreakpoint.Internal() {
+			p.threads[i].CurrentBreakpoint = nil
+		}
+	}
+	return nil
+}
+
+type threadUpdater struct {
+	p    *GdbserverProcess
+	seen map[int]bool
+	done bool
+}
+
+func (tu *threadUpdater) Add(threads []string) error {
+	if tu.done {
+		panic("threadUpdater: Add after Finish")
+	}
+	if tu.seen == nil {
+		tu.seen = map[int]bool{}
+	}
+	for _, threadID := range threads {
+		b := threadID
+		if period := strings.Index(b, "."); period >= 0 {
+			b = b[period+1:]
+		}
+		n, err := strconv.ParseUint(b, 16, 32)
+		if err != nil {
+			return &GdbMalformedThreadIDError{threadID}
+		}
+		tid := int(n)
+		tu.seen[tid] = true
+		if _, found := tu.p.threads[tid]; !found {
+			tu.p.threads[tid] = &GdbserverThread{ID: tid, strID: threadID, p: tu.p}
+		}
+	}
+	return nil
+}
+
+func (tu *threadUpdater) Finish() {
+	tu.done = true
+	for threadID := range tu.p.threads {
+		_, threadSeen := tu.seen[threadID]
+		if threadSeen {
+			continue
+		}
+		delete(tu.p.threads, threadID)
+		if tu.p.currentThread.ID == threadID {
+			tu.p.currentThread = nil
+		}
+	}
+	if tu.p.currentThread == nil {
+		for _, thread := range tu.p.threads {
+			tu.p.currentThread = thread
+			break
+		}
+	}
+}
+
+// updateThreadsList retrieves the list of inferior threads from the stub
+// and passes it to the threadUpdater.
+// Then it reloads the register information for all running threads.
+// Some stubs will return the list of running threads in the stop packet, if
+// this happens the threadUpdater will know that we have already updated the
+// thread list and the first step of updateThreadList will be skipped.
+// Registers are always reloaded.
+func (p *GdbserverProcess) updateThreadList(tu *threadUpdater) error {
+	if !tu.done {
+		first := true
+		for {
+			threads, err := p.conn.queryThreads(first)
+			if err != nil {
+				return err
+			}
+			if len(threads) == 0 {
+				break
+			}
+			first = false
+			if err := tu.Add(threads); err != nil {
+				return err
+			}
+		}
+
+		tu.Finish()
+	}
+
+	if p.threadStopInfo {
+		for _, th := range p.threads {
+			sig, reason, err := p.conn.threadStopInfo(th.strID)
+			if err != nil {
+				if isProtocolErrorUnsupported(err) {
+					p.threadStopInfo = false
+					break
+				}
+				return err
+			}
+			th.setbp = (reason == "breakpoint" || (reason == "" && sig == breakpointSignal))
+		}
+	}
+
+	for _, thread := range p.threads {
+		if err := thread.reloadRegisters(); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (p *GdbserverProcess) setCurrentBreakpoints() error {
+	if p.threadStopInfo {
+		for _, th := range p.threads {
+			if th.setbp {
+				err := th.SetCurrentBreakpoint()
+				if err != nil {
+					return err
+				}
+			}
+		}
+	}
+	if !p.threadStopInfo {
+		for _, th := range p.threads {
+			if th.CurrentBreakpoint == nil {
+				err := th.SetCurrentBreakpoint()
+				if err != nil {
+					return err
+				}
+			}
+		}
+	}
+	return nil
+}
+
+func (t *GdbserverThread) readMemory(addr uintptr, size int) (data []byte, err error) {
+	return t.p.conn.readMemory(addr, size)
+}
+
+func (t *GdbserverThread) writeMemory(addr uintptr, data []byte) (written int, err error) {
+	return t.p.conn.writeMemory(addr, data)
+}
+
+func (t *GdbserverThread) Location() (*Location, error) {
+	regs, err := t.Registers(false)
+	if err != nil {
+		return nil, err
+	}
+	pc := regs.PC()
+	f, l, fn := t.p.bi.PCToLine(pc)
+	return &Location{PC: pc, File: f, Line: l, Fn: fn}, nil
+}
+
+func (t *GdbserverThread) Breakpoint() (breakpoint *Breakpoint, active bool, condErr error) {
+	return t.CurrentBreakpoint, (t.CurrentBreakpoint != nil && t.BreakpointConditionMet), t.BreakpointConditionError
+}
+
+func (t *GdbserverThread) ThreadID() int {
+	return t.ID
+}
+
+func (t *GdbserverThread) Registers(floatingPoint bool) (Registers, error) {
+	return &t.regs, nil
+}
+
+func (t *GdbserverThread) Arch() Arch {
+	return t.p.bi.arch
+}
+
+func (t *GdbserverThread) BinInfo() *BinaryInfo {
+	return &t.p.bi
+}
+
+func (t *GdbserverThread) stepInstruction(tu *threadUpdater) error {
+	pc := t.regs.PC()
+	if _, atbp := t.p.breakpoints[pc]; atbp {
+		err := t.p.conn.clearBreakpoint(pc)
+		if err != nil {
+			return err
+		}
+		defer t.p.conn.setBreakpoint(pc)
+	}
+	_, _, err := t.p.conn.step(t.strID, tu)
+	return err
+}
+
+func (t *GdbserverThread) StepInstruction() error {
+	if err := t.stepInstruction(&threadUpdater{p: t.p}); err != nil {
+		return err
+	}
+	return t.reloadRegisters()
+}
+
+// loadGInstr returns the correct MOV instruction for the current
+// OS/architecture that can be executed to load the address of G from an
+// inferior's thread.
+func (p *GdbserverProcess) loadGInstr() []byte {
+	switch p.bi.goos {
+	case "windows":
+		//TODO(aarzilli): implement
+		panic("not implemented")
+	case "linux":
+		switch p.bi.arch.GStructOffset() {
+		case 0xfffffffffffffff8, 0x0:
+			// mov    rcx,QWORD PTR fs:0xfffffffffffffff8
+			return []byte{0x64, 0x48, 0x8B, 0x0C, 0x25, 0xF8, 0xFF, 0xFF, 0xFF}
+		case 0xfffffffffffffff0:
+			// mov    rcx,QWORD PTR fs:0xfffffffffffffff0
+			return []byte{0x64, 0x48, 0x8B, 0x0C, 0x25, 0xF0, 0xFF, 0xFF, 0xFF}
+		default:
+			panic("not implemented")
+		}
+	case "darwin":
+		// mov    rcx,QWORD PTR gs:0x8a0
+		return []byte{0x65, 0x48, 0x8B, 0x0C, 0x25, 0xA0, 0x08, 0x00, 0x00}
+	default:
+		panic("unsupported operating system attempting to find Goroutine on Thread")
+	}
+}
+
+// reloadRegisters loads the current value of the thread's registers.
+// It will also load the address of the thread's G.
+// Loading the address of G can be done in one of two ways reloadGAlloc, if
+// the stub can allocate memory, or reloadGAtPC, if the stub can't.
+func (t *GdbserverThread) reloadRegisters() error {
+	if t.regs.regs == nil {
+		t.regs.regs = make(map[string]gdbRegister)
+		t.regs.regsInfo = t.p.conn.regsInfo
+
+		regsz := 0
+		for _, reginfo := range t.p.conn.regsInfo {
+			if endoff := reginfo.Offset + (reginfo.Bitsize / 8); endoff > regsz {
+				regsz = endoff
+			}
+		}
+		t.regs.buf = make([]byte, regsz)
+		for _, reginfo := range t.p.conn.regsInfo {
+			t.regs.regs[reginfo.Name] = gdbRegister{regnum: reginfo.Regnum, value: t.regs.buf[reginfo.Offset : reginfo.Offset+reginfo.Bitsize/8]}
+		}
+	}
+
+	if t.p.gcmdok {
+		if err := t.p.conn.readRegisters(t.strID, t.regs.buf); err != nil {
+			if isProtocolErrorUnsupported(err) {
+				t.p.gcmdok = false
+			} else {
+				return err
+			}
+		}
+	}
+	if !t.p.gcmdok {
+		for _, reginfo := range t.p.conn.regsInfo {
+			if err := t.p.conn.readRegister(t.strID, reginfo.Regnum, t.regs.regs[reginfo.Name].value); err != nil {
+				return err
+			}
+		}
+	}
+
+	if t.p.loadGInstrAddr > 0 {
+		return t.reloadGAlloc()
+	}
+	return t.reloadGAtPC()
+}
+
+func (t *GdbserverThread) writeSomeRegisters(regNames ...string) error {
+	if t.p.gcmdok {
+		return t.p.conn.writeRegisters(t.strID, t.regs.buf)
+	}
+	for _, regName := range regNames {
+		if err := t.p.conn.writeRegister(t.strID, t.regs.regs[regName].regnum, t.regs.regs[regName].value); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (t *GdbserverThread) readSomeRegisters(regNames ...string) error {
+	if t.p.gcmdok {
+		return t.p.conn.readRegisters(t.strID, t.regs.buf)
+	}
+	for _, regName := range regNames {
+		err := t.p.conn.readRegister(t.strID, t.regs.regs[regName].regnum, t.regs.regs[regName].value)
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// reloadGAtPC overwrites the instruction that the thread is stopped at with
+// the MOV instruction used to load current G, executes this single
+// instruction and then puts everything back the way it was.
+func (t *GdbserverThread) reloadGAtPC() error {
+	movinstr := t.p.loadGInstr()
+
+	if gdbserverThreadBlocked(t) {
+		t.regs.tls = 0
+		t.regs.gaddr = 0
+		t.regs.hasgaddr = true
+		return nil
+	}
+
+	cx := t.regs.CX()
+	pc := t.regs.PC()
+
+	// We are partially replicating the code of GdbserverThread.stepInstruction
+	// here.
+	// The reason is that lldb-server has a bug with writing to memory and
+	// setting/clearing breakpoints to that same memory which we must work
+	// around by clearing and re-setting the breakpoint in a specific sequence
+	// with the memory writes.
+	// Additionally all breakpoints in [pc, pc+len(movinstr)] need to be removed
+	for addr, _ := range t.p.breakpoints {
+		if addr >= pc && addr <= pc+uint64(len(movinstr)) {
+			err := t.p.conn.clearBreakpoint(addr)
+			if err != nil {
+				return err
+			}
+			defer t.p.conn.setBreakpoint(addr)
+		}
+	}
+
+	savedcode, err := t.readMemory(uintptr(pc), len(movinstr))
+	if err != nil {
+		return err
+	}
+
+	_, err = t.writeMemory(uintptr(pc), movinstr)
+	if err != nil {
+		return err
+	}
+
+	defer func() {
+		_, err0 := t.writeMemory(uintptr(pc), savedcode)
+		if err == nil {
+			err = err0
+		}
+		t.regs.setPC(pc)
+		t.regs.setCX(cx)
+		err1 := t.writeSomeRegisters(regnamePC, regnameCX)
+		if err == nil {
+			err = err1
+		}
+	}()
+
+	_, _, err = t.p.conn.step(t.strID, nil)
+	if err != nil {
+		return err
+	}
+
+	if err := t.readSomeRegisters(regnamePC, regnameCX); err != nil {
+		return err
+	}
+
+	t.regs.gaddr = t.regs.CX()
+	t.regs.hasgaddr = true
+
+	return err
+}
+
+// reloadGAlloc makes the specified thread execute one instruction stored at
+// t.p.loadGInstrAddr then restores the value of the thread's registers.
+// t.p.loadGInstrAddr must point to valid memory on the inferior, containing
+// a MOV instruction that loads the address of the current G in the RCX
+// register.
+func (t *GdbserverThread) reloadGAlloc() error {
+	if gdbserverThreadBlocked(t) {
+		t.regs.tls = 0
+		t.regs.gaddr = 0
+		t.regs.hasgaddr = true
+		return nil
+	}
+
+	cx := t.regs.CX()
+	pc := t.regs.PC()
+
+	t.regs.setPC(t.p.loadGInstrAddr)
+	if err := t.writeSomeRegisters(regnamePC); err != nil {
+		return err
+	}
+
+	var err error
+
+	defer func() {
+		t.regs.setPC(pc)
+		t.regs.setCX(cx)
+		err1 := t.writeSomeRegisters(regnamePC, regnameCX)
+		if err == nil {
+			err = err1
+		}
+	}()
+
+	_, _, err = t.p.conn.step(t.strID, nil)
+	if err != nil {
+		return err
+	}
+
+	if err := t.readSomeRegisters(regnameCX); err != nil {
+		return err
+	}
+
+	t.regs.gaddr = t.regs.CX()
+	t.regs.hasgaddr = true
+
+	return err
+}
+
+func gdbserverThreadBlocked(t *GdbserverThread) bool {
+	regs, err := t.Registers(false)
+	if err != nil {
+		return false
+	}
+	pc := regs.PC()
+	fn := t.BinInfo().goSymTable.PCToFunc(pc)
+	if fn == nil {
+		return false
+	}
+	switch fn.Name {
+	case "runtime.futex", "runtime.usleep", "runtime.clone":
+		return true
+	case "runtime.kevent":
+		return true
+	case "runtime.mach_semaphore_wait", "runtime.mach_semaphore_timedwait":
+		return true
+	}
+	return false
+}
+
+func (t *GdbserverThread) clearBreakpointState() {
+	t.setbp = false
+	t.CurrentBreakpoint = nil
+	t.BreakpointConditionMet = false
+	t.BreakpointConditionError = nil
+}
+
+func (thread *GdbserverThread) SetCurrentBreakpoint() error {
+	thread.CurrentBreakpoint = nil
+	regs, err := thread.Registers(false)
+	if err != nil {
+		return err
+	}
+	pc := regs.PC()
+	if bp, ok := thread.p.FindBreakpoint(pc); ok {
+		if thread.regs.PC() != bp.Addr {
+			if err := thread.regs.SetPC(thread, bp.Addr); err != nil {
+				return err
+			}
+		}
+		thread.CurrentBreakpoint = bp
+		thread.BreakpointConditionMet, thread.BreakpointConditionError = bp.checkCondition(thread)
+		if thread.CurrentBreakpoint != nil && thread.BreakpointConditionMet {
+			if g, err := GetG(thread); err == nil {
+				thread.CurrentBreakpoint.HitCount[g.ID]++
+			}
+			thread.CurrentBreakpoint.TotalHitCount++
+		}
+	}
+	return nil
+}
+
+func (regs *gdbRegisters) PC() uint64 {
+	return binary.LittleEndian.Uint64(regs.regs[regnamePC].value)
+}
+
+func (regs *gdbRegisters) setPC(value uint64) {
+	binary.LittleEndian.PutUint64(regs.regs[regnamePC].value, value)
+}
+
+func (regs *gdbRegisters) SP() uint64 {
+	return binary.LittleEndian.Uint64(regs.regs[regnameSP].value)
+}
+
+func (regs *gdbRegisters) BP() uint64 {
+	return binary.LittleEndian.Uint64(regs.regs[regnameBP].value)
+}
+
+func (regs *gdbRegisters) CX() uint64 {
+	return binary.LittleEndian.Uint64(regs.regs[regnameCX].value)
+}
+
+func (regs *gdbRegisters) setCX(value uint64) {
+	binary.LittleEndian.PutUint64(regs.regs[regnameCX].value, value)
+}
+
+func (regs *gdbRegisters) TLS() uint64 {
+	return regs.tls
+}
+
+func (regs *gdbRegisters) GAddr() (uint64, bool) {
+	return regs.gaddr, regs.hasgaddr
+}
+
+func (regs *gdbRegisters) byName(name string) uint64 {
+	reg, ok := regs.regs[name]
+	if !ok {
+		return 0
+	}
+	return binary.LittleEndian.Uint64(reg.value)
+}
+
+func (regs *gdbRegisters) Get(n int) (uint64, error) {
+	reg := x86asm.Reg(n)
+	const (
+		mask8  = 0x000f
+		mask16 = 0x00ff
+		mask32 = 0xffff
+	)
+
+	switch reg {
+	// 8-bit
+	case x86asm.AL:
+		return regs.byName("rax") & mask8, nil
+	case x86asm.CL:
+		return regs.byName("rcx") & mask8, nil
+	case x86asm.DL:
+		return regs.byName("rdx") & mask8, nil
+	case x86asm.BL:
+		return regs.byName("rbx") & mask8, nil
+	case x86asm.AH:
+		return (regs.byName("rax") >> 8) & mask8, nil
+	case x86asm.CH:
+		return (regs.byName("rcx") >> 8) & mask8, nil
+	case x86asm.DH:
+		return (regs.byName("rdx") >> 8) & mask8, nil
+	case x86asm.BH:
+		return (regs.byName("rbx") >> 8) & mask8, nil
+	case x86asm.SPB:
+		return regs.byName("rsp") & mask8, nil
+	case x86asm.BPB:
+		return regs.byName("rbp") & mask8, nil
+	case x86asm.SIB:
+		return regs.byName("rsi") & mask8, nil
+	case x86asm.DIB:
+		return regs.byName("rdi") & mask8, nil
+	case x86asm.R8B:
+		return regs.byName("r8") & mask8, nil
+	case x86asm.R9B:
+		return regs.byName("r9") & mask8, nil
+	case x86asm.R10B:
+		return regs.byName("r10") & mask8, nil
+	case x86asm.R11B:
+		return regs.byName("r11") & mask8, nil
+	case x86asm.R12B:
+		return regs.byName("r12") & mask8, nil
+	case x86asm.R13B:
+		return regs.byName("r13") & mask8, nil
+	case x86asm.R14B:
+		return regs.byName("r14") & mask8, nil
+	case x86asm.R15B:
+		return regs.byName("r15") & mask8, nil
+
+	// 16-bit
+	case x86asm.AX:
+		return regs.byName("rax") & mask16, nil
+	case x86asm.CX:
+		return regs.byName("rcx") & mask16, nil
+	case x86asm.DX:
+		return regs.byName("rdx") & mask16, nil
+	case x86asm.BX:
+		return regs.byName("rbx") & mask16, nil
+	case x86asm.SP:
+		return regs.byName("rsp") & mask16, nil
+	case x86asm.BP:
+		return regs.byName("rbp") & mask16, nil
+	case x86asm.SI:
+		return regs.byName("rsi") & mask16, nil
+	case x86asm.DI:
+		return regs.byName("rdi") & mask16, nil
+	case x86asm.R8W:
+		return regs.byName("r8") & mask16, nil
+	case x86asm.R9W:
+		return regs.byName("r9") & mask16, nil
+	case x86asm.R10W:
+		return regs.byName("r10") & mask16, nil
+	case x86asm.R11W:
+		return regs.byName("r11") & mask16, nil
+	case x86asm.R12W:
+		return regs.byName("r12") & mask16, nil
+	case x86asm.R13W:
+		return regs.byName("r13") & mask16, nil
+	case x86asm.R14W:
+		return regs.byName("r14") & mask16, nil
+	case x86asm.R15W:
+		return regs.byName("r15") & mask16, nil
+
+	// 32-bit
+	case x86asm.EAX:
+		return regs.byName("rax") & mask32, nil
+	case x86asm.ECX:
+		return regs.byName("rcx") & mask32, nil
+	case x86asm.EDX:
+		return regs.byName("rdx") & mask32, nil
+	case x86asm.EBX:
+		return regs.byName("rbx") & mask32, nil
+	case x86asm.ESP:
+		return regs.byName("rsp") & mask32, nil
+	case x86asm.EBP:
+		return regs.byName("rbp") & mask32, nil
+	case x86asm.ESI:
+		return regs.byName("rsi") & mask32, nil
+	case x86asm.EDI:
+		return regs.byName("rdi") & mask32, nil
+	case x86asm.R8L:
+		return regs.byName("r8") & mask32, nil
+	case x86asm.R9L:
+		return regs.byName("r9") & mask32, nil
+	case x86asm.R10L:
+		return regs.byName("r10") & mask32, nil
+	case x86asm.R11L:
+		return regs.byName("r11") & mask32, nil
+	case x86asm.R12L:
+		return regs.byName("r12") & mask32, nil
+	case x86asm.R13L:
+		return regs.byName("r13") & mask32, nil
+	case x86asm.R14L:
+		return regs.byName("r14") & mask32, nil
+	case x86asm.R15L:
+		return regs.byName("r15") & mask32, nil
+
+	// 64-bit
+	case x86asm.RAX:
+		return regs.byName("rax"), nil
+	case x86asm.RCX:
+		return regs.byName("rcx"), nil
+	case x86asm.RDX:
+		return regs.byName("rdx"), nil
+	case x86asm.RBX:
+		return regs.byName("rbx"), nil
+	case x86asm.RSP:
+		return regs.byName("rsp"), nil
+	case x86asm.RBP:
+		return regs.byName("rbp"), nil
+	case x86asm.RSI:
+		return regs.byName("rsi"), nil
+	case x86asm.RDI:
+		return regs.byName("rdi"), nil
+	case x86asm.R8:
+		return regs.byName("r8"), nil
+	case x86asm.R9:
+		return regs.byName("r9"), nil
+	case x86asm.R10:
+		return regs.byName("r10"), nil
+	case x86asm.R11:
+		return regs.byName("r11"), nil
+	case x86asm.R12:
+		return regs.byName("r12"), nil
+	case x86asm.R13:
+		return regs.byName("r13"), nil
+	case x86asm.R14:
+		return regs.byName("r14"), nil
+	case x86asm.R15:
+		return regs.byName("r15"), nil
+	}
+
+	return 0, UnknownRegisterError
+}
+
+func (regs *gdbRegisters) SetPC(thread IThread, pc uint64) error {
+	regs.setPC(pc)
+	t := thread.(*GdbserverThread)
+	if t.p.gcmdok {
+		return t.p.conn.writeRegisters(t.strID, t.regs.buf)
+	}
+	reg := regs.regs[regnamePC]
+	return t.p.conn.writeRegister(t.strID, reg.regnum, reg.value)
+}
+
+func (regs *gdbRegisters) Slice() []Register {
+	r := make([]Register, 0, len(regs.regsInfo))
+	for _, reginfo := range regs.regsInfo {
+		switch {
+		case reginfo.Name == "eflags":
+			r = appendFlagReg(r, reginfo.Name, uint64(binary.LittleEndian.Uint32(regs.regs[reginfo.Name].value)), eflagsDescription, 32)
+		case reginfo.Name == "mxcsr":
+			r = appendFlagReg(r, reginfo.Name, uint64(binary.LittleEndian.Uint32(regs.regs[reginfo.Name].value)), mxcsrDescription, 32)
+		case reginfo.Bitsize == 16:
+			r = appendWordReg(r, reginfo.Name, binary.LittleEndian.Uint16(regs.regs[reginfo.Name].value))
+		case reginfo.Bitsize == 32:
+			r = appendDwordReg(r, reginfo.Name, binary.LittleEndian.Uint32(regs.regs[reginfo.Name].value))
+		case reginfo.Bitsize == 64:
+			r = appendQwordReg(r, reginfo.Name, binary.LittleEndian.Uint64(regs.regs[reginfo.Name].value))
+		case reginfo.Bitsize == 80:
+			idx := 0
+			for _, stprefix := range []string{"stmm", "st"} {
+				if strings.HasPrefix(reginfo.Name, stprefix) {
+					idx, _ = strconv.Atoi(reginfo.Name[len(stprefix):])
+					break
+				}
+			}
+			value := regs.regs[reginfo.Name].value
+			r = appendX87Reg(r, idx, binary.LittleEndian.Uint16(value[8:]), binary.LittleEndian.Uint64(value[:8]))
+
+		case reginfo.Bitsize == 128:
+			r = appendSSEReg(r, strings.ToUpper(reginfo.Name), regs.regs[reginfo.Name].value)
+
+		case reginfo.Bitsize == 256:
+			if !strings.HasPrefix(strings.ToLower(reginfo.Name), "ymm") {
+				continue
+			}
+
+			value := regs.regs[reginfo.Name].value
+			xmmName := "x" + reginfo.Name[1:]
+			r = appendSSEReg(r, strings.ToUpper(xmmName), value[:16])
+			r = appendSSEReg(r, strings.ToUpper(reginfo.Name), value[16:])
+		}
+	}
+	return r
+}

--- a/pkg/proc/gdbserver.go
+++ b/pkg/proc/gdbserver.go
@@ -841,8 +841,12 @@ func (p *GdbserverProcess) setCurrentBreakpoints() error {
 	return nil
 }
 
-func (t *GdbserverThread) readMemory(addr uintptr, size int) (data []byte, err error) {
-	return t.p.conn.readMemory(addr, size)
+func (t *GdbserverThread) ReadMemory(data []byte, addr uintptr) (n int, err error) {
+	err = t.p.conn.readMemory(data, addr)
+	if err != nil {
+		return 0, err
+	}
+	return len(data), nil
 }
 
 func (t *GdbserverThread) writeMemory(addr uintptr, data []byte) (written int, err error) {
@@ -1028,7 +1032,8 @@ func (t *GdbserverThread) reloadGAtPC() error {
 		}
 	}
 
-	savedcode, err := t.readMemory(uintptr(pc), len(movinstr))
+	savedcode := make([]byte, len(movinstr))
+	_, err := t.ReadMemory(savedcode, uintptr(pc))
 	if err != nil {
 		return err
 	}

--- a/pkg/proc/gdbserver_conn.go
+++ b/pkg/proc/gdbserver_conn.go
@@ -1,0 +1,1066 @@
+package proc
+
+import (
+	"bufio"
+	"bytes"
+	"encoding/xml"
+	"errors"
+	"fmt"
+	"io"
+	"net"
+	"os"
+	"strconv"
+	"strings"
+	"time"
+)
+
+type gdbConn struct {
+	conn net.Conn
+	rdr  *bufio.Reader
+
+	inbuf  []byte
+	outbuf bytes.Buffer
+
+	running bool
+
+	packetSize int               // maximum packet size supported by stub
+	regsInfo   []gdbRegisterInfo // list of registers
+
+	pid int // cache process id
+
+	ack                   bool // when ack is true acknowledgment packets are enabled
+	multiprocess          bool // multiprocess extensions are active
+	maxTransmitAttempts   int  // maximum number of transmit or receive attempts when bad checksums are read
+	threadSuffixSupported bool // thread suffix supported by stub
+	isDebugserver         bool // true if the stub is debugserver
+}
+
+const (
+	regnamePC = "rip"
+	regnameCX = "rcx"
+	regnameSP = "rsp"
+	regnameBP = "rbp"
+)
+
+var ErrTooManyAttempts = errors.New("too many transmit attempts")
+var ErrNoTargetDescrption = errors.New("target description not supported")
+
+// GdbProtocolError is an error response (Exx) of Gdb Remote Serial Protocol
+// or an "unsupported command" response (empty packet).
+type GdbProtocolError struct {
+	context string
+	cmd     string
+	code    string
+}
+
+func (err *GdbProtocolError) Error() string {
+	cmd := err.cmd
+	if len(cmd) > 20 {
+		cmd = cmd[:20] + "..."
+	}
+	if err.code == "" {
+		return fmt.Sprintf("unsupported packet %s during %s", cmd, err.context)
+	}
+	return fmt.Sprintf("protocol error %s during %s for packet %s", err.code, err.context, cmd)
+}
+
+func isProtocolErrorUnsupported(err error) bool {
+	gdberr, ok := err.(*GdbProtocolError)
+	if !ok {
+		return false
+	}
+	return gdberr.code == ""
+}
+
+// GdbMalformedThreadIDError is returned when a the stub responds with a
+// thread ID that does not conform with the Gdb Remote Serial Protocol
+// specification.
+type GdbMalformedThreadIDError struct {
+	tid string
+}
+
+func (err *GdbMalformedThreadIDError) Error() string {
+	return fmt.Sprintf("malformed thread ID %q", err.tid)
+}
+
+const (
+	qSupportedSimple       = "$qSupported:swbreak+;hwbreak+;no-resumed+;xmlRegisters=i386"
+	qSupportedMultiprocess = "$qSupported:multiprocess+;swbreak+;hwbreak+;no-resumed+;xmlRegisters=i386"
+)
+
+func (conn *gdbConn) handshake() error {
+	conn.ack = true
+	conn.packetSize = 256
+	conn.rdr = bufio.NewReader(conn.conn)
+
+	// This first ack packet is needed to start up the connection
+	conn.sendack('+')
+
+	conn.disableAck()
+
+	// Try to enable thread suffixes for the command 'g' and 'p'
+	if _, err := conn.exec([]byte("$QThreadSuffixSupported"), "init"); err != nil {
+		if isProtocolErrorUnsupported(err) {
+			conn.threadSuffixSupported = false
+		} else {
+			return err
+		}
+	} else {
+		conn.threadSuffixSupported = true
+	}
+
+	if !conn.threadSuffixSupported {
+		features, err := conn.qSupported(true)
+		if err != nil {
+			return err
+		}
+		conn.multiprocess = features["multiprocess"]
+
+		// for some reason gdbserver won't let us read target.xml unless first we
+		// select a thread.
+		if conn.multiprocess {
+			conn.exec([]byte("$Hgp0.0"), "init")
+		} else {
+			conn.exec([]byte("$Hgp0"), "init")
+		}
+	} else {
+		// execute qSupported with the multiprocess feature disabled (the
+		// interaction of thread suffixes and multiprocess is not documented), we
+		// only need this call to configure conn.packetSize.
+		if _, err := conn.qSupported(false); err != nil {
+			return err
+		}
+	}
+
+	// Attempt to figure out the name of the processor register.
+	// We either need qXfer:features:read (gdbserver/rr) or qRegisterInfo (lldb)
+	if err := conn.readRegisterInfo(); err != nil {
+		if isProtocolErrorUnsupported(err) {
+			if err := conn.readTargetXml(); err != nil {
+				return err
+			}
+		} else {
+			return err
+		}
+	}
+
+	// We either need:
+	//  * QListThreadsInStopReply + qThreadStopInfo (i.e. lldb-server/debugserver),
+	//  * or a stub that runs the inferior in single threaded mode (i.e. rr).
+	// Otherwise we'll have problems handling breakpoints in multithreaded programs.
+	if _, err := conn.exec([]byte("$QListThreadsInStopReply"), "init"); err != nil {
+		gdberr, ok := err.(*GdbProtocolError)
+		if !ok {
+			return err
+		}
+		if gdberr.code != "" {
+			return err
+		}
+	}
+
+	return nil
+}
+
+// qSupported interprets qSupported responses.
+func (conn *gdbConn) qSupported(multiprocess bool) (features map[string]bool, err error) {
+	q := qSupportedSimple
+	if multiprocess {
+		q = qSupportedMultiprocess
+	}
+	respBuf, err := conn.exec([]byte(q), "init/qSupported")
+	if err != nil {
+		return nil, err
+	}
+	resp := strings.Split(string(respBuf), ";")
+	features = make(map[string]bool)
+	for _, stubfeature := range resp {
+		if len(stubfeature) <= 0 {
+			continue
+		} else if equal := strings.Index(stubfeature, "="); equal >= 0 {
+			if stubfeature[:equal] == "PacketSize" {
+				if n, err := strconv.ParseInt(stubfeature[equal+1:], 16, 64); err == nil {
+					conn.packetSize = int(n)
+				}
+			}
+		} else if stubfeature[len(stubfeature)-1] == '+' {
+			features[stubfeature[:len(stubfeature)-1]] = true
+		}
+	}
+	return features, nil
+}
+
+// disableAck disables protocol acks.
+func (conn *gdbConn) disableAck() error {
+	_, err := conn.exec([]byte("$QStartNoAckMode"), "init/disableAck")
+	if err == nil {
+		conn.ack = false
+	}
+	return err
+}
+
+// gdbTarget is a struct type used to parse target.xml
+type gdbTarget struct {
+	Includes  []gdbTargetInclude `xml:"xi include"`
+	Registers []gdbRegisterInfo  `xml:"reg"`
+}
+
+type gdbTargetInclude struct {
+	Href string `xml:"href,attr"`
+}
+
+type gdbRegisterInfo struct {
+	Name    string `xml:"name,attr"`
+	Bitsize int    `xml:"bitsize,attr"`
+	Offset  int
+	Regnum  int `xml:"regnum,attr"`
+}
+
+// readTargetXml reads target.xml file from stub using qXfer:features:read,
+// then parses it requesting any additional files.
+// The schema of target.xml is described by:
+//  https://github.com/bminor/binutils-gdb/blob/61baf725eca99af2569262d10aca03dcde2698f6/gdb/features/gdb-target.dtd
+func (conn *gdbConn) readTargetXml() (err error) {
+	conn.regsInfo, err = conn.readAnnex("target.xml")
+	if err != nil {
+		return err
+	}
+	var offset int
+	var pcFound, cxFound, spFound bool
+	regnum := 0
+	for i := range conn.regsInfo {
+		if conn.regsInfo[i].Regnum == 0 {
+			conn.regsInfo[i].Regnum = regnum
+		} else {
+			regnum = conn.regsInfo[i].Regnum
+		}
+		conn.regsInfo[i].Offset = offset
+		offset += conn.regsInfo[i].Bitsize / 8
+		switch conn.regsInfo[i].Name {
+		case regnamePC:
+			pcFound = true
+		case regnameCX:
+			cxFound = true
+		case regnameSP:
+			spFound = true
+		}
+		regnum++
+	}
+	if !pcFound {
+		return errors.New("could not find RIP register")
+	}
+	if !spFound {
+		return errors.New("could not find RSP register")
+	}
+	if !cxFound {
+		return errors.New("could not find RCX register")
+	}
+	return nil
+}
+
+// readRegisterInfo uses qRegisterInfo to read register information (used
+// when qXfer:feature:read is not supported).
+func (conn *gdbConn) readRegisterInfo() (err error) {
+	regnum := 0
+	var pcFound, cxFound, spFound bool
+	for {
+		conn.outbuf.Reset()
+		fmt.Fprintf(&conn.outbuf, "$qRegisterInfo%x", regnum)
+		respbytes, err := conn.exec(conn.outbuf.Bytes(), "register info")
+		if err != nil {
+			break
+		}
+
+		var regname string
+		var offset int
+		var bitsize int
+		var contained bool
+
+		resp := string(respbytes)
+		for {
+			semicolon := strings.Index(resp, ";")
+			keyval := resp
+			if semicolon >= 0 {
+				keyval = resp[:semicolon]
+			}
+
+			colon := strings.Index(keyval, ":")
+			if colon >= 0 {
+				name := keyval[:colon]
+				value := keyval[colon+1:]
+
+				switch name {
+				case "name":
+					regname = value
+				case "offset":
+					offset, _ = strconv.Atoi(value)
+				case "bitsize":
+					bitsize, _ = strconv.Atoi(value)
+				case "container-regs":
+					contained = true
+				}
+			}
+
+			if semicolon < 0 {
+				break
+			}
+			resp = resp[semicolon+1:]
+		}
+
+		if contained {
+			regnum++
+			continue
+		}
+
+		switch regname {
+		case regnamePC:
+			pcFound = true
+		case regnameCX:
+			cxFound = true
+		case regnameSP:
+			spFound = true
+		}
+
+		conn.regsInfo = append(conn.regsInfo, gdbRegisterInfo{Regnum: regnum, Name: regname, Bitsize: bitsize, Offset: offset})
+
+		regnum++
+	}
+
+	if !pcFound {
+		return errors.New("could not find RIP register")
+	}
+	if !spFound {
+		return errors.New("could not find RSP register")
+	}
+	if !cxFound {
+		return errors.New("could not find RCX register")
+	}
+
+	return nil
+}
+
+func (conn *gdbConn) readAnnex(annex string) ([]gdbRegisterInfo, error) {
+	tgtbuf, err := conn.qXfer("features", annex)
+	if err != nil {
+		return nil, err
+	}
+	var tgt gdbTarget
+	if err := xml.Unmarshal(tgtbuf, &tgt); err != nil {
+		return nil, err
+	}
+
+	for _, incl := range tgt.Includes {
+		regs, err := conn.readAnnex(incl.Href)
+		if err != nil {
+			return nil, err
+		}
+		tgt.Registers = append(tgt.Registers, regs...)
+	}
+	return tgt.Registers, nil
+}
+
+func (conn *gdbConn) readExecFile() (string, error) {
+	outbuf, err := conn.qXfer("exec-file", "")
+	if err != nil {
+		return "", err
+	}
+	return string(outbuf), nil
+}
+
+// qXfer executes a 'qXfer' read with the specified kind (i.e. feature,
+// exec-file, etc...) and annex.
+func (conn *gdbConn) qXfer(kind, annex string) ([]byte, error) {
+	out := []byte{}
+	for {
+		buf, err := conn.exec([]byte(fmt.Sprintf("$qXfer:%s:read:%s:%x,fff", kind, annex, len(out))), "target features transfer")
+		if err != nil {
+			return nil, err
+		}
+
+		out = append(out, buf[1:]...)
+		if buf[0] == 'l' {
+			break
+		}
+	}
+	return out, nil
+}
+
+// setBreakpoint executes a 'Z' (insert breakpoint) command of type '0' and kind '1'
+func (conn *gdbConn) setBreakpoint(addr uint64) error {
+	conn.outbuf.Reset()
+	fmt.Fprintf(&conn.outbuf, "$Z0,%x,1", addr)
+	_, err := conn.exec(conn.outbuf.Bytes(), "set breakpoint")
+	return err
+}
+
+// clearBreakpoint executes a 'z' (remove breakpoint) command of type '0' and kind '1'
+func (conn *gdbConn) clearBreakpoint(addr uint64) error {
+	conn.outbuf.Reset()
+	fmt.Fprintf(&conn.outbuf, "$z0,%x,1", addr)
+	_, err := conn.exec(conn.outbuf.Bytes(), "clear breakpoint")
+	return err
+}
+
+// kill executes a 'k' (kill) command.
+func (conn *gdbConn) kill() error {
+	resp, err := conn.exec([]byte{'$', 'k'}, "kill")
+	if err == io.EOF {
+		// The stub is allowed to shut the connection on us immediately after a
+		// kill. This is not an error.
+		conn.conn.Close()
+		conn.conn = nil
+		return nil
+	}
+	if err != nil {
+		return err
+	}
+	_, _, err = conn.parseStopPacket(resp, "", nil)
+	return err
+}
+
+// detach executes a 'D' (detach) command.
+func (conn *gdbConn) detach() error {
+	if conn.conn == nil {
+		// Already detached
+		return nil
+	}
+	_, err := conn.exec([]byte{'$', 'D'}, "detach")
+	conn.conn.Close()
+	conn.conn = nil
+	return err
+}
+
+// readRegisters executes a 'g' (read registers) command.
+func (conn *gdbConn) readRegisters(threadID string, data []byte) error {
+	if !conn.threadSuffixSupported {
+		if err := conn.selectThread('g', threadID, "registers read"); err != nil {
+			return err
+		}
+	}
+	conn.outbuf.Reset()
+	conn.outbuf.WriteString("$g")
+	conn.appendThreadSelector(threadID)
+	resp, err := conn.exec(conn.outbuf.Bytes(), "registers read")
+	if err != nil {
+		return err
+	}
+
+	for i := 0; i < len(resp); i += 2 {
+		n, _ := strconv.ParseUint(string(resp[i:i+2]), 16, 8)
+		data[i/2] = uint8(n)
+	}
+
+	return nil
+}
+
+// writeRegisters executes a 'G' (write registers) command.
+func (conn *gdbConn) writeRegisters(threadID string, data []byte) error {
+	if !conn.threadSuffixSupported {
+		if err := conn.selectThread('g', threadID, "registers write"); err != nil {
+			return err
+		}
+	}
+	conn.outbuf.Reset()
+	conn.outbuf.WriteString("$G")
+
+	for _, b := range data {
+		fmt.Fprintf(&conn.outbuf, "%02x", b)
+	}
+	conn.appendThreadSelector(threadID)
+	_, err := conn.exec(conn.outbuf.Bytes(), "registers write")
+	return err
+}
+
+// readRegister executes 'p' (read register) command.
+func (conn *gdbConn) readRegister(threadID string, regnum int, data []byte) error {
+	if !conn.threadSuffixSupported {
+		if err := conn.selectThread('g', threadID, "registers write"); err != nil {
+			return err
+		}
+	}
+	conn.outbuf.Reset()
+	fmt.Fprintf(&conn.outbuf, "$p%x", regnum)
+	conn.appendThreadSelector(threadID)
+	resp, err := conn.exec(conn.outbuf.Bytes(), "register read")
+	if err != nil {
+		return err
+	}
+
+	for i := 0; i < len(resp); i += 2 {
+		n, _ := strconv.ParseUint(string(resp[i:i+2]), 16, 8)
+		data[i/2] = uint8(n)
+	}
+
+	return nil
+}
+
+// writeRegister executes 'P' (write register) command.
+func (conn *gdbConn) writeRegister(threadID string, regnum int, data []byte) error {
+	if !conn.threadSuffixSupported {
+		if err := conn.selectThread('g', threadID, "registers write"); err != nil {
+			return err
+		}
+	}
+	conn.outbuf.Reset()
+	fmt.Fprintf(&conn.outbuf, "$P%x=", regnum)
+	for _, b := range data {
+		fmt.Fprintf(&conn.outbuf, "%02x", b)
+	}
+	conn.appendThreadSelector(threadID)
+	_, err := conn.exec(conn.outbuf.Bytes(), "register write")
+	return err
+}
+
+// resume executes a 'vCont' command on all threads with action 'c' if sig
+// is 0 or 'C' if it isn't.
+func (conn *gdbConn) resume(sig uint8, tu *threadUpdater) (string, uint8, error) {
+	conn.outbuf.Reset()
+	if sig == 0 {
+		fmt.Fprintf(&conn.outbuf, "$vCont;c")
+	} else {
+		fmt.Fprintf(&conn.outbuf, "$vCont;C%02x", sig)
+	}
+	if err := conn.send(conn.outbuf.Bytes()); err != nil {
+		return "", 0, err
+	}
+	conn.running = true
+	defer func() {
+		conn.running = false
+	}()
+	return conn.waitForvContStop("resume", "-1", tu)
+}
+
+// step executes a 'vCont' command on the specified thread with 's' action.
+func (conn *gdbConn) step(threadID string, tu *threadUpdater) (string, uint8, error) {
+	conn.outbuf.Reset()
+	fmt.Fprintf(&conn.outbuf, "$vCont;s:%s", threadID)
+	if err := conn.send(conn.outbuf.Bytes()); err != nil {
+		return "", 0, err
+	}
+	return conn.waitForvContStop("singlestep", threadID, tu)
+}
+
+func (conn *gdbConn) waitForvContStop(context string, threadID string, tu *threadUpdater) (string, uint8, error) {
+	for {
+		conn.conn.SetReadDeadline(time.Now().Add(heartbeatInterval))
+		resp, err := conn.recv(nil, context)
+		conn.conn.SetReadDeadline(time.Time{})
+		if neterr, isneterr := err.(net.Error); isneterr && neterr.Timeout() {
+			// Debugserver sometimes forgets to inform us that inferior stopped,
+			// sending this status request after a timeout helps us get unstuck.
+			// Debugserver will not respond to this request unless inferior is
+			// already stopped.
+			if conn.isDebugserver {
+				conn.send([]byte("$?"))
+			}
+		} else if err != nil {
+			return "", 0, err
+		} else {
+			repeat, sp, err := conn.parseStopPacket(resp, threadID, tu)
+			if !repeat {
+				return sp.threadID, sp.sig, err
+			}
+		}
+	}
+}
+
+type stopPacket struct {
+	threadID string
+	sig      uint8
+	reason   string
+}
+
+// executes 'vCont' (continue/step) command
+func (conn *gdbConn) parseStopPacket(resp []byte, threadID string, tu *threadUpdater) (repeat bool, sp stopPacket, err error) {
+	switch resp[0] {
+	case 'T':
+		if len(resp) < 3 {
+			return false, stopPacket{}, fmt.Errorf("malformed response for vCont %s", string(resp))
+		}
+
+		sig, err := strconv.ParseUint(string(resp[1:3]), 16, 8)
+		if err != nil {
+			return false, stopPacket{}, fmt.Errorf("malformed stop packet: %s", string(resp))
+		}
+		sp.sig = uint8(sig)
+
+		if logGdbWire && logGdbWireFullStopPacket {
+			fmt.Fprintf(os.Stderr, "full stop packet: %s\n", string(resp))
+		}
+
+		buf := resp[3:]
+		for buf != nil {
+			colon := bytes.Index(buf, []byte{':'})
+			if colon < 0 {
+				break
+			}
+			key := buf[:colon]
+			buf = buf[colon+1:]
+
+			semicolon := bytes.Index(buf, []byte{';'})
+			var value []byte
+			if semicolon < 0 {
+				value = buf
+				buf = nil
+			} else {
+				value = buf[:semicolon]
+				buf = buf[semicolon+1:]
+			}
+
+			switch string(key) {
+			case "thread":
+				sp.threadID = string(value)
+			case "threads":
+				if tu != nil {
+					tu.Add(strings.Split(string(value), ","))
+					tu.Finish()
+				}
+			case "reason":
+				sp.reason = string(value)
+			}
+		}
+
+		return false, sp, nil
+
+	case 'W', 'X':
+		// process exited, next two character are exit code
+
+		semicolon := bytes.Index(resp, []byte{';'})
+
+		if semicolon < 0 {
+			semicolon = len(resp)
+		}
+		status, _ := strconv.ParseUint(string(resp[1:semicolon]), 16, 8)
+		return false, stopPacket{}, ProcessExitedError{Pid: conn.pid, Status: int(status)}
+
+	case 'N':
+		// we were singlestepping the thread and the thread exited
+		sp.threadID = threadID
+		return false, sp, nil
+
+	case 'O':
+		data := make([]byte, 0, len(resp[1:])/2)
+		for i := 1; i < len(resp); i += 2 {
+			n, _ := strconv.ParseUint(string(resp[i:i+2]), 16, 8)
+			data = append(data, uint8(n))
+		}
+		os.Stdout.Write(data)
+		return true, sp, nil
+
+	default:
+		return false, sp, fmt.Errorf("unexpected response for vCont %c", resp[0])
+	}
+}
+
+const ctrlC = 0x03 // the ASCII character for ^C
+
+// executes a ctrl-C on the line
+func (conn *gdbConn) sendCtrlC() error {
+	if logGdbWire {
+		fmt.Println("<- interrupt")
+	}
+	_, err := conn.conn.Write([]byte{ctrlC})
+	return err
+}
+
+// queryProcessInfo executes a qProcessInfoPID (if pid != 0) or a qProcessInfo (if pid == 0)
+func (conn *gdbConn) queryProcessInfo(pid int) (map[string]string, error) {
+	conn.outbuf.Reset()
+	if pid != 0 {
+		fmt.Fprintf(&conn.outbuf, "$qProcessInfoPID:%d", pid)
+	} else {
+		fmt.Fprintf(&conn.outbuf, "$qProcessInfo")
+	}
+	resp, err := conn.exec(conn.outbuf.Bytes(), "process info for pid")
+	if err != nil {
+		return nil, err
+	}
+
+	pi := make(map[string]string)
+
+	for len(resp) > 0 {
+		semicolon := bytes.Index(resp, []byte{';'})
+		keyval := resp
+		if semicolon >= 0 {
+			keyval = resp[:semicolon]
+			resp = resp[semicolon+1:]
+		}
+
+		colon := bytes.Index(keyval, []byte{':'})
+		if colon < 0 {
+			continue
+		}
+
+		key := string(keyval[:colon])
+		value := string(keyval[colon+1:])
+
+		switch key {
+		case "name":
+			name := make([]byte, len(value)/2)
+			for i := 0; i < len(value); i += 2 {
+				n, _ := strconv.ParseUint(string(value[i:i+2]), 16, 8)
+				name[i/2] = byte(n)
+			}
+			pi[key] = string(name)
+
+		default:
+			pi[key] = value
+		}
+	}
+	return pi, nil
+}
+
+// executes qfThreadInfo/qsThreadInfo commands
+func (conn *gdbConn) queryThreads(first bool) (threads []string, err error) {
+	// https://sourceware.org/gdb/onlinedocs/gdb/General-Query-Packets.html
+	conn.outbuf.Reset()
+	if first {
+		conn.outbuf.WriteString("$qfThreadInfo")
+	} else {
+		conn.outbuf.WriteString("$qsThreadInfo")
+	}
+
+	resp, err := conn.exec(conn.outbuf.Bytes(), "thread info")
+	if err != nil {
+		return nil, err
+	}
+
+	switch resp[0] {
+	case 'l':
+		return nil, nil
+	case 'm':
+		// parse list...
+	default:
+		return nil, errors.New("malformed qfThreadInfo response")
+	}
+
+	var pid int
+	resp = resp[1:]
+	for {
+		tidbuf := resp
+		comma := bytes.Index(tidbuf, []byte{','})
+		if comma >= 0 {
+			tidbuf = tidbuf[:comma]
+		}
+		if conn.multiprocess && pid == 0 {
+			dot := bytes.Index(tidbuf, []byte{'.'})
+			if dot >= 0 {
+				pid, _ = strconv.Atoi(string(tidbuf[1:dot]))
+			}
+		}
+		threads = append(threads, string(tidbuf))
+		if comma < 0 {
+			break
+		}
+		resp = resp[comma+1:]
+	}
+
+	if conn.multiprocess && pid > 0 {
+		conn.pid = pid
+	}
+	return threads, nil
+}
+
+func (conn *gdbConn) selectThread(kind byte, threadID string, context string) error {
+	if conn.threadSuffixSupported {
+		panic("selectThread when thread suffix is supported")
+	}
+	conn.outbuf.Reset()
+	fmt.Fprintf(&conn.outbuf, "$H%c%s", kind, threadID)
+	_, err := conn.exec(conn.outbuf.Bytes(), context)
+	return err
+}
+
+func (conn *gdbConn) appendThreadSelector(threadID string) {
+	if !conn.threadSuffixSupported {
+		return
+	}
+	fmt.Fprintf(&conn.outbuf, ";thread:%s;", threadID)
+}
+
+// executes 'm' (read memory) command
+func (conn *gdbConn) readMemory(addr uintptr, size int) (data []byte, err error) {
+	data = make([]byte, 0, size)
+
+	for size > 0 {
+		conn.outbuf.Reset()
+
+		// gdbserver will crash if we ask too many bytes... not return an error, actually crash
+		sz := size
+		if dataSize := (conn.packetSize - 4) / 2; sz > dataSize {
+			sz = dataSize
+		}
+		size = size - sz
+
+		fmt.Fprintf(&conn.outbuf, "$m%x,%x", addr+uintptr(len(data)), sz)
+		resp, err := conn.exec(conn.outbuf.Bytes(), "memory read")
+		if err != nil {
+			return nil, err
+		}
+
+		for i := 0; i < len(resp); i += 2 {
+			n, _ := strconv.ParseUint(string(resp[i:i+2]), 16, 8)
+			data = append(data, uint8(n))
+		}
+	}
+	return data, nil
+}
+
+// executes 'M' (write memory) command
+func (conn *gdbConn) writeMemory(addr uintptr, data []byte) (written int, err error) {
+	conn.outbuf.Reset()
+	//TODO(aarzilli): do not send packets larger than conn.PacketSize
+	fmt.Fprintf(&conn.outbuf, "$M%x,%x:", addr, len(data))
+
+	for _, b := range data {
+		fmt.Fprintf(&conn.outbuf, "%02x", b)
+	}
+
+	_, err = conn.exec(conn.outbuf.Bytes(), "memory write")
+	if err != nil {
+		return 0, err
+	}
+	return len(data), nil
+}
+
+func (conn *gdbConn) allocMemory(sz uint64) (uint64, error) {
+	conn.outbuf.Reset()
+	fmt.Fprintf(&conn.outbuf, "$_M%x,rwx", sz)
+	resp, err := conn.exec(conn.outbuf.Bytes(), "memory allocation")
+	if err != nil {
+		return 0, err
+	}
+	return strconv.ParseUint(string(resp), 16, 64)
+}
+
+// threadStopInfo executes a 'qThreadStopInfo' and returns the reason the
+// thread stopped.
+func (conn *gdbConn) threadStopInfo(threadID string) (sig uint8, reason string, err error) {
+	conn.outbuf.Reset()
+	fmt.Fprintf(&conn.outbuf, "$qThreadStopInfo%s", threadID)
+	resp, err := conn.exec(conn.outbuf.Bytes(), "thread stop info")
+	if err != nil {
+		return 0, "", err
+	}
+	_, sp, err := conn.parseStopPacket(resp, "", nil)
+	if err != nil {
+		return 0, "", err
+	}
+	return sp.sig, sp.reason, nil
+}
+
+// exec executes a message to the stub and reads a response.
+// The details of the wire protocol are described here:
+//  https://sourceware.org/gdb/onlinedocs/gdb/Overview.html#Overview
+func (conn *gdbConn) exec(cmd []byte, context string) ([]byte, error) {
+	if err := conn.send(cmd); err != nil {
+		return nil, err
+	}
+	return conn.recv(cmd, context)
+
+}
+
+var hexdigit = []byte{'0', '1', '2', '3', '4', '5', '6', '7', '8', '9', 'a', 'b', 'c', 'd', 'e', 'f'}
+
+func (conn *gdbConn) send(cmd []byte) error {
+	if len(cmd) == 0 || cmd[0] != '$' {
+		panic("gdb protocol error: command doesn't start with '$'")
+	}
+
+	// append checksum to packet
+	cmd = append(cmd, '#')
+	sum := checksum(cmd)
+	cmd = append(cmd, hexdigit[sum>>4])
+	cmd = append(cmd, hexdigit[sum&0xf])
+
+	attempt := 0
+	for {
+		if logGdbWire {
+			if len(cmd) > logGdbWireMaxLen {
+				fmt.Printf("<- %s...\n", string(cmd[:logGdbWireMaxLen]))
+			} else {
+				fmt.Printf("<- %s\n", string(cmd))
+			}
+		}
+		_, err := conn.conn.Write(cmd)
+		if err != nil {
+			return err
+		}
+
+		if !conn.ack {
+			break
+		}
+
+		if conn.readack() {
+			break
+		}
+		if attempt > conn.maxTransmitAttempts {
+			return ErrTooManyAttempts
+		}
+		attempt++
+	}
+	return nil
+}
+
+func (conn *gdbConn) recv(cmd []byte, context string) (resp []byte, err error) {
+	attempt := 0
+	for {
+		var err error
+		resp, err = conn.rdr.ReadBytes('#')
+		if err != nil {
+			return nil, err
+		}
+
+		// read checksum
+		_, err = conn.rdr.Read(conn.inbuf[:2])
+		if err != nil {
+			return nil, err
+		}
+		if logGdbWire {
+			out := resp
+			partial := false
+			if idx := bytes.Index(out, []byte{'\n'}); idx >= 0 {
+				out = resp[:idx]
+				partial = true
+			}
+			if len(out) > logGdbWireMaxLen {
+				out = out[:logGdbWireMaxLen]
+				partial = true
+			}
+			if !partial {
+				fmt.Printf("-> %s%s\n", string(resp), string(conn.inbuf[:2]))
+			} else {
+				fmt.Printf("-> %s...\n", string(out))
+			}
+		}
+
+		if !conn.ack {
+			break
+		}
+
+		if resp[0] == '%' {
+			// If the first character is a % (instead of $) the stub sent us a
+			// notification packet, this is weird since we specifically claimed that
+			// we don't support notifications of any kind, but it should be safe to
+			// ignore regardless.
+			continue
+		}
+
+		if checksumok(resp, conn.inbuf[:2]) {
+			conn.sendack('+')
+			break
+		}
+		if attempt > conn.maxTransmitAttempts {
+			conn.sendack('+')
+			return nil, ErrTooManyAttempts
+		}
+		attempt++
+		conn.sendack('-')
+	}
+
+	conn.inbuf, resp = wiredecode(resp, conn.inbuf)
+
+	if len(resp) == 0 || resp[0] == 'E' {
+		cmdstr := ""
+		if cmd != nil {
+			cmdstr = string(cmd)
+		}
+		return nil, &GdbProtocolError{context, cmdstr, string(resp)}
+	}
+
+	return resp, nil
+}
+
+// Readack reads one byte from stub, returns true if the byte is '+'
+func (conn *gdbConn) readack() bool {
+	b, err := conn.rdr.ReadByte()
+	if err != nil {
+		return false
+	}
+	if logGdbWire {
+		fmt.Printf("-> %s\n", string(b))
+	}
+	return b == '+'
+}
+
+// Sendack executes an ack character, c must be either '+' or '-'
+func (conn *gdbConn) sendack(c byte) {
+	if c != '+' && c != '-' {
+		panic(fmt.Errorf("sendack(%c)", c))
+	}
+	conn.conn.Write([]byte{c})
+	if logGdbWire {
+		fmt.Printf("<- %s\n", string(c))
+	}
+}
+
+// wiredecode decodes the contents of in into buf.
+// If buf is nil it will be allocated ex-novo, if the size of buf is not
+// enough to hold the decoded contents it will be grown.
+// Returns the newly allocated buffer as newbuf and the message contents as
+// msg.
+func wiredecode(in, buf []byte) (newbuf, msg []byte) {
+	if buf != nil {
+		buf = buf[:0]
+	} else {
+		buf = make([]byte, 0, 256)
+	}
+
+	start := 1
+
+	for i := 0; i < len(in); i++ {
+		switch ch := in[i]; ch {
+		case '{': // escape
+			if i+1 >= len(in) {
+				buf = append(buf, ch)
+			} else {
+				buf = append(buf, in[i+1]^0x20)
+			}
+		case ':':
+			buf = append(buf, ch)
+			if i == 3 {
+				// we just read the sequence identifier
+				start = i + 1
+			}
+		case '#': // end of packet
+			return buf, buf[start:]
+		case '*': // runlenght encoding marker
+			if i+1 >= len(in) || i == 0 {
+				buf = append(buf, ch)
+			} else {
+				n := in[i+1] - 29
+				r := buf[len(buf)-1]
+				for j := uint8(0); j < n; j++ {
+					buf = append(buf, r)
+				}
+				i++
+			}
+		default:
+			buf = append(buf, ch)
+		}
+	}
+	return buf, buf[start:]
+}
+
+// Checksumok checks that checksum is a valid checksum for packet.
+func checksumok(packet, checksumBuf []byte) bool {
+	if packet[0] != '$' {
+		return false
+	}
+
+	sum := checksum(packet)
+	tgt, err := strconv.ParseUint(string(checksumBuf), 16, 8)
+	if err != nil {
+		return false
+	}
+	return sum == uint8(tgt)
+}
+
+func checksum(packet []byte) (sum uint8) {
+	for i := 1; i < len(packet); i++ {
+		if packet[i] == '#' {
+			return sum
+		}
+		sum += packet[i]
+	}
+	return sum
+}

--- a/pkg/proc/gdbserver_conn.go
+++ b/pkg/proc/gdbserver_conn.go
@@ -778,8 +778,9 @@ func (conn *gdbConn) appendThreadSelector(threadID string) {
 }
 
 // executes 'm' (read memory) command
-func (conn *gdbConn) readMemory(addr uintptr, size int) (data []byte, err error) {
-	data = make([]byte, 0, size)
+func (conn *gdbConn) readMemory(data []byte, addr uintptr) error {
+	size := len(data)
+	data = data[:0]
 
 	for size > 0 {
 		conn.outbuf.Reset()
@@ -794,7 +795,7 @@ func (conn *gdbConn) readMemory(addr uintptr, size int) (data []byte, err error)
 		fmt.Fprintf(&conn.outbuf, "$m%x,%x", addr+uintptr(len(data)), sz)
 		resp, err := conn.exec(conn.outbuf.Bytes(), "memory read")
 		if err != nil {
-			return nil, err
+			return err
 		}
 
 		for i := 0; i < len(resp); i += 2 {
@@ -802,7 +803,7 @@ func (conn *gdbConn) readMemory(addr uintptr, size int) (data []byte, err error)
 			data = append(data, uint8(n))
 		}
 	}
-	return data, nil
+	return nil
 }
 
 // executes 'M' (write memory) command

--- a/pkg/proc/gdbserver_unix.go
+++ b/pkg/proc/gdbserver_unix.go
@@ -1,0 +1,9 @@
+// +build linux darwin
+
+package proc
+
+import "syscall"
+
+func backgroundSysProcAttr() *syscall.SysProcAttr {
+	return &syscall.SysProcAttr{Setpgid: true, Pgid: 0, Foreground: false}
+}

--- a/pkg/proc/gdbserver_windows.go
+++ b/pkg/proc/gdbserver_windows.go
@@ -1,0 +1,7 @@
+package proc
+
+import "syscall"
+
+func backgroundSysProcAttr() *syscall.SysProcAttr {
+	return nil
+}

--- a/pkg/proc/linux_amd64_core.go
+++ b/pkg/proc/linux_amd64_core.go
@@ -3,15 +3,285 @@ package proc
 import (
 	"bytes"
 	"encoding/binary"
+	"errors"
 	"fmt"
 	"io"
 	"os"
 
 	"golang.org/x/debug/elf"
-	"golang.org/x/sys/unix"
+
+	"golang.org/x/arch/x86/x86asm"
 )
 
+// Copied from golang.org/x/sys/unix.PtraceRegs since it's not available on
+// all systems.
+type LinuxCoreRegisters struct {
+	R15      uint64
+	R14      uint64
+	R13      uint64
+	R12      uint64
+	Rbp      uint64
+	Rbx      uint64
+	R11      uint64
+	R10      uint64
+	R9       uint64
+	R8       uint64
+	Rax      uint64
+	Rcx      uint64
+	Rdx      uint64
+	Rsi      uint64
+	Rdi      uint64
+	Orig_rax uint64
+	Rip      uint64
+	Cs       uint64
+	Eflags   uint64
+	Rsp      uint64
+	Ss       uint64
+	Fs_base  uint64
+	Gs_base  uint64
+	Ds       uint64
+	Es       uint64
+	Fs       uint64
+	Gs       uint64
+}
+
+// Copied from golang.org/x/sys/unix.Timeval since it's not available on all
+// systems.
+type LinuxCoreTimeval struct {
+	Sec  int64
+	Usec int64
+}
+
 const NT_FILE elf.NType = 0x46494c45 // "FILE".
+
+func (r *LinuxCoreRegisters) PC() uint64 {
+	return r.Rip
+}
+
+func (r *LinuxCoreRegisters) SP() uint64 {
+	return r.Rsp
+}
+
+func (r *LinuxCoreRegisters) BP() uint64 {
+	return r.Rbp
+}
+
+func (r *LinuxCoreRegisters) CX() uint64 {
+	return r.Rcx
+}
+
+func (r *LinuxCoreRegisters) TLS() uint64 {
+	return r.Fs_base
+}
+
+func (r *LinuxCoreRegisters) GAddr() (uint64, bool) {
+	return 0, false
+}
+
+func (r *LinuxCoreRegisters) Get(n int) (uint64, error) {
+	reg := x86asm.Reg(n)
+	const (
+		mask8  = 0x000f
+		mask16 = 0x00ff
+		mask32 = 0xffff
+	)
+
+	switch reg {
+	// 8-bit
+	case x86asm.AL:
+		return r.Rax & mask8, nil
+	case x86asm.CL:
+		return r.Rcx & mask8, nil
+	case x86asm.DL:
+		return r.Rdx & mask8, nil
+	case x86asm.BL:
+		return r.Rbx & mask8, nil
+	case x86asm.AH:
+		return (r.Rax >> 8) & mask8, nil
+	case x86asm.CH:
+		return (r.Rcx >> 8) & mask8, nil
+	case x86asm.DH:
+		return (r.Rdx >> 8) & mask8, nil
+	case x86asm.BH:
+		return (r.Rbx >> 8) & mask8, nil
+	case x86asm.SPB:
+		return r.Rsp & mask8, nil
+	case x86asm.BPB:
+		return r.Rbp & mask8, nil
+	case x86asm.SIB:
+		return r.Rsi & mask8, nil
+	case x86asm.DIB:
+		return r.Rdi & mask8, nil
+	case x86asm.R8B:
+		return r.R8 & mask8, nil
+	case x86asm.R9B:
+		return r.R9 & mask8, nil
+	case x86asm.R10B:
+		return r.R10 & mask8, nil
+	case x86asm.R11B:
+		return r.R11 & mask8, nil
+	case x86asm.R12B:
+		return r.R12 & mask8, nil
+	case x86asm.R13B:
+		return r.R13 & mask8, nil
+	case x86asm.R14B:
+		return r.R14 & mask8, nil
+	case x86asm.R15B:
+		return r.R15 & mask8, nil
+
+	// 16-bit
+	case x86asm.AX:
+		return r.Rax & mask16, nil
+	case x86asm.CX:
+		return r.Rcx & mask16, nil
+	case x86asm.DX:
+		return r.Rdx & mask16, nil
+	case x86asm.BX:
+		return r.Rbx & mask16, nil
+	case x86asm.SP:
+		return r.Rsp & mask16, nil
+	case x86asm.BP:
+		return r.Rbp & mask16, nil
+	case x86asm.SI:
+		return r.Rsi & mask16, nil
+	case x86asm.DI:
+		return r.Rdi & mask16, nil
+	case x86asm.R8W:
+		return r.R8 & mask16, nil
+	case x86asm.R9W:
+		return r.R9 & mask16, nil
+	case x86asm.R10W:
+		return r.R10 & mask16, nil
+	case x86asm.R11W:
+		return r.R11 & mask16, nil
+	case x86asm.R12W:
+		return r.R12 & mask16, nil
+	case x86asm.R13W:
+		return r.R13 & mask16, nil
+	case x86asm.R14W:
+		return r.R14 & mask16, nil
+	case x86asm.R15W:
+		return r.R15 & mask16, nil
+
+	// 32-bit
+	case x86asm.EAX:
+		return r.Rax & mask32, nil
+	case x86asm.ECX:
+		return r.Rcx & mask32, nil
+	case x86asm.EDX:
+		return r.Rdx & mask32, nil
+	case x86asm.EBX:
+		return r.Rbx & mask32, nil
+	case x86asm.ESP:
+		return r.Rsp & mask32, nil
+	case x86asm.EBP:
+		return r.Rbp & mask32, nil
+	case x86asm.ESI:
+		return r.Rsi & mask32, nil
+	case x86asm.EDI:
+		return r.Rdi & mask32, nil
+	case x86asm.R8L:
+		return r.R8 & mask32, nil
+	case x86asm.R9L:
+		return r.R9 & mask32, nil
+	case x86asm.R10L:
+		return r.R10 & mask32, nil
+	case x86asm.R11L:
+		return r.R11 & mask32, nil
+	case x86asm.R12L:
+		return r.R12 & mask32, nil
+	case x86asm.R13L:
+		return r.R13 & mask32, nil
+	case x86asm.R14L:
+		return r.R14 & mask32, nil
+	case x86asm.R15L:
+		return r.R15 & mask32, nil
+
+	// 64-bit
+	case x86asm.RAX:
+		return r.Rax, nil
+	case x86asm.RCX:
+		return r.Rcx, nil
+	case x86asm.RDX:
+		return r.Rdx, nil
+	case x86asm.RBX:
+		return r.Rbx, nil
+	case x86asm.RSP:
+		return r.Rsp, nil
+	case x86asm.RBP:
+		return r.Rbp, nil
+	case x86asm.RSI:
+		return r.Rsi, nil
+	case x86asm.RDI:
+		return r.Rdi, nil
+	case x86asm.R8:
+		return r.R8, nil
+	case x86asm.R9:
+		return r.R9, nil
+	case x86asm.R10:
+		return r.R10, nil
+	case x86asm.R11:
+		return r.R11, nil
+	case x86asm.R12:
+		return r.R12, nil
+	case x86asm.R13:
+		return r.R13, nil
+	case x86asm.R14:
+		return r.R14, nil
+	case x86asm.R15:
+		return r.R15, nil
+	}
+
+	return 0, UnknownRegisterError
+}
+
+func (r *LinuxCoreRegisters) SetPC(IThread, uint64) error {
+	return errors.New("not supported")
+}
+
+func (r *LinuxCoreRegisters) Slice() []Register {
+	var regs = []struct {
+		k string
+		v uint64
+	}{
+		{"Rip", r.Rip},
+		{"Rsp", r.Rsp},
+		{"Rax", r.Rax},
+		{"Rbx", r.Rbx},
+		{"Rcx", r.Rcx},
+		{"Rdx", r.Rdx},
+		{"Rdi", r.Rdi},
+		{"Rsi", r.Rsi},
+		{"Rbp", r.Rbp},
+		{"R8", r.R8},
+		{"R9", r.R9},
+		{"R10", r.R10},
+		{"R11", r.R11},
+		{"R12", r.R12},
+		{"R13", r.R13},
+		{"R14", r.R14},
+		{"R15", r.R15},
+		{"Orig_rax", r.Orig_rax},
+		{"Cs", r.Cs},
+		{"Eflags", r.Eflags},
+		{"Ss", r.Ss},
+		{"Fs_base", r.Fs_base},
+		{"Gs_base", r.Gs_base},
+		{"Ds", r.Ds},
+		{"Es", r.Es},
+		{"Fs", r.Fs},
+		{"Gs", r.Gs},
+	}
+	out := make([]Register, 0, len(regs))
+	for _, reg := range regs {
+		if reg.k == "Eflags" {
+			out = appendFlagReg(out, reg.k, reg.v, eflagsDescription, 64)
+		} else {
+			out = appendQwordReg(out, reg.k, reg.v)
+		}
+	}
+	return out
+}
 
 // readCore reads a core file from corePath corresponding to the executable at
 // exePath. For details on the Linux ELF core format, see:
@@ -234,8 +504,8 @@ type LinuxPrStatus struct {
 	Sigpend                      uint64
 	Sighold                      uint64
 	Pid, Ppid, Pgrp, Sid         int32
-	Utime, Stime, CUtime, CStime unix.Timeval
-	Reg                          unix.PtraceRegs
+	Utime, Stime, CUtime, CStime LinuxCoreTimeval
+	Reg                          LinuxCoreRegisters
 	Fpvalid                      int32
 }
 

--- a/pkg/proc/mem.go
+++ b/pkg/proc/mem.go
@@ -2,8 +2,17 @@ package proc
 
 const cacheEnabled = true
 
+// MemoryReader is like io.ReaderAt, but the offset is a uintptr so that it
+// can address all of 64-bit memory.
+// Redundant with memoryReadWriter but more easily suited to working with
+// the standard io package.
+type MemoryReader interface {
+	// ReadMemory is just like io.ReaderAt.ReadAt.
+	ReadMemory(buf []byte, addr uintptr) (n int, err error)
+}
+
 type memoryReadWriter interface {
-	readMemory(addr uintptr, size int) (data []byte, err error)
+	MemoryReader
 	writeMemory(addr uintptr, data []byte) (written int, err error)
 }
 
@@ -17,14 +26,13 @@ func (m *memCache) contains(addr uintptr, size int) bool {
 	return addr >= m.cacheAddr && addr <= (m.cacheAddr+uintptr(len(m.cache)-size))
 }
 
-func (m *memCache) readMemory(addr uintptr, size int) (data []byte, err error) {
-	if m.contains(addr, size) {
-		d := make([]byte, size)
-		copy(d, m.cache[addr-m.cacheAddr:])
-		return d, nil
+func (m *memCache) ReadMemory(data []byte, addr uintptr) (n int, err error) {
+	if m.contains(addr, len(data)) {
+		copy(data, m.cache[addr-m.cacheAddr:])
+		return len(data), nil
 	}
 
-	return m.mem.readMemory(addr, size)
+	return m.mem.ReadMemory(data, addr)
 }
 
 func (m *memCache) writeMemory(addr uintptr, data []byte) (written int, err error) {
@@ -42,14 +50,16 @@ func cacheMemory(mem memoryReadWriter, addr uintptr, size int) memoryReadWriter 
 		if cacheMem.contains(addr, size) {
 			return mem
 		} else {
-			cache, err := cacheMem.mem.readMemory(addr, size)
+			cache := make([]byte, size)
+			_, err := cacheMem.mem.ReadMemory(cache, addr)
 			if err != nil {
 				return mem
 			}
 			return &memCache{addr, cache, mem}
 		}
 	}
-	cache, err := mem.readMemory(addr, size)
+	cache := make([]byte, size)
+	_, err := mem.ReadMemory(cache, addr)
 	if err != nil {
 		return mem
 	}

--- a/pkg/proc/moduledata.go
+++ b/pkg/proc/moduledata.go
@@ -142,7 +142,8 @@ const (
 
 func loadName(bi *BinaryInfo, addr uintptr, mem memoryReadWriter) (name, tag string, pkgpathoff int32, err error) {
 	off := addr
-	namedata, err := mem.readMemory(off, 3)
+	namedata := make([]byte, 3)
+	_, err = mem.ReadMemory(namedata, off)
 	off += 3
 	if err != nil {
 		return "", "", 0, err
@@ -150,7 +151,8 @@ func loadName(bi *BinaryInfo, addr uintptr, mem memoryReadWriter) (name, tag str
 
 	namelen := uint16(namedata[1]<<8) | uint16(namedata[2])
 
-	rawstr, err := mem.readMemory(off, int(namelen))
+	rawstr := make([]byte, int(namelen))
+	_, err = mem.ReadMemory(rawstr, off)
 	off += uintptr(namelen)
 	if err != nil {
 		return "", "", 0, err
@@ -159,14 +161,16 @@ func loadName(bi *BinaryInfo, addr uintptr, mem memoryReadWriter) (name, tag str
 	name = string(rawstr)
 
 	if namedata[0]&nameflagHasTag != 0 {
-		taglendata, err := mem.readMemory(off, 2)
+		taglendata := make([]byte, 2)
+		_, err = mem.ReadMemory(taglendata, off)
 		off += 2
 		if err != nil {
 			return "", "", 0, err
 		}
 		taglen := uint16(taglendata[0]<<8) | uint16(taglendata[1])
 
-		rawstr, err := mem.readMemory(off, int(taglen))
+		rawstr := make([]byte, int(taglen))
+		_, err = mem.ReadMemory(rawstr, off)
 		off += uintptr(taglen)
 		if err != nil {
 			return "", "", 0, err
@@ -176,7 +180,8 @@ func loadName(bi *BinaryInfo, addr uintptr, mem memoryReadWriter) (name, tag str
 	}
 
 	if namedata[0]&nameflagHasPkg != 0 {
-		pkgdata, err := mem.readMemory(off, 4)
+		pkgdata := make([]byte, 4)
+		_, err = mem.ReadMemory(pkgdata, off)
 		if err != nil {
 			return "", "", 0, err
 		}

--- a/pkg/proc/proc.go
+++ b/pkg/proc/proc.go
@@ -295,7 +295,7 @@ func (dbp *Process) ClearBreakpoint(addr uint64) (*Breakpoint, error) {
 		return nil, NoBreakpointError{addr: addr}
 	}
 
-	if _, err := bp.Clear(dbp.currentThread); err != nil {
+	if _, err := dbp.currentThread.ClearBreakpoint(bp); err != nil {
 		return nil, err
 	}
 

--- a/pkg/proc/proc.go
+++ b/pkg/proc/proc.go
@@ -282,7 +282,8 @@ func (dbp *Process) SetBreakpoint(addr uint64, kind BreakpointKind, cond ast.Exp
 	}
 
 	thread := dbp.threads[tid]
-	originalData, err := thread.readMemory(uintptr(addr), dbp.bi.arch.BreakpointSize())
+	originalData := make([]byte, dbp.bi.arch.BreakpointSize())
+	_, err := thread.ReadMemory(originalData, uintptr(addr))
 	if err != nil {
 		return nil, err
 	}
@@ -707,7 +708,8 @@ func GoroutinesInfo(dbp EvalScopeConvertible) ([]*G, error) {
 	if err != nil {
 		return nil, err
 	}
-	allglenBytes, err := dbp.CurrentThread().readMemory(uintptr(addr), 8)
+	allglenBytes := make([]byte, 8)
+	_, err = dbp.CurrentThread().ReadMemory(allglenBytes, uintptr(addr))
 	if err != nil {
 		return nil, err
 	}
@@ -722,7 +724,8 @@ func GoroutinesInfo(dbp EvalScopeConvertible) ([]*G, error) {
 			return nil, err
 		}
 	}
-	faddr, err := dbp.CurrentThread().readMemory(uintptr(allgentryaddr), dbp.BinInfo().arch.PtrSize())
+	faddr := make([]byte, dbp.BinInfo().arch.PtrSize())
+	_, err = dbp.CurrentThread().ReadMemory(faddr, uintptr(allgentryaddr))
 	allgptr := binary.LittleEndian.Uint64(faddr)
 
 	for i := uint64(0); i < allglen; i++ {

--- a/pkg/proc/proc_test.go
+++ b/pkg/proc/proc_test.go
@@ -135,7 +135,9 @@ func getRegisters(p IProcess, t *testing.T) Registers {
 }
 
 func dataAtAddr(thread memoryReadWriter, addr uint64) ([]byte, error) {
-	return thread.readMemory(uintptr(addr), 1)
+	data := make([]byte, 1)
+	_, err := thread.ReadMemory(data, uintptr(addr))
+	return data, err
 }
 
 func assertNoError(err error, t testing.TB, s string) {

--- a/pkg/proc/proc_unix_test.go
+++ b/pkg/proc/proc_unix_test.go
@@ -6,24 +6,40 @@ import (
 	"syscall"
 	"testing"
 	"time"
+	"runtime"
 
 	protest "github.com/derekparker/delve/pkg/proc/test"
 )
 
 func TestIssue419(t *testing.T) {
+	if testBackend == "lldb" && runtime.GOOS == "darwin" {
+		// debugserver bug?
+		return
+	}
 	// SIGINT directed at the inferior should be passed along not swallowed by delve
-	withTestProcess("issue419", t, func(p *Process, fixture protest.Fixture) {
+	withTestProcess("issue419", t, func(p IProcess, fixture protest.Fixture) {
+		_, err := setFunctionBreakpoint(p, "main.main")
+		assertNoError(err, t, "SetBreakpoint()")
+		assertNoError(Continue(p), t, "Continue()")
 		go func() {
 			for {
+				time.Sleep(500 * time.Millisecond)
 				if p.Running() {
 					time.Sleep(2 * time.Second)
-					err := syscall.Kill(p.pid, syscall.SIGINT)
+					if p.Pid() <= 0 {
+						// if we don't stop the inferior the test will never finish
+						p.RequestManualStop()
+						p.Kill()
+						t.Fatalf("Pid is zero or negative: %d", p.Pid())
+						return
+					}
+					err := syscall.Kill(p.Pid(), syscall.SIGINT)
 					assertNoError(err, t, "syscall.Kill")
 					return
 				}
 			}
 		}()
-		err := Continue(p)
+		err = Continue(p)
 		if _, exited := err.(ProcessExitedError); !exited {
 			t.Fatalf("Unexpected error after Continue(): %v\n", err)
 		}

--- a/pkg/proc/proc_unix_test.go
+++ b/pkg/proc/proc_unix_test.go
@@ -23,7 +23,7 @@ func TestIssue419(t *testing.T) {
 				}
 			}
 		}()
-		err := p.Continue()
+		err := Continue(p)
 		if _, exited := err.(ProcessExitedError); !exited {
 			t.Fatalf("Unexpected error after Continue(): %v\n", err)
 		}

--- a/pkg/proc/proc_windows.go
+++ b/pkg/proc/proc_windows.go
@@ -330,7 +330,8 @@ func (dbp *Process) waitForDebugEvent(flags waitForDebugEventFlags) (threadID, e
 				// this exception anymore.
 				atbp := true
 				if thread, found := dbp.threads[tid]; found {
-					if data, err := thread.readMemory(exception.ExceptionRecord.ExceptionAddress, dbp.bi.arch.BreakpointSize()); err == nil {
+					data := make([]byte, dbp.bi.arch.BreakpointSize())
+					if _, err := thread.ReadMemory(data, exception.ExceptionRecord.ExceptionAddress); err == nil {
 						instr := dbp.bi.arch.BreakpointInstruction()
 						for i := range instr {
 							if data[i] != instr[i] {

--- a/pkg/proc/registers.go
+++ b/pkg/proc/registers.go
@@ -21,7 +21,7 @@ type Registers interface {
 	CX() uint64
 	TLS() uint64
 	Get(int) (uint64, error)
-	SetPC(*Thread, uint64) error
+	SetPC(IThread, uint64) error
 	Slice() []Register
 }
 

--- a/pkg/proc/registers.go
+++ b/pkg/proc/registers.go
@@ -20,6 +20,8 @@ type Registers interface {
 	BP() uint64
 	CX() uint64
 	TLS() uint64
+	// GAddr returns the address of the G variable if it is known, 0 and false otherwise
+	GAddr() (uint64, bool)
 	Get(int) (uint64, error)
 	SetPC(IThread, uint64) error
 	Slice() []Register

--- a/pkg/proc/registers_darwin_amd64.go
+++ b/pkg/proc/registers_darwin_amd64.go
@@ -105,6 +105,10 @@ func (r *Regs) TLS() uint64 {
 	return r.gsBase
 }
 
+func (r *Regs) GAddr() (uint64, bool) {
+	return 0, false
+}
+
 // SetPC sets the RIP register to the value specified by `pc`.
 func (r *Regs) SetPC(t IThread, pc uint64) error {
 	thread := t.(*Thread)

--- a/pkg/proc/registers_darwin_amd64.go
+++ b/pkg/proc/registers_darwin_amd64.go
@@ -106,7 +106,8 @@ func (r *Regs) TLS() uint64 {
 }
 
 // SetPC sets the RIP register to the value specified by `pc`.
-func (r *Regs) SetPC(thread *Thread, pc uint64) error {
+func (r *Regs) SetPC(t IThread, pc uint64) error {
+	thread := t.(*Thread)
 	kret := C.set_pc(thread.os.threadAct, C.uint64_t(pc))
 	if kret != C.KERN_SUCCESS {
 		return fmt.Errorf("could not set pc")

--- a/pkg/proc/registers_linux_amd64.go
+++ b/pkg/proc/registers_linux_amd64.go
@@ -83,6 +83,10 @@ func (r *Regs) TLS() uint64 {
 	return r.regs.Fs_base
 }
 
+func (r *Regs) GAddr() (uint64, bool) {
+	return 0, false
+}
+
 // SetPC sets RIP to the value specified by 'pc'.
 func (r *Regs) SetPC(t IThread, pc uint64) (err error) {
 	thread := t.(*Thread)

--- a/pkg/proc/registers_linux_amd64.go
+++ b/pkg/proc/registers_linux_amd64.go
@@ -84,7 +84,8 @@ func (r *Regs) TLS() uint64 {
 }
 
 // SetPC sets RIP to the value specified by 'pc'.
-func (r *Regs) SetPC(thread *Thread, pc uint64) (err error) {
+func (r *Regs) SetPC(t IThread, pc uint64) (err error) {
+	thread := t.(*Thread)
 	r.regs.SetPC(pc)
 	thread.dbp.execPtraceFunc(func() { err = sys.PtraceSetRegs(thread.ID, r.regs) })
 	return

--- a/pkg/proc/registers_windows_amd64.go
+++ b/pkg/proc/registers_windows_amd64.go
@@ -125,7 +125,8 @@ func (r *Regs) TLS() uint64 {
 }
 
 // SetPC sets the RIP register to the value specified by `pc`.
-func (r *Regs) SetPC(thread *Thread, pc uint64) error {
+func (r *Regs) SetPC(t IThread, pc uint64) error {
+	thread := t.(*Thread)
 	context := newCONTEXT()
 	context.ContextFlags = _CONTEXT_ALL
 

--- a/pkg/proc/registers_windows_amd64.go
+++ b/pkg/proc/registers_windows_amd64.go
@@ -124,6 +124,10 @@ func (r *Regs) TLS() uint64 {
 	return r.tls
 }
 
+func (r *Regs) GAddr() (uint64, bool) {
+	return 0, false
+}
+
 // SetPC sets the RIP register to the value specified by `pc`.
 func (r *Regs) SetPC(t IThread, pc uint64) error {
 	thread := t.(*Thread)

--- a/pkg/proc/threads.go
+++ b/pkg/proc/threads.go
@@ -83,7 +83,7 @@ func (thread *Thread) StepInstruction() (err error) {
 	bp, ok := thread.dbp.FindBreakpoint(pc)
 	if ok {
 		// Clear the breakpoint so that we can continue execution.
-		_, err = bp.Clear(thread)
+		_, err = thread.ClearBreakpoint(bp)
 		if err != nil {
 			return err
 		}

--- a/pkg/proc/threads.go
+++ b/pkg/proc/threads.go
@@ -385,7 +385,8 @@ func getGVariable(thread IThread) (*Variable, error) {
 
 	gaddr, hasgaddr := regs.GAddr()
 	if !hasgaddr {
-		gaddrbs, err := thread.readMemory(uintptr(regs.TLS()+arch.GStructOffset()), arch.PtrSize())
+		gaddrbs := make([]byte, arch.PtrSize())
+		_, err := thread.ReadMemory(gaddrbs, uintptr(regs.TLS()+arch.GStructOffset()))
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/proc/threads_darwin.go
+++ b/pkg/proc/threads_darwin.go
@@ -93,7 +93,7 @@ func threadBlocked(t IThread) bool {
 		return false
 	}
 	switch fn.Name {
-	case "runtime.kevent", "runtime.mach_semaphore_wait", "runtime.usleep":
+	case "runtime.kevent", "runtime.mach_semaphore_wait", "runtime.usleep", "runtime.mach_semaphore_timedwait":
 		return true
 	default:
 		return false

--- a/pkg/proc/threads_darwin.go
+++ b/pkg/proc/threads_darwin.go
@@ -119,20 +119,19 @@ func (t *Thread) writeMemory(addr uintptr, data []byte) (int, error) {
 	return len(data), nil
 }
 
-func (t *Thread) readMemory(addr uintptr, size int) ([]byte, error) {
-	if size == 0 {
-		return nil, nil
+func (t *Thread) ReadMemory(buf []byte, addr uintptr) (int, error) {
+	if len(buf) == 0 {
+		return 0, nil
 	}
 	var (
-		buf    = make([]byte, size)
 		vmData = unsafe.Pointer(&buf[0])
 		vmAddr = C.mach_vm_address_t(addr)
-		length = C.mach_msg_type_number_t(size)
+		length = C.mach_msg_type_number_t(len(buf))
 	)
 
 	ret := C.read_memory(t.dbp.os.task, vmAddr, vmData, length)
 	if ret < 0 {
-		return nil, fmt.Errorf("could not read memory")
+		return 0, fmt.Errorf("could not read memory")
 	}
-	return buf, nil
+	return len(buf), nil
 }

--- a/pkg/proc/threads_darwin.go
+++ b/pkg/proc/threads_darwin.go
@@ -81,13 +81,14 @@ func (t *Thread) resume() error {
 	return nil
 }
 
-func (t *Thread) blocked() bool {
+func threadBlocked(t IThread) bool {
 	// TODO(dp) cache the func pc to remove this lookup
-	pc, err := t.PC()
+	regs, err := t.Registers(false)
 	if err != nil {
 		return false
 	}
-	fn := t.dbp.bi.goSymTable.PCToFunc(pc)
+	pc := regs.PC()
+	fn := t.BinInfo().goSymTable.PCToFunc(pc)
 	if fn == nil {
 		return false
 	}

--- a/pkg/proc/threads_linux.go
+++ b/pkg/proc/threads_linux.go
@@ -67,9 +67,13 @@ func (t *Thread) singleStep() (err error) {
 	}
 }
 
-func (t *Thread) blocked() bool {
-	pc, _ := t.PC()
-	fn := t.dbp.bi.goSymTable.PCToFunc(pc)
+func threadBlocked(t IThread) bool {
+	regs, err := t.Registers(false)
+	if err != nil {
+		return false
+	}
+	pc := regs.PC()
+	fn := t.BinInfo().goSymTable.PCToFunc(pc)
 	if fn != nil && ((fn.Name == "runtime.futex") || (fn.Name == "runtime.usleep") || (fn.Name == "runtime.clone")) {
 		return true
 	}

--- a/pkg/proc/threads_linux.go
+++ b/pkg/proc/threads_linux.go
@@ -102,11 +102,10 @@ func (t *Thread) writeMemory(addr uintptr, data []byte) (written int, err error)
 	return
 }
 
-func (t *Thread) readMemory(addr uintptr, size int) (data []byte, err error) {
-	if size == 0 {
+func (t *Thread) ReadMemory(data []byte, addr uintptr) (n int, err error) {
+	if len(data) == 0 {
 		return
 	}
-	data = make([]byte, size)
 	t.dbp.execPtraceFunc(func() { _, err = sys.PtracePeekData(t.ID, addr, data) })
 	return
 }

--- a/pkg/proc/threads_windows.go
+++ b/pkg/proc/threads_windows.go
@@ -138,15 +138,14 @@ func (t *Thread) writeMemory(addr uintptr, data []byte) (int, error) {
 	return int(count), nil
 }
 
-func (t *Thread) readMemory(addr uintptr, size int) ([]byte, error) {
-	if size == 0 {
-		return nil, nil
+func (t *Thread) ReadMemory(buf []byte, addr uintptr) (int, error) {
+	if len(buf) == 0 {
+		return 0, nil
 	}
 	var count uintptr
-	buf := make([]byte, size)
-	err := _ReadProcessMemory(t.dbp.os.hProcess, addr, &buf[0], uintptr(size), &count)
-	if err != nil {
-		return nil, err
+	err := _ReadProcessMemory(t.dbp.os.hProcess, addr, &buf[0], uintptr(len(buf)), &count)
+	if err == nil && count != uintptr(len(buf)) {
+		err = ErrShortRead
 	}
-	return buf[:count], nil
+	return int(count), err
 }

--- a/pkg/proc/threads_windows.go
+++ b/pkg/proc/threads_windows.go
@@ -103,14 +103,15 @@ func (t *Thread) resume() error {
 	return err
 }
 
-func (t *Thread) blocked() bool {
+func threadBlocked(t IThread) bool {
 	// TODO: Probably incorrect - what are the runtime functions that
 	// indicate blocking on Windows?
-	pc, err := t.PC()
+	regs, err := t.Registers(false)
 	if err != nil {
 		return false
 	}
-	fn := t.dbp.bi.goSymTable.PCToFunc(pc)
+	pc := regs.PC()
+	fn := t.BinInfo().goSymTable.PCToFunc(pc)
 	if fn == nil {
 		return false
 	}

--- a/pkg/proc/variables.go
+++ b/pkg/proc/variables.go
@@ -129,7 +129,7 @@ type G struct {
 	CurrentLoc Location
 
 	// Thread that this goroutine is currently allocated to
-	thread *Thread
+	thread IThread
 
 	variable *Variable
 }
@@ -157,8 +157,8 @@ func (scope *EvalScope) newVariable(name string, addr uintptr, dwarfType dwarf.T
 	return newVariable(name, addr, dwarfType, scope.bi, scope.Mem)
 }
 
-func (t *Thread) newVariable(name string, addr uintptr, dwarfType dwarf.Type) *Variable {
-	return newVariable(name, addr, dwarfType, t.dbp.BinInfo(), t)
+func newVariableFromThread(t IThread, name string, addr uintptr, dwarfType dwarf.Type) *Variable {
+	return newVariable(name, addr, dwarfType, t.BinInfo(), t)
 }
 
 func (v *Variable) newVariable(name string, addr uintptr, dwarfType dwarf.Type) *Variable {

--- a/pkg/target/target.go
+++ b/pkg/target/target.go
@@ -60,16 +60,12 @@ type ThreadInfo interface {
 
 // GoroutineInfo is an interface for getting information on running goroutines.
 type GoroutineInfo interface {
-	GoroutinesInfo() ([]*proc.G, error)
 	SelectedGoroutine() *proc.G
 }
 
 // ProcessManipulation is an interface for changing the execution state of a process.
 type ProcessManipulation interface {
-	Continue() error
-	Next() error
-	Step() error
-	StepOut() error
+	ContinueOnce() (trapthread proc.IThread, err error)
 	StepInstruction() error
 	SwitchThread(int) error
 	SwitchGoroutine(int) error

--- a/pkg/target/target.go
+++ b/pkg/target/target.go
@@ -90,3 +90,4 @@ type VariableEval interface {
 }
 
 var _ Interface = &proc.Process{}
+var _ Interface = &proc.CoreProcess{}

--- a/pkg/target/target.go
+++ b/pkg/target/target.go
@@ -91,3 +91,4 @@ type VariableEval interface {
 
 var _ Interface = &proc.Process{}
 var _ Interface = &proc.CoreProcess{}
+var _ Interface = &proc.GdbserverProcess{}

--- a/pkg/target/target.go
+++ b/pkg/target/target.go
@@ -13,7 +13,6 @@ type Interface interface {
 	Info
 	ProcessManipulation
 	BreakpointManipulation
-	VariableEval
 }
 
 // Info is an interface that provides general information on the target.
@@ -25,10 +24,6 @@ type Info interface {
 
 	ThreadInfo
 	GoroutineInfo
-
-	// Disassemble disassembles target memory between startPC and endPC, marking
-	// the current instruction being executed in goroutine g.
-	Disassemble(g *proc.G, startPC, endPC uint64) ([]proc.AsmInstruction, error)
 
 	// FindFileLocation returns the address of the first instruction belonging
 	// to line lineNumber in file fileName.
@@ -58,15 +53,15 @@ type Info interface {
 // ThreadInfo is an interface for getting information on active threads
 // in the process.
 type ThreadInfo interface {
-	Threads() map[int]*proc.Thread
-	CurrentThread() *proc.Thread
+	FindThread(threadID int) (proc.IThread, bool)
+	ThreadList() []proc.IThread
+	CurrentThread() proc.IThread
 }
 
 // GoroutineInfo is an interface for getting information on running goroutines.
 type GoroutineInfo interface {
 	GoroutinesInfo() ([]*proc.G, error)
 	SelectedGoroutine() *proc.G
-	FindGoroutine(int) (*proc.G, error)
 }
 
 // ProcessManipulation is an interface for changing the execution state of a process.

--- a/pkg/terminal/command_test.go
+++ b/pkg/terminal/command_test.go
@@ -1,6 +1,7 @@
 package terminal
 
 import (
+	"flag"
 	"fmt"
 	"io/ioutil"
 	"net"
@@ -16,6 +17,20 @@ import (
 	"github.com/derekparker/delve/service/rpc2"
 	"github.com/derekparker/delve/service/rpccommon"
 )
+
+var testBackend string
+
+func TestMain(m *testing.M) {
+	flag.StringVar(&testBackend, "backend", "", "selects backend")
+	flag.Parse()
+	if testBackend == "" {
+		testBackend = os.Getenv("PROCTEST")
+		if testBackend == "" {
+			testBackend = "native"
+		}
+	}
+	os.Exit(m.Run())
+}
 
 type FakeTerminal struct {
 	*Term
@@ -81,6 +96,7 @@ func withTestTerminal(name string, t testing.TB, fn func(*FakeTerminal)) {
 	server := rpccommon.NewServer(&service.Config{
 		Listener:    listener,
 		ProcessArgs: []string{test.BuildFixture(name).Path},
+		Backend:     testBackend,
 	}, false)
 	if err := server.Run(); err != nil {
 		t.Fatal(err)

--- a/service/api/conversions.go
+++ b/service/api/conversions.go
@@ -47,7 +47,7 @@ func ConvertBreakpoint(bp *proc.Breakpoint) *Breakpoint {
 
 // ConvertThread converts a proc.Thread into an
 // api thread.
-func ConvertThread(th *proc.Thread) *Thread {
+func ConvertThread(th proc.IThread) *Thread {
 	var (
 		function *Function
 		file     string
@@ -66,16 +66,16 @@ func ConvertThread(th *proc.Thread) *Thread {
 
 	var bp *Breakpoint
 
-	if th.CurrentBreakpoint != nil && th.BreakpointConditionMet {
-		bp = ConvertBreakpoint(th.CurrentBreakpoint)
+	if b, active, _ := th.Breakpoint(); active {
+		bp = ConvertBreakpoint(b)
 	}
 
-	if g, _ := th.GetG(); g != nil {
+	if g, _ := proc.GetG(th); g != nil {
 		gid = g.ID
 	}
 
 	return &Thread{
-		ID:          th.ID,
+		ID:          th.ThreadID(),
 		PC:          pc,
 		File:        file,
 		Line:        line,
@@ -204,7 +204,7 @@ func ConvertGoroutine(g *proc.G) *Goroutine {
 	th := g.Thread()
 	tid := 0
 	if th != nil {
-		tid = th.ID
+		tid = th.ThreadID()
 	}
 	return &Goroutine{
 		ID:             g.ID,

--- a/service/config.go
+++ b/service/config.go
@@ -25,4 +25,7 @@ type Config struct {
 	AcceptMulti bool
 	// APIVersion selects which version of the API to serve (default: 1).
 	APIVersion int
+
+	// CoreFile specifies the path to the core dump to open
+	CoreFile string
 }

--- a/service/config.go
+++ b/service/config.go
@@ -26,6 +26,9 @@ type Config struct {
 	// APIVersion selects which version of the API to serve (default: 1).
 	APIVersion int
 
-	// CoreFile specifies the path to the core dump to open
+	// CoreFile specifies the path to the core dump to open.
 	CoreFile string
+
+	// Selects server backend.
+	Backend string
 }

--- a/service/debugger/debugger.go
+++ b/service/debugger/debugger.go
@@ -163,10 +163,10 @@ func (d *Debugger) Detach(kill bool) error {
 }
 
 func (d *Debugger) detach(kill bool) error {
-	if d.config.AttachPid != 0 {
-		return d.target.Detach(kill)
+	if d.config.AttachPid == 0 {
+		kill = true
 	}
-	return d.target.Kill()
+	return d.target.Detach(kill)
 }
 
 // Restart will restart the target process, first killing
@@ -187,9 +187,9 @@ func (d *Debugger) Restart() ([]api.DiscardedBreakpoint, error) {
 		if err := stopProcess(d.ProcessPid()); err != nil {
 			return nil, err
 		}
-		if err := d.detach(true); err != nil {
-			return nil, err
-		}
+	}
+	if err := d.detach(true); err != nil {
+		return nil, err
 	}
 	p, err := d.Launch(d.config.ProcessArgs, d.config.WorkingDir)
 	if err != nil {
@@ -215,9 +215,8 @@ func (d *Debugger) Restart() ([]api.DiscardedBreakpoint, error) {
 			return nil, err
 		}
 	}
-	err = d.target.Detach(true)
 	d.target = p
-	return discarded, err
+	return discarded, nil
 }
 
 // State returns the current state of the debugger.

--- a/service/debugger/debugger.go
+++ b/service/debugger/debugger.go
@@ -412,7 +412,7 @@ func (d *Debugger) Command(command *api.DebuggerCommand) (*api.DebuggerState, er
 	switch command.Name {
 	case api.Continue:
 		log.Print("continuing")
-		err = d.target.Continue()
+		err = proc.Continue(d.target)
 		if err != nil {
 			if exitedErr, exited := err.(proc.ProcessExitedError); exited {
 				state := &api.DebuggerState{}
@@ -432,16 +432,16 @@ func (d *Debugger) Command(command *api.DebuggerCommand) (*api.DebuggerState, er
 
 	case api.Next:
 		log.Print("nexting")
-		err = d.target.Next()
+		err = proc.Next(d.target)
 	case api.Step:
 		log.Print("stepping")
-		err = d.target.Step()
+		err = proc.Step(d.target)
 	case api.StepInstruction:
 		log.Print("single stepping")
 		err = d.target.StepInstruction()
 	case api.StepOut:
 		log.Print("step out")
-		err = d.target.StepOut()
+		err = proc.StepOut(d.target)
 	case api.SwitchThread:
 		log.Printf("switching to thread %d", command.ThreadID)
 		err = d.target.SwitchThread(command.ThreadID)
@@ -714,7 +714,7 @@ func (d *Debugger) Goroutines() ([]*api.Goroutine, error) {
 	defer d.processMutex.Unlock()
 
 	goroutines := []*api.Goroutine{}
-	gs, err := d.target.GoroutinesInfo()
+	gs, err := proc.GoroutinesInfo(d.target)
 	if err != nil {
 		return nil, err
 	}

--- a/service/rpccommon/server.go
+++ b/service/rpccommon/server.go
@@ -114,6 +114,7 @@ func (s *ServerImpl) Run() error {
 		ProcessArgs: s.config.ProcessArgs,
 		AttachPid:   s.config.AttachPid,
 		WorkingDir:  s.config.WorkingDir,
+		CoreFile:    s.config.CoreFile,
 	}); err != nil {
 		return err
 	}

--- a/service/rpccommon/server.go
+++ b/service/rpccommon/server.go
@@ -115,6 +115,7 @@ func (s *ServerImpl) Run() error {
 		AttachPid:   s.config.AttachPid,
 		WorkingDir:  s.config.WorkingDir,
 		CoreFile:    s.config.CoreFile,
+		Backend:     s.config.Backend,
 	}); err != nil {
 		return err
 	}

--- a/service/test/integration1_test.go
+++ b/service/test/integration1_test.go
@@ -29,6 +29,7 @@ func withTestClient1(name string, t *testing.T, fn func(c *rpc1.RPCClient)) {
 	server := rpccommon.NewServer(&service.Config{
 		Listener:    listener,
 		ProcessArgs: []string{protest.BuildFixture(name).Path},
+		Backend:     testBackend,
 	}, false)
 	if err := server.Run(); err != nil {
 		t.Fatal(err)
@@ -50,6 +51,7 @@ func Test1RunWithInvalidPath(t *testing.T) {
 	server := rpccommon.NewServer(&service.Config{
 		Listener:    listener,
 		ProcessArgs: []string{"invalid_path"},
+		Backend:     testBackend,
 	}, false)
 	if err := server.Run(); err == nil {
 		t.Fatal("Expected Run to return error for invalid program path")
@@ -138,6 +140,7 @@ func Test1Restart_attachPid(t *testing.T) {
 	server := rpccommon.NewServer(&service.Config{
 		Listener:  nil,
 		AttachPid: 999,
+		Backend:   testBackend,
 	}, false)
 	if err := server.Restart(); err == nil {
 		t.Fatal("expected error on restart after attaching to pid but got none")

--- a/service/test/variables_test.go
+++ b/service/test/variables_test.go
@@ -138,7 +138,7 @@ func TestVariableEvaluation(t *testing.T) {
 	}
 
 	withTestProcess("testvariables", t, func(p *proc.Process, fixture protest.Fixture) {
-		err := p.Continue()
+		err := proc.Continue(p)
 		assertNoError(err, t, "Continue() returned an error")
 
 		for _, tc := range testcases {
@@ -216,7 +216,7 @@ func TestVariableEvaluationShort(t *testing.T) {
 	}
 
 	withTestProcess("testvariables", t, func(p *proc.Process, fixture protest.Fixture) {
-		err := p.Continue()
+		err := proc.Continue(p)
 		assertNoError(err, t, "Continue() returned an error")
 
 		for _, tc := range testcases {
@@ -271,7 +271,7 @@ func TestMultilineVariableEvaluation(t *testing.T) {
 	}
 
 	withTestProcess("testvariables", t, func(p *proc.Process, fixture protest.Fixture) {
-		err := p.Continue()
+		err := proc.Continue(p)
 		assertNoError(err, t, "Continue() returned an error")
 
 		for _, tc := range testcases {
@@ -344,7 +344,7 @@ func TestLocalVariables(t *testing.T) {
 	}
 
 	withTestProcess("testvariables", t, func(p *proc.Process, fixture protest.Fixture) {
-		err := p.Continue()
+		err := proc.Continue(p)
 		assertNoError(err, t, "Continue() returned an error")
 
 		for _, tc := range testcases {
@@ -377,7 +377,7 @@ func TestEmbeddedStruct(t *testing.T) {
 			{"b.s", true, "\"hello\"", "\"hello\"", "string", nil},
 			{"b2", true, "main.B {main.A: main.A {val: 42}, *main.C: *main.C nil, a: main.A {val: 47}, ptr: *main.A nil}", "main.B {main.A: (*main.A)(0x…", "main.B", nil},
 		}
-		assertNoError(p.Continue(), t, "Continue()")
+		assertNoError(proc.Continue(p), t, "Continue()")
 
 		for _, tc := range testcases {
 			variable, err := evalVariable(p, tc.name, pnormalLoadConfig)
@@ -398,7 +398,7 @@ func TestEmbeddedStruct(t *testing.T) {
 
 func TestComplexSetting(t *testing.T) {
 	withTestProcess("testvariables", t, func(p *proc.Process, fixture protest.Fixture) {
-		err := p.Continue()
+		err := proc.Continue(p)
 		assertNoError(err, t, "Continue() returned an error")
 
 		h := func(setExpr, value string) {
@@ -644,7 +644,7 @@ func TestEvalExpression(t *testing.T) {
 	}
 
 	withTestProcess("testvariables2", t, func(p *proc.Process, fixture protest.Fixture) {
-		assertNoError(p.Continue(), t, "Continue() returned an error")
+		assertNoError(proc.Continue(p), t, "Continue() returned an error")
 		for _, tc := range testcases {
 			variable, err := evalVariable(p, tc.name, pnormalLoadConfig)
 			if tc.err == nil {
@@ -668,7 +668,7 @@ func TestEvalExpression(t *testing.T) {
 
 func TestEvalAddrAndCast(t *testing.T) {
 	withTestProcess("testvariables2", t, func(p *proc.Process, fixture protest.Fixture) {
-		assertNoError(p.Continue(), t, "Continue() returned an error")
+		assertNoError(proc.Continue(p), t, "Continue() returned an error")
 		c1addr, err := evalVariable(p, "&c1", pnormalLoadConfig)
 		assertNoError(err, t, "EvalExpression(&c1)")
 		c1addrstr := api.ConvertVar(c1addr).SinglelineString()
@@ -694,7 +694,7 @@ func TestEvalAddrAndCast(t *testing.T) {
 
 func TestMapEvaluation(t *testing.T) {
 	withTestProcess("testvariables2", t, func(p *proc.Process, fixture protest.Fixture) {
-		assertNoError(p.Continue(), t, "Continue() returned an error")
+		assertNoError(proc.Continue(p), t, "Continue() returned an error")
 		m1v, err := evalVariable(p, "m1", pnormalLoadConfig)
 		assertNoError(err, t, "EvalVariable()")
 		m1 := api.ConvertVar(m1v)
@@ -728,7 +728,7 @@ func TestMapEvaluation(t *testing.T) {
 
 func TestUnsafePointer(t *testing.T) {
 	withTestProcess("testvariables2", t, func(p *proc.Process, fixture protest.Fixture) {
-		assertNoError(p.Continue(), t, "Continue() returned an error")
+		assertNoError(proc.Continue(p), t, "Continue() returned an error")
 		up1v, err := evalVariable(p, "up1", pnormalLoadConfig)
 		assertNoError(err, t, "EvalVariable(up1)")
 		up1 := api.ConvertVar(up1v)
@@ -765,7 +765,7 @@ func TestIssue426(t *testing.T) {
 	// Serialization of type expressions (go/ast.Expr) containing anonymous structs or interfaces
 	// differs from the serialization used by the linker to produce DWARF type information
 	withTestProcess("testvariables2", t, func(p *proc.Process, fixture protest.Fixture) {
-		assertNoError(p.Continue(), t, "Continue() returned an error")
+		assertNoError(proc.Continue(p), t, "Continue() returned an error")
 		for _, testcase := range testcases {
 			v, err := evalVariable(p, testcase.name, pnormalLoadConfig)
 			assertNoError(err, t, fmt.Sprintf("EvalVariable(%s)", testcase.name))
@@ -816,7 +816,7 @@ func TestPackageRenames(t *testing.T) {
 	}
 
 	withTestProcess("pkgrenames", t, func(p *proc.Process, fixture protest.Fixture) {
-		assertNoError(p.Continue(), t, "Continue() returned an error")
+		assertNoError(proc.Continue(p), t, "Continue() returned an error")
 		for _, tc := range testcases {
 			variable, err := evalVariable(p, tc.name, pnormalLoadConfig)
 			if tc.err == nil {

--- a/service/test/variables_test.go
+++ b/service/test/variables_test.go
@@ -54,7 +54,7 @@ func assertVariable(t *testing.T, variable *proc.Variable, expected varTest) {
 }
 
 func evalVariable(p *proc.Process, symbol string, cfg proc.LoadConfig) (*proc.Variable, error) {
-	scope, err := p.CurrentThread().GoroutineScope()
+	scope, err := proc.GoroutineScope(p.CurrentThread())
 	if err != nil {
 		return nil, err
 	}
@@ -68,7 +68,7 @@ func (tc *varTest) alternateVarTest() varTest {
 }
 
 func setVariable(p *proc.Process, symbol, value string) error {
-	scope, err := p.CurrentThread().GoroutineScope()
+	scope, err := proc.GoroutineScope(p.CurrentThread())
 	if err != nil {
 		return err
 	}
@@ -348,7 +348,7 @@ func TestLocalVariables(t *testing.T) {
 		assertNoError(err, t, "Continue() returned an error")
 
 		for _, tc := range testcases {
-			scope, err := p.CurrentThread().GoroutineScope()
+			scope, err := proc.GoroutineScope(p.CurrentThread())
 			assertNoError(err, t, "AsScope()")
 			vars, err := tc.fn(scope, pnormalLoadConfig)
 			assertNoError(err, t, "LocalVariables() returned an error")


### PR DESCRIPTION
This is a continuation of the refactoring work I started in #745 progressing it to the point where it's actually possible to write multiple implementations of `target.Interface`.

To help me with the refactoring I also produced two new implementations of `target.Interface`:

1. `proc.CoreProcess` properly integrates the changes in #726
2. `proc.GdbserverProcesss` provides an implementation of `target.Interface` using an instance of `lldb-server` or `debugserver` as backend. I've written a longer explanation of how this work in a comment at the top of gdbserver.go.

I've also changed `dlv` to use `proc.GdbserverProcess` by default on macOS since there it's more reliable, as you can see this is the first time we get a green checkmark on macOS in a long while.
This also makes delve go gettable on macOS.

I don't consider the refactoring work finished with this, IMHO `proc` should be split to separate each backend into its own package, we would therefore have:

- `proc/native` for our old native `target.Interface` implementation
- `proc/core` for CoreProcess
- `proc/gdbserver` for GdbserverProcess
- `proc/test` for `proc_test.go` (because of cyclic imports)
- `proc` for all the stuff common to all backends (stacktraces, disassembly, Continue/Next/Step logic, etc.)

I haven't done this now because reviewing this will take a long time and splitting proc would be to disruptive.

I think the individual commits in this branch should be reviewed one by one, separately, I just posted this as a whole so that we can have a general idea of where we go.