### PR TITLE
Add instructions to clone delve in case of error

### DIFF
--- a/Documentation/installation/windows/install.md
+++ b/Documentation/installation/windows/install.md
@@ -7,3 +7,9 @@ go get github.com/derekparker/delve/cmd/dlv
 ```
 
 Note: If you are using Go 1.5 you must set `GO15VENDOREXPERIMENT=1` before continuing. The `GO15VENDOREXPERIMENT` env var simply opts into the [Go 1.5 Vendor Experiment](https://docs.google.com/document/d/1Bz5-UB7g2uPBdOx-rw5t9MxJwkfpx90cqG9AFL0JAYo/).
+
+If you encounter an error saying "Not a git repository", clone delve first to the /src/github.com/dererkparker/delve directory.
+
+```
+git clone https://github.com/derekparker/delve.git
+```


### PR DESCRIPTION
Not sure if `go get` should be doing this clone automatically, but here's a workaround if it fails to clone delve.