### PR TITLE
proc: next, stepout should work on recursive goroutines

### DIFF
--- a/_fixtures/increment.go
+++ b/_fixtures/increment.go
@@ -1,0 +1,18 @@
+package main
+
+import "fmt"
+
+// Increment Natural number y
+func Increment(y uint) uint {
+	if y == 0 {
+		return 1
+	}
+	if y%2 == 1 {
+		return (2 * Increment(y/2))
+	}
+	return y + 1
+}
+
+func main() {
+	fmt.Printf("%d\n", Increment(3))
+}

--- a/pkg/proc/breakpoints.go
+++ b/pkg/proc/breakpoints.go
@@ -117,11 +117,15 @@ func (bp *Breakpoint) CheckCondition(thread Thread) (bool, error) {
 			}
 		}
 	}
+	return evalBreakpointCondition(thread, bp.Cond)
+}
+
+func evalBreakpointCondition(thread Thread, cond ast.Expr) (bool, error) {
 	scope, err := GoroutineScope(thread)
 	if err != nil {
 		return true, err
 	}
-	v, err := scope.evalAST(bp.Cond)
+	v, err := scope.evalAST(cond)
 	if err != nil {
 		return true, fmt.Errorf("error evaluating expression: %v", err)
 	}

--- a/pkg/proc/core/core.go
+++ b/pkg/proc/core/core.go
@@ -248,6 +248,10 @@ func (t *Thread) Blocked() bool {
 	return false
 }
 
+func (t *Thread) SetCurrentBreakpoint() error {
+	return nil
+}
+
 func (p *Process) Breakpoints() map[uint64]*proc.Breakpoint {
 	return p.breakpoints
 }

--- a/pkg/proc/eval.go
+++ b/pkg/proc/eval.go
@@ -71,6 +71,8 @@ func (scope *EvalScope) evalAST(t ast.Expr) (*Variable, error) {
 					return nilVariable, nil
 				}
 				return scope.Gvar.clone(), nil
+			} else if maybePkg.Name == "runtime" && node.Sel.Name == "frameoff" {
+				return newConstant(constant.MakeInt64(scope.CFA-int64(scope.StackHi)), scope.Mem), nil
 			} else if v, err := scope.packageVarAddr(maybePkg.Name + "." + node.Sel.Name); err == nil {
 				return v, nil
 			}
@@ -851,7 +853,7 @@ func (scope *EvalScope) evalBinary(node *ast.BinaryExpr) (*Variable, error) {
 		r := xv.newVariable("", 0, typ)
 		r.Value = rc
 		if r.Kind == reflect.String {
-			r.Len = xv.Len+yv.Len
+			r.Len = xv.Len + yv.Len
 		}
 		return r, nil
 	}

--- a/pkg/proc/moduledata.go
+++ b/pkg/proc/moduledata.go
@@ -13,7 +13,7 @@ type moduleData struct {
 
 func loadModuleData(bi *BinaryInfo, mem MemoryReadWriter) (err error) {
 	bi.loadModuleDataOnce.Do(func() {
-		scope := &EvalScope{0, 0, mem, nil, bi}
+		scope := &EvalScope{0, 0, mem, nil, bi, 0}
 		var md *Variable
 		md, err = scope.packageVarAddr("runtime.firstmoduledata")
 		if err != nil {
@@ -119,7 +119,7 @@ func resolveNameOff(bi *BinaryInfo, typeAddr uintptr, off uintptr, mem MemoryRea
 }
 
 func reflectOffsMapAccess(bi *BinaryInfo, off uintptr, mem MemoryReadWriter) (*Variable, error) {
-	scope := &EvalScope{0, 0, mem, nil, bi}
+	scope := &EvalScope{0, 0, mem, nil, bi, 0}
 	reflectOffs, err := scope.packageVarAddr("runtime.reflectOffs")
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
This is a substantial change to our implementation of next/step/stepout so maybe we should hold it until after 1.0.0. OTOH next/step/stepout won't work on recursive functions because currently we are only checking that we stay on the same goroutine, where we should be checking that we stay on the same *call frame* too. 

```
proc: next, stepout should work on recursive goroutines

Before this commit our temp breakpoints only checked that we would stay
on the same goroutine.
However this isn't enough for recursive functions we must check that we
stay on the same goroutine AND on the same stack frame (or, in the case
of the StepOut breakpoint, the previous stack frame).

This commit:
1. adds a new synthetic variable runtime.frameoff that returns the
offset of the current frame from the base of the call stack.
This is similar to runtime.curg
2. Changes the condition used for breakpoints on the lines of the
current function to check that runtime.frameoff hasn't changed.
3. Changes the condition used for breakpoints on the return address to
check that runtime.frameoff corresponds to the previous frame in the
stack.
4. All other temporary breakpoints (the step-into breakpoints and defer
breakpoints) remain unchanged.

Fixes #828

```
