### PR TITLE
proc: fix build on go1.6

### DIFF
--- a/pkg/proc/core/linux_amd64_core.go
+++ b/pkg/proc/core/linux_amd64_core.go
@@ -437,14 +437,14 @@ func readNote(r io.ReadSeeker) (*Note, error) {
 
 // skipPadding moves r to the next multiple of pad.
 func skipPadding(r io.ReadSeeker, pad int64) error {
-	pos, err := r.Seek(0, io.SeekCurrent)
+	pos, err := r.Seek(0, os.SEEK_CUR)
 	if err != nil {
 		return err
 	}
 	if pos%pad == 0 {
 		return nil
 	}
-	if _, err := r.Seek(pad-(pos%pad), io.SeekCurrent); err != nil {
+	if _, err := r.Seek(pad-(pos%pad), os.SEEK_CUR); err != nil {
 		return err
 	}
 	return nil


### PR DESCRIPTION
```
proc: fix build on go1.6

Fixes #799

```
