### PR TITLE
proc/gdbserial: pass environment variables to target

### DIFF
--- a/_fixtures/testenv.go
+++ b/_fixtures/testenv.go
@@ -1,0 +1,13 @@
+package main
+
+import (
+	"fmt"
+	"os"
+	"runtime"
+)
+
+func main() {
+	x := os.Getenv("SOMEVAR")
+	runtime.Breakpoint()
+	fmt.Printf("SOMEVAR=%s\n", x)
+}

--- a/pkg/proc/gdbserial/gdbserver.go
+++ b/pkg/proc/gdbserial/gdbserver.go
@@ -306,8 +306,8 @@ func LLDBLaunch(cmd []string, wd string) (*Process, error) {
 
 	var proc *exec.Cmd
 	if _, err := os.Stat(debugserverExecutable); err == nil {
-		args := make([]string, 0, len(cmd)+1)
-		args = append(args, "127.0.0.1"+port)
+		args := make([]string, 0, len(cmd)+2)
+		args = append(args, "-F", "127.0.0.1"+port)
 		args = append(args, cmd...)
 
 		isDebugserver = true

--- a/pkg/proc/proc_test.go
+++ b/pkg/proc/proc_test.go
@@ -2730,3 +2730,17 @@ func TestPackageWithPathVar(t *testing.T) {
 		assertNoError(err, t, "EvalVariable(pkg.SomeVar.X)")
 	})
 }
+
+func TestEnvironment(t *testing.T) {
+	os.Setenv("SOMEVAR", "bah")
+	withTestProcess("testenv", t, func(p proc.Process, fixture protest.Fixture) {
+		assertNoError(proc.Continue(p), t, "Continue()")
+		v, err := evalVariable(p, "x")
+		assertNoError(err, t, "EvalVariable()")
+		vv := constant.StringVal(v.Value)
+		t.Logf("v = %q", vv)
+		if vv != "bah" {
+			t.Fatalf("value of v is %q (expected \"bah\")", vv)
+		}
+	})
+}


### PR DESCRIPTION
```
proc/gdbserial: pass environment variables to target

debugserver requires a special option to forward the environment to the target.

Fixes #818

```
