### PR TITLE
proc/native: Detach should use Kill with child processes we want killed

### DIFF
--- a/pkg/proc/native/proc.go
+++ b/pkg/proc/native/proc.go
@@ -41,6 +41,7 @@ type Process struct {
 	exited                      bool
 	ptraceChan                  chan func()
 	ptraceDoneChan              chan interface{}
+	childProcess                bool // this process was launched, not attached to
 }
 
 // New returns an initialized Process struct. Before returning,
@@ -69,6 +70,14 @@ func (dbp *Process) BinInfo() *proc.BinaryInfo {
 // Detach from the process being debugged, optionally killing it.
 func (dbp *Process) Detach(kill bool) (err error) {
 	if dbp.exited {
+		return nil
+	}
+	if kill && dbp.childProcess {
+		err := dbp.Kill()
+		if err != nil {
+			return err
+		}
+		dbp.bi.Close()
 		return nil
 	}
 	if dbp.Running() {

--- a/pkg/proc/native/proc_darwin.go
+++ b/pkg/proc/native/proc_darwin.go
@@ -75,6 +75,7 @@ func Launch(cmd []string, wd string) (*Process, error) {
 		return nil, fmt.Errorf("could not fork/exec")
 	}
 	dbp.pid = pid
+	dbp.childProcess = true
 	for i := range argvSlice {
 		C.free(unsafe.Pointer(argvSlice[i]))
 	}

--- a/pkg/proc/native/proc_linux.go
+++ b/pkg/proc/native/proc_linux.go
@@ -68,6 +68,7 @@ func Launch(cmd []string, wd string) (*Process, error) {
 		return nil, err
 	}
 	dbp.pid = process.Process.Pid
+	dbp.childProcess = true
 	_, _, err = dbp.wait(process.Process.Pid, 0)
 	if err != nil {
 		return nil, fmt.Errorf("waiting for target execve failed: %s", err)

--- a/pkg/proc/native/proc_windows.go
+++ b/pkg/proc/native/proc_windows.go
@@ -125,6 +125,7 @@ func Launch(cmd []string, wd string) (*Process, error) {
 	sys.CloseHandle(sys.Handle(pi.Thread))
 
 	dbp.pid = int(pi.ProcessId)
+	dbp.childProcess = true
 
 	return newDebugProcess(dbp, argv0Go)
 }

--- a/pkg/proc/proc_test.go
+++ b/pkg/proc/proc_test.go
@@ -918,6 +918,20 @@ func TestKill(t *testing.T) {
 			}
 		}
 	})
+	withTestProcess("testprog", t, func(p proc.Process, fixture protest.Fixture) {
+		if err := p.Detach(true); err != nil {
+			t.Fatal(err)
+		}
+		if p.Exited() != true {
+			t.Fatal("expected process to have exited")
+		}
+		if runtime.GOOS == "linux" {
+			_, err := os.Open(fmt.Sprintf("/proc/%d/", p.Pid()))
+			if err == nil {
+				t.Fatal("process has not exited", p.Pid())
+			}
+		}
+	})
 }
 
 func testGSupportFunc(name string, t *testing.T, p proc.Process, fixture protest.Fixture) {


### PR DESCRIPTION
```
proc/native: Detach should use Kill with child processes we want killed

While implementing the gdbserial backend everything was changed to call
Detach to "close" a process so that gdbserial could do its clean up in
a single place. However the native implementation of Detach does not
actually kill processes we launched.

Fixes #821

```
