### PR TITLE
proc/native: error when reading/writing memory of exited process

### DIFF
--- a/pkg/proc/gdbserial/gdbserver.go
+++ b/pkg/proc/gdbserial/gdbserver.go
@@ -554,6 +554,9 @@ func (p *Process) StepInstruction() error {
 }
 
 func (p *Process) SwitchThread(tid int) error {
+	if p.exited {
+		return proc.ProcessExitedError{Pid: p.conn.pid}
+	}
 	if th, ok := p.threads[tid]; ok {
 		p.currentThread = th
 		p.selectedGoroutine, _ = proc.GetG(p.CurrentThread())

--- a/pkg/proc/native/threads_darwin.go
+++ b/pkg/proc/native/threads_darwin.go
@@ -8,6 +8,8 @@ import (
 	"unsafe"
 
 	sys "golang.org/x/sys/unix"
+
+	"github.com/derekparker/delve/pkg/proc"
 )
 
 // WaitStatus is a synonym for the platform-specific WaitStatus
@@ -105,6 +107,9 @@ func (t *Thread) stopped() bool {
 }
 
 func (t *Thread) WriteMemory(addr uintptr, data []byte) (int, error) {
+	if t.dbp.exited {
+		return 0, proc.ProcessExitedError{Pid: t.dbp.pid}
+	}
 	if len(data) == 0 {
 		return 0, nil
 	}
@@ -120,6 +125,9 @@ func (t *Thread) WriteMemory(addr uintptr, data []byte) (int, error) {
 }
 
 func (t *Thread) ReadMemory(buf []byte, addr uintptr) (int, error) {
+	if t.dbp.exited {
+		return 0, proc.ProcessExitedError{Pid: t.dbp.pid}
+	}
 	if len(buf) == 0 {
 		return 0, nil
 	}

--- a/pkg/proc/native/threads_linux.go
+++ b/pkg/proc/native/threads_linux.go
@@ -97,6 +97,9 @@ func (t *Thread) restoreRegisters() (err error) {
 }
 
 func (t *Thread) WriteMemory(addr uintptr, data []byte) (written int, err error) {
+	if t.dbp.exited {
+		return 0, proc.ProcessExitedError{Pid: t.dbp.pid}
+	}
 	if len(data) == 0 {
 		return
 	}
@@ -105,6 +108,9 @@ func (t *Thread) WriteMemory(addr uintptr, data []byte) (written int, err error)
 }
 
 func (t *Thread) ReadMemory(data []byte, addr uintptr) (n int, err error) {
+	if t.dbp.exited {
+		return 0, proc.ProcessExitedError{Pid: t.dbp.pid}
+	}
 	if len(data) == 0 {
 		return
 	}

--- a/pkg/proc/native/threads_windows.go
+++ b/pkg/proc/native/threads_windows.go
@@ -133,6 +133,9 @@ func (t *Thread) stopped() bool {
 }
 
 func (t *Thread) WriteMemory(addr uintptr, data []byte) (int, error) {
+	if t.dbp.exited {
+		return 0, proc.ProcessExitedError{Pid: t.dbp.pid}
+	}
 	var count uintptr
 	err := _WriteProcessMemory(t.dbp.os.hProcess, addr, &data[0], uintptr(len(data)), &count)
 	if err != nil {
@@ -144,6 +147,9 @@ func (t *Thread) WriteMemory(addr uintptr, data []byte) (int, error) {
 var ErrShortRead = errors.New("short read")
 
 func (t *Thread) ReadMemory(buf []byte, addr uintptr) (int, error) {
+	if t.dbp.exited {
+		return 0, proc.ProcessExitedError{Pid: t.dbp.pid}
+	}
 	if len(buf) == 0 {
 		return 0, nil
 	}

--- a/service/test/common_test.go
+++ b/service/test/common_test.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"path/filepath"
 	"runtime"
+	"strings"
 	"testing"
 
 	"github.com/derekparker/delve/service/api"
@@ -23,6 +24,12 @@ func assertError(err error, t *testing.T, s string) {
 		_, file, line, _ := runtime.Caller(1)
 		fname := filepath.Base(file)
 		t.Fatalf("failed assertion at %s:%d: %s (no error)\n", fname, line, s)
+	}
+
+	if strings.Index(err.Error(), "Internal debugger error") >= 0 {
+		_, file, line, _ := runtime.Caller(1)
+		fname := filepath.Base(file)
+		t.Fatalf("failed assertion at %s:%d: %s internal debugger error: %v\n", fname, line, s, err)
 	}
 }
 


### PR DESCRIPTION
```
proc/native: error when reading/writing memory of exited process

Fixes #809

```
