### PR TITLE
terminal: bugfix: tolerate spurious spaces after command prefixes

### DIFF
--- a/cmd/dlv/cmds/commands.go
+++ b/cmd/dlv/cmds/commands.go
@@ -333,7 +333,7 @@ func traceCmd(cmd *cobra.Command, args []string) {
 		cmds := terminal.DebugCommands(client)
 		t := terminal.New(client, nil)
 		defer t.Close()
-		err = cmds.Call("continue", "", t)
+		err = cmds.Call("continue", t)
 		if err != nil {
 			fmt.Fprintln(os.Stderr, err)
 			return 1

--- a/pkg/terminal/command_test.go
+++ b/pkg/terminal/command_test.go
@@ -38,8 +38,6 @@ type FakeTerminal struct {
 }
 
 func (ft *FakeTerminal) Exec(cmdstr string) (outstr string, err error) {
-	cmdstr, args := parseCommand(cmdstr)
-
 	outfh, err := ioutil.TempFile("", "cmdtestout")
 	if err != nil {
 		ft.t.Fatalf("could not create temporary file: %v", err)
@@ -57,7 +55,7 @@ func (ft *FakeTerminal) Exec(cmdstr string) (outstr string, err error) {
 		outstr = string(outbs)
 		os.Remove(outfh.Name())
 	}()
-	err = ft.cmds.Call(cmdstr, args, ft.Term)
+	err = ft.cmds.Call(cmdstr, ft.Term)
 	return
 }
 
@@ -305,7 +303,7 @@ func TestScopePrefix(t *testing.T) {
 			if fid < 0 {
 				t.Fatalf("Could not find frame for goroutine %d: %v", gid, stackOut)
 			}
-			term.AssertExec(fmt.Sprintf("goroutine %d frame %d locals", gid, fid), "(no locals)\n")
+			term.AssertExec(fmt.Sprintf("goroutine     %d    frame     %d     locals", gid, fid), "(no locals)\n")
 			argsOut := strings.Split(term.MustExec(fmt.Sprintf("goroutine %d frame %d args", gid, fid)), "\n")
 			if len(argsOut) != 4 || argsOut[3] != "" {
 				t.Fatalf("Wrong number of arguments in goroutine %d frame %d: %v", gid, fid, argsOut)

--- a/pkg/terminal/terminal.go
+++ b/pkg/terminal/terminal.go
@@ -128,8 +128,7 @@ func (t *Term) Run() (int, error) {
 			return 1, fmt.Errorf("Prompt for input failed.\n")
 		}
 
-		cmdstr, args := parseCommand(strings.TrimSpace(cmdstr))
-		if err := t.cmds.Call(cmdstr, args, t); err != nil {
+		if err := t.cmds.Call(cmdstr, t); err != nil {
 			if _, ok := err.(ExitRequestError); ok {
 				return t.handleExit()
 			}
@@ -240,12 +239,4 @@ func (t *Term) handleExit() (int, error) {
 		}
 	}
 	return 0, nil
-}
-
-func parseCommand(cmdstr string) (string, string) {
-	vals := strings.SplitN(cmdstr, " ", 2)
-	if len(vals) == 1 {
-		return vals[0], ""
-	}
-	return vals[0], strings.TrimSpace(vals[1])
 }


### PR DESCRIPTION
```
terminal: bugfix: tolerate spurious spaces after command prefixes

Expressions such as:

frame 0    list
frame   0   list
on abreakpoint     print x
goroutine    1    frame     0     list

should all execute correctly

Fixes #712

```
