### PR TITLE
Minor post-refactoring cleanup

### DIFF
--- a/pkg/proc/core/core.go
+++ b/pkg/proc/core/core.go
@@ -1,7 +1,6 @@
 package core
 
 import (
-	"debug/gosym"
 	"errors"
 	"fmt"
 	"go/ast"
@@ -275,18 +274,6 @@ func (p *Process) Detach(bool) error {
 
 func (p *Process) Exited() bool {
 	return false
-}
-
-func (p *Process) FindFileLocation(fileName string, lineNumber int) (uint64, error) {
-	return proc.FindFileLocation(p.CurrentThread(), p.breakpoints, &p.bi, fileName, lineNumber)
-}
-
-func (p *Process) FirstPCAfterPrologue(fn *gosym.Func, sameline bool) (uint64, error) {
-	return proc.FirstPCAfterPrologue(p.CurrentThread(), p.breakpoints, &p.bi, fn, sameline)
-}
-
-func (p *Process) FindFunctionLocation(funcName string, firstLine bool, lineOffset int) (uint64, error) {
-	return proc.FindFunctionLocation(p.CurrentThread(), p.breakpoints, &p.bi, funcName, firstLine, lineOffset)
 }
 
 func (p *Process) AllGCache() *[]*proc.G {

--- a/pkg/proc/disasm_amd64.go
+++ b/pkg/proc/disasm_amd64.go
@@ -142,7 +142,10 @@ func init() {
 
 // FirstPCAfterPrologue returns the address of the first instruction after the prologue for function fn
 // If sameline is set FirstPCAfterPrologue will always return an address associated with the same line as fn.Entry
-func FirstPCAfterPrologue(mem MemoryReadWriter, breakpoints map[uint64]*Breakpoint, bi *BinaryInfo, fn *gosym.Func, sameline bool) (uint64, error) {
+func FirstPCAfterPrologue(p Process, fn *gosym.Func, sameline bool) (uint64, error) {
+	var mem MemoryReadWriter = p.CurrentThread()
+	breakpoints := p.Breakpoints()
+	bi := p.BinInfo()
 	text, err := disassemble(mem, nil, breakpoints, bi, fn.Entry, fn.End)
 	if err != nil {
 		return fn.Entry, err

--- a/pkg/proc/gdbserial/gdbserver.go
+++ b/pkg/proc/gdbserial/gdbserver.go
@@ -62,7 +62,6 @@
 package gdbserial
 
 import (
-	"debug/gosym"
 	"encoding/binary"
 	"errors"
 	"fmt"
@@ -259,7 +258,7 @@ func Connect(addr string, path string, pid int, attempts int) (*Process, error) 
 	p.bi.Arch.SetGStructOffset(ver, isextld)
 	p.selectedGoroutine, _ = proc.GetG(p.CurrentThread())
 
-	panicpc, err := p.FindFunctionLocation("runtime.startpanic", true, 0)
+	panicpc, err := proc.FindFunctionLocation(p, "runtime.startpanic", true, 0)
 	if err == nil {
 		bp, err := p.SetBreakpoint(panicpc, proc.UserBreakpoint, nil)
 		if err == nil {
@@ -415,18 +414,6 @@ func (p *Process) Exited() bool {
 
 func (p *Process) Running() bool {
 	return p.conn.running
-}
-
-func (p *Process) FindFileLocation(fileName string, lineNumber int) (uint64, error) {
-	return proc.FindFileLocation(p.CurrentThread(), p.breakpoints, &p.bi, fileName, lineNumber)
-}
-
-func (p *Process) FirstPCAfterPrologue(fn *gosym.Func, sameline bool) (uint64, error) {
-	return proc.FirstPCAfterPrologue(p.CurrentThread(), p.breakpoints, &p.bi, fn, sameline)
-}
-
-func (p *Process) FindFunctionLocation(funcName string, firstLine bool, lineOffset int) (uint64, error) {
-	return proc.FindFunctionLocation(p.CurrentThread(), p.breakpoints, &p.bi, funcName, firstLine, lineOffset)
 }
 
 func (p *Process) FindThread(threadID int) (proc.Thread, bool) {

--- a/pkg/proc/interface.go
+++ b/pkg/proc/interface.go
@@ -1,7 +1,6 @@
 package proc
 
 import (
-	"debug/gosym"
 	"go/ast"
 )
 
@@ -22,30 +21,6 @@ type Info interface {
 
 	ThreadInfo
 	GoroutineInfo
-
-	// FindFileLocation returns the address of the first instruction belonging
-	// to line lineNumber in file fileName.
-	FindFileLocation(fileName string, lineNumber int) (uint64, error)
-
-	// FirstPCAfterPrologue returns the first instruction address after fn's
-	// prologue.
-	// If sameline is true and the first instruction after the prologue belongs
-	// to a different source line the entry point will be returned instead.
-	FirstPCAfterPrologue(fn *gosym.Func, sameline bool) (uint64, error)
-
-	// FindFunctionLocation finds address of a function's line
-	//
-	// If firstLine == true is passed FindFunctionLocation will attempt to find
-	// the first line of the function.
-	//
-	// If lineOffset is passed FindFunctionLocation will return the address of
-	// that line.
-	//
-	// Pass lineOffset == 0 and firstLine == false if you want the address for
-	// the function's entry point. Note that setting breakpoints at that
-	// address will cause surprising behavior:
-	// https://github.com/derekparker/delve/issues/170
-	FindFunctionLocation(funcName string, firstLine bool, lineOffset int) (uint64, error)
 }
 
 // ThreadInfo is an interface for getting information on active threads

--- a/pkg/proc/native/proc.go
+++ b/pkg/proc/native/proc.go
@@ -177,11 +177,6 @@ func (dbp *Process) FirstPCAfterPrologue(fn *gosym.Func, sameline bool) (uint64,
 	return proc.FirstPCAfterPrologue(dbp.currentThread, dbp.breakpoints, &dbp.bi, fn, sameline)
 }
 
-// CurrentLocation returns the location of the current thread.
-func (dbp *Process) CurrentLocation() (*proc.Location, error) {
-	return dbp.currentThread.Location()
-}
-
 // RequestManualStop sets the `halt` flag and
 // sends SIGSTOP to all threads.
 func (dbp *Process) RequestManualStop() error {
@@ -257,11 +252,6 @@ func (dbp *Process) ClearBreakpoint(addr uint64) (*proc.Breakpoint, error) {
 	delete(dbp.breakpoints, addr)
 
 	return bp, nil
-}
-
-// Status returns the status of the current main thread context.
-func (dbp *Process) Status() *WaitStatus {
-	return dbp.currentThread.Status
 }
 
 func (dbp *Process) ContinueOnce() (proc.Thread, error) {
@@ -363,33 +353,6 @@ func (dbp *Process) Halt() (err error) {
 		}
 	}
 	return nil
-}
-
-// Registers obtains register values from the
-// "current" thread of the traced process.
-func (dbp *Process) Registers() (proc.Registers, error) {
-	return dbp.currentThread.Registers(false)
-}
-
-// PC returns the PC of the current thread.
-func (dbp *Process) PC() (uint64, error) {
-	return dbp.currentThread.PC()
-}
-
-// CurrentBreakpoint returns the breakpoint the current thread
-// is stopped at.
-func (dbp *Process) CurrentBreakpoint() *proc.Breakpoint {
-	return dbp.currentThread.CurrentBreakpoint
-}
-
-// FindBreakpointByID finds the breakpoint for the given ID.
-func (dbp *Process) FindBreakpointByID(id int) (*proc.Breakpoint, bool) {
-	for _, bp := range dbp.breakpoints {
-		if bp.ID == id {
-			return bp, true
-		}
-	}
-	return nil, false
 }
 
 // FindBreakpoint finds the breakpoint for the given pc.
@@ -507,19 +470,3 @@ func (dbp *Process) writeSoftwareBreakpoint(thread *Thread, addr uint64) error {
 func (dbp *Process) AllGCache() *[]*proc.G {
 	return &dbp.allGCache
 }
-
-/*
-
-// EvalPackageVariable will evaluate the package level variable
-// specified by 'name'.
-func (dbp *Process) EvalPackageVariable(name string, cfg proc.LoadConfig) (*proc.Variable, error) {
-	scope := &proc.EvalScope{0, 0, dbp.currentThread, nil, dbp.BinInfo()}
-
-	v, err := scope.packageVarAddr(name)
-	if err != nil {
-		return nil, err
-	}
-	v.loadValue(cfg)
-	return v, nil
-}
-*/

--- a/pkg/proc/native/proc.go
+++ b/pkg/proc/native/proc.go
@@ -1,7 +1,6 @@
 package native
 
 import (
-	"debug/gosym"
 	"errors"
 	"fmt"
 	"go/ast"
@@ -163,18 +162,6 @@ func (dbp *Process) LoadInformation(path string) error {
 	wg.Wait()
 
 	return nil
-}
-
-func (dbp *Process) FindFunctionLocation(funcName string, firstLine bool, lineOffset int) (uint64, error) {
-	return proc.FindFunctionLocation(dbp.currentThread, dbp.breakpoints, &dbp.bi, funcName, firstLine, lineOffset)
-}
-
-func (dbp *Process) FindFileLocation(fileName string, lineno int) (uint64, error) {
-	return proc.FindFileLocation(dbp.currentThread, dbp.breakpoints, &dbp.bi, fileName, lineno)
-}
-
-func (dbp *Process) FirstPCAfterPrologue(fn *gosym.Func, sameline bool) (uint64, error) {
-	return proc.FirstPCAfterPrologue(dbp.currentThread, dbp.breakpoints, &dbp.bi, fn, sameline)
 }
 
 // RequestManualStop sets the `halt` flag and
@@ -409,7 +396,7 @@ func initializeDebugProcess(dbp *Process, path string, attach bool) (*Process, e
 	// the offset of g struct inside TLS
 	dbp.selectedGoroutine, _ = proc.GetG(dbp.currentThread)
 
-	panicpc, err := dbp.FindFunctionLocation("runtime.startpanic", true, 0)
+	panicpc, err := proc.FindFunctionLocation(dbp, "runtime.startpanic", true, 0)
 	if err == nil {
 		bp, err := dbp.SetBreakpoint(panicpc, proc.UserBreakpoint, nil)
 		if err == nil {

--- a/pkg/proc/native/threads.go
+++ b/pkg/proc/native/threads.go
@@ -189,7 +189,6 @@ func (t *Thread) Registers(floatingPoint bool) (proc.Registers, error) {
 	return registers(t, floatingPoint)
 }
 
-// PC returns the current PC for this thread.
 func (t *Thread) PC() (uint64, error) {
 	regs, err := t.Registers(false)
 	if err != nil {

--- a/pkg/proc/threads.go
+++ b/pkg/proc/threads.go
@@ -158,7 +158,7 @@ func next(dbp Process, stepInto bool) error {
 			if deferPCEntry != 0 {
 				_, _, deferfn := dbp.BinInfo().PCToLine(deferPCEntry)
 				var err error
-				deferpc, err = dbp.FirstPCAfterPrologue(deferfn, false)
+				deferpc, err = FirstPCAfterPrologue(dbp, deferfn, false)
 				if err != nil {
 					return err
 				}
@@ -236,7 +236,7 @@ func setStepIntoBreakpoint(dbp Process, text []AsmInstruction, cond ast.Expr) er
 	// those extra checks should be done here.
 
 	// Set a breakpoint after the function's prologue
-	pc, _ := dbp.FirstPCAfterPrologue(fn, false)
+	pc, _ := FirstPCAfterPrologue(dbp, fn, false)
 	if _, err := dbp.SetBreakpoint(pc, NextBreakpoint, cond); err != nil {
 		if _, ok := err.(BreakpointExistsError); !ok {
 			return err

--- a/service/debugger/debugger.go
+++ b/service/debugger/debugger.go
@@ -203,7 +203,7 @@ func (d *Debugger) Restart() ([]api.DiscardedBreakpoint, error) {
 			continue
 		}
 		if len(oldBp.File) > 0 {
-			oldBp.Addr, err = p.FindFileLocation(oldBp.File, oldBp.Line)
+			oldBp.Addr, err = proc.FindFileLocation(p, oldBp.File, oldBp.Line)
 			if err != nil {
 				discarded = append(discarded, api.DiscardedBreakpoint{oldBp, err.Error()})
 				continue
@@ -298,12 +298,12 @@ func (d *Debugger) CreateBreakpoint(requestedBp *api.Breakpoint) (*api.Breakpoin
 				}
 			}
 		}
-		addr, err = d.target.FindFileLocation(fileName, requestedBp.Line)
+		addr, err = proc.FindFileLocation(d.target, fileName, requestedBp.Line)
 	case len(requestedBp.FunctionName) > 0:
 		if requestedBp.Line >= 0 {
-			addr, err = d.target.FindFunctionLocation(requestedBp.FunctionName, false, requestedBp.Line)
+			addr, err = proc.FindFunctionLocation(d.target, requestedBp.FunctionName, false, requestedBp.Line)
 		} else {
-			addr, err = d.target.FindFunctionLocation(requestedBp.FunctionName, true, 0)
+			addr, err = proc.FindFunctionLocation(d.target, requestedBp.FunctionName, true, 0)
 		}
 	default:
 		addr = requestedBp.Addr

--- a/service/debugger/locations.go
+++ b/service/debugger/locations.go
@@ -250,7 +250,7 @@ func (loc *RegexLocationSpec) Find(d *Debugger, scope *proc.EvalScope, locStr st
 	}
 	r := make([]api.Location, 0, len(matches))
 	for i := range matches {
-		addr, err := d.target.FindFunctionLocation(matches[i], true, 0)
+		addr, err := proc.FindFunctionLocation(d.target, matches[i], true, 0)
 		if err == nil {
 			r = append(r, api.Location{PC: addr})
 		}
@@ -279,7 +279,7 @@ func (loc *AddrLocationSpec) Find(d *Debugger, scope *proc.EvalScope, locStr str
 			return []api.Location{{PC: addr}}, nil
 		case reflect.Func:
 			_, _, fn := d.target.BinInfo().PCToLine(uint64(v.Base))
-			pc, err := d.target.FirstPCAfterPrologue(fn, false)
+			pc, err := proc.FirstPCAfterPrologue(d.target, fn, false)
 			if err != nil {
 				return nil, err
 			}
@@ -366,12 +366,12 @@ func (loc *NormalLocationSpec) Find(d *Debugger, scope *proc.EvalScope, locStr s
 			if loc.LineOffset < 0 {
 				return nil, fmt.Errorf("Malformed breakpoint location, no line offset specified")
 			}
-			addr, err = d.target.FindFileLocation(candidates[0], loc.LineOffset)
+			addr, err = proc.FindFileLocation(d.target, candidates[0], loc.LineOffset)
 		} else {
 			if loc.LineOffset < 0 {
-				addr, err = d.target.FindFunctionLocation(candidates[0], true, 0)
+				addr, err = proc.FindFunctionLocation(d.target, candidates[0], true, 0)
 			} else {
-				addr, err = d.target.FindFunctionLocation(candidates[0], false, loc.LineOffset)
+				addr, err = proc.FindFunctionLocation(d.target, candidates[0], false, loc.LineOffset)
 			}
 		}
 		if err != nil {
@@ -394,7 +394,7 @@ func (loc *OffsetLocationSpec) Find(d *Debugger, scope *proc.EvalScope, locStr s
 	if fn == nil {
 		return nil, fmt.Errorf("could not determine current location")
 	}
-	addr, err := d.target.FindFileLocation(file, line+loc.Offset)
+	addr, err := proc.FindFileLocation(d.target, file, line+loc.Offset)
 	return []api.Location{{PC: addr}}, err
 }
 
@@ -406,6 +406,6 @@ func (loc *LineLocationSpec) Find(d *Debugger, scope *proc.EvalScope, locStr str
 	if fn == nil {
 		return nil, fmt.Errorf("could not determine current location")
 	}
-	addr, err := d.target.FindFileLocation(file, loc.Line)
+	addr, err := proc.FindFileLocation(d.target, file, loc.Line)
 	return []api.Location{{PC: addr}}, err
 }


### PR DESCRIPTION
```
proc: turn FindFileLocation, FindFunctionLocation, FirstPCAfterPrologue methods into function

proc/native: remove unused utility methods

```
