### PR TITLE
proc/variables: protect form invalid G struct in parseG

### DIFF
--- a/pkg/proc/proc_test.go
+++ b/pkg/proc/proc_test.go
@@ -546,6 +546,9 @@ func TestNextConcurrentVariant2(t *testing.T) {
 			var vval int64
 			for {
 				v, err := evalVariable(p, "n")
+				for _, thread := range p.ThreadList() {
+					proc.GetG(thread)
+				}
 				assertNoError(err, t, "EvalVariable")
 				vval, _ = constant.Int64Val(v.Value)
 				if bp, _, _ := p.CurrentThread().Breakpoint(); bp == nil {

--- a/pkg/proc/variables.go
+++ b/pkg/proc/variables.go
@@ -380,7 +380,10 @@ func (gvar *Variable) parseG() (*G, error) {
 	sp, _ := constant.Int64Val(schedVar.fieldVariable("sp").Value)
 	id, _ := constant.Int64Val(gvar.fieldVariable("goid").Value)
 	gopc, _ := constant.Int64Val(gvar.fieldVariable("gopc").Value)
-	waitReason := constant.StringVal(gvar.fieldVariable("waitreason").Value)
+	waitReason := ""
+	if wrvar := gvar.fieldVariable("waitreason"); wrvar.Value != nil {
+		waitReason = constant.StringVal(wrvar.Value)
+	}
 	var stackhi uint64
 	if stackVar := gvar.fieldVariable("stack"); stackVar != nil {
 		if stackhiVar := stackVar.fieldVariable("hi"); stackhiVar != nil {


### PR DESCRIPTION
This problem came up while I was implementing #831, it's pretty rare and I can only seem to reproduce it with the lldb backend, it's caused by the length of G.waitreason containing garbage.

```
proc/variables: protect form invalid G struct in parseG

A waitreason string that has invalid length (because the G struct is
corrupted or being modified) could cause a crash.

```
