### PR TITLE
proc: print runtime.curg._panic.arg on unrecovered-panic breakpoint

### DIFF
--- a/pkg/proc/gdbserial/gdbserver.go
+++ b/pkg/proc/gdbserial/gdbserver.go
@@ -267,6 +267,7 @@ func Connect(addr string, path string, pid int, attempts int) (*Process, error) 
 		bp, err := p.SetBreakpoint(panicpc, proc.UserBreakpoint, nil)
 		if err == nil {
 			bp.Name = "unrecovered-panic"
+			bp.Variables = []string{"runtime.curg._panic.arg"}
 			bp.ID = -1
 			p.breakpointIDCounter--
 		}

--- a/pkg/proc/native/proc.go
+++ b/pkg/proc/native/proc.go
@@ -418,6 +418,7 @@ func initializeDebugProcess(dbp *Process, path string, attach bool) (*Process, e
 		bp, err := dbp.SetBreakpoint(panicpc, proc.UserBreakpoint, nil)
 		if err == nil {
 			bp.Name = "unrecovered-panic"
+			bp.Variables = []string{"runtime.curg._panic.arg"}
 			bp.ID = -1
 			dbp.breakpointIDCounter--
 		}


### PR DESCRIPTION
```
proc: print runtime.curg._panic.arg on unrecovered-panic breakpoint

You usually want to know the reason for the panic when a panic happens,
it can be printed manually this is a small quality of life improvement.

```
