### PR TITLE
makefile: use git's $Id$ instead of setting ver.Build in makefile

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+pkg/version/version.go ident

--- a/Makefile
+++ b/Makefile
@@ -2,13 +2,10 @@
 UNAME=$(shell uname)
 PREFIX=github.com/derekparker/delve
 GOVERSION=$(shell go version)
-BUILD_SHA=$(shell git rev-parse HEAD)
 LLDB_SERVER=$(shell which lldb-server)
 
 ifeq "$(UNAME)" "Darwin"
-    BUILD_FLAGS=-ldflags="-s -X main.Build=$(BUILD_SHA)"
-else
-    BUILD_FLAGS=-ldflags="-X main.Build=$(BUILD_SHA)"
+    BUILD_FLAGS=-ldflags="-s"
 endif
 
 # Workaround for GO15VENDOREXPERIMENT bug (https://github.com/golang/go/issues/11659)

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -13,7 +13,10 @@ type Version struct {
 
 var (
 	// DelveVersion is the current version of Delve.
-	DelveVersion = Version{Major: "0", Minor: "12", Patch: "2", Metadata: ""}
+	DelveVersion = Version{
+		Major: "0", Minor: "12", Patch: "2", Metadata: "",
+		Build: "$Id$",
+	}
 )
 
 func (v Version) String() string {


### PR DESCRIPTION
```
makefile: use git's $Id$ instead of setting ver.Build in makefile

```
