### PR TITLE
terminal: bugfix: deref of nil SelectedGoroutine switching goroutines

### DIFF
--- a/_fixtures/notify-v2.go
+++ b/_fixtures/notify-v2.go
@@ -1,0 +1,23 @@
+package main
+
+import (
+	"fmt"
+	"log"
+	"net/http"
+	"sync"
+)
+
+func main() {
+	http.HandleFunc("/test", func(w http.ResponseWriter, req *http.Request) {
+		go func() {
+			// I know this is wrong, it is just to simulate a deadlocked goroutine
+			fmt.Println("locking...")
+			mtx := &sync.Mutex{}
+			mtx.Lock()
+			mtx.Lock()
+			fmt.Println("will never print this")
+		}()
+	})
+
+	log.Fatalln(http.ListenAndServe("127.0.0.1:8888", nil))
+}

--- a/pkg/terminal/command.go
+++ b/pkg/terminal/command.go
@@ -473,6 +473,13 @@ func goroutines(t *Term, ctx callContext, argstr string) error {
 	return nil
 }
 
+func selectedGID(state *api.DebuggerState) int {
+	if state.SelectedGoroutine == nil {
+		return 0
+	}
+	return state.SelectedGoroutine.ID
+}
+
 func (c *Commands) goroutine(t *Term, ctx callContext, argstr string) error {
 	args := strings.SplitN(argstr, " ", 2)
 
@@ -505,7 +512,7 @@ func (c *Commands) goroutine(t *Term, ctx callContext, argstr string) error {
 			return err
 		}
 
-		fmt.Printf("Switched from %d to %d (thread %d)\n", oldState.SelectedGoroutine.ID, gid, newState.CurrentThread.ID)
+		fmt.Printf("Switched from %d to %d (thread %d)\n", selectedGID(oldState), gid, newState.CurrentThread.ID)
 		return nil
 	}
 


### PR DESCRIPTION
```
terminal: bugfix: deref of nil SelectedGoroutine switching goroutines

If CurrentThread isn't running a goroutine SelectedGoroutine can be
nil, do not blindly dereference it.

Fixes #827

```
