### PR TITLE
service/test: change test package name to service_test

### DIFF
--- a/service/test/common_test.go
+++ b/service/test/common_test.go
@@ -1,4 +1,4 @@
-package servicetest
+package service_test
 
 import (
 	"fmt"

--- a/service/test/integration1_test.go
+++ b/service/test/integration1_test.go
@@ -1,4 +1,4 @@
-package servicetest
+package service_test
 
 import (
 	"fmt"

--- a/service/test/integration2_test.go
+++ b/service/test/integration2_test.go
@@ -1,4 +1,4 @@
-package servicetest
+package service_test
 
 import (
 	"flag"

--- a/service/test/variables_test.go
+++ b/service/test/variables_test.go
@@ -1,4 +1,4 @@
-package servicetest
+package service_test
 
 import (
 	"fmt"
@@ -8,8 +8,8 @@ import (
 	"testing"
 
 	"github.com/derekparker/delve/pkg/proc"
-	"github.com/derekparker/delve/service/api"
 	"github.com/derekparker/delve/pkg/target"
+	"github.com/derekparker/delve/service/api"
 
 	protest "github.com/derekparker/delve/pkg/proc/test"
 )


### PR DESCRIPTION
According to https://golang.org/cmd/go/#hdr-Test_packages
service_test is more appropriate because this directory contains
no non-test code and the intention is to compile these *_test.go
files as a separate package and link/run with the main test package.