### PR TITLE
proc/variables: fill Len field of maps when recursion limit is reached

### DIFF
--- a/_fixtures/testvariables2.go
+++ b/_fixtures/testvariables2.go
@@ -85,6 +85,10 @@ type Item struct {
 
 type Menu []Item
 
+type truncatedMap struct {
+	v []map[string]astruct
+}
+
 func main() {
 	i1 := 1
 	i2 := 2
@@ -223,6 +227,8 @@ func main() {
 	zsvar := struct{}{}
 	zsslice := make([]struct{}, 3)
 	zsvmap := map[string]struct{}{"testkey": struct{}{}}
+	var tm truncatedMap
+	tm.v = []map[string]astruct{m1}
 
 	var amb1 = 1
 	runtime.Breakpoint()
@@ -231,5 +237,5 @@ func main() {
 	}
 
 	runtime.Breakpoint()
-	fmt.Println(i1, i2, i3, p1, amb1, s1, s3, a1, p2, p3, s2, as1, str1, f1, fn1, fn2, nilslice, nilptr, ch1, chnil, m1, mnil, m2, m3, up1, i4, i5, i6, err1, err2, errnil, iface1, iface2, ifacenil, arr1, parr, cpx1, const1, iface3, iface4, recursive1, recursive1.x, iface5, iface2fn1, iface2fn2, bencharr, benchparr, mapinf, mainMenu, b, b2, sd, anonstruct1, anonstruct2, anoniface1, anonfunc, mapanonstruct1, ifacearr, efacearr, ni8, ni16, ni32, pinf, ninf, nan, zsvmap, zsslice, zsvar)
+	fmt.Println(i1, i2, i3, p1, amb1, s1, s3, a1, p2, p3, s2, as1, str1, f1, fn1, fn2, nilslice, nilptr, ch1, chnil, m1, mnil, m2, m3, up1, i4, i5, i6, err1, err2, errnil, iface1, iface2, ifacenil, arr1, parr, cpx1, const1, iface3, iface4, recursive1, recursive1.x, iface5, iface2fn1, iface2fn2, bencharr, benchparr, mapinf, mainMenu, b, b2, sd, anonstruct1, anonstruct2, anoniface1, anonfunc, mapanonstruct1, ifacearr, efacearr, ni8, ni16, ni32, pinf, ninf, nan, zsvmap, zsslice, zsvar, tm)
 }

--- a/pkg/proc/variables.go
+++ b/pkg/proc/variables.go
@@ -824,6 +824,9 @@ func (v *Variable) loadValueInternal(recurseLevel int, cfg LoadConfig) {
 	case reflect.Map:
 		if recurseLevel <= cfg.MaxVariableRecurse {
 			v.loadMap(recurseLevel, cfg)
+		} else {
+			// loads length so that the client knows that the map isn't empty
+			v.mapIterator()
 		}
 
 	case reflect.String:

--- a/service/test/variables_test.go
+++ b/service/test/variables_test.go
@@ -694,6 +694,7 @@ func TestEvalExpression(t *testing.T) {
 
 		{"zsslice", false, `[]struct {} len: 3, cap: 3, [{},{},{}]`, `[]struct {} len: 3, cap: 3, [...]`, "[]struct {}", nil},
 		{"zsvmap", false, `map[string]struct {} ["testkey": {}, ]`, `map[string]struct {} [...]`, "map[string]struct {}", nil},
+		{"tm", false, "main.truncatedMap {v: []map[string]main.astruct len: 1, cap: 1, [[...]]}", "main.truncatedMap {v: []map[string]main.astruct len: 1, cap: 1, [...]}", "main.truncatedMap", nil},
 	}
 
 	ver, _ := proc.ParseVersionString(runtime.Version())


### PR DESCRIPTION
```
proc/variables: fill Len field of maps when recursion limit is reached

If we don't fill the Len field there will be no way for the user to
distinguish maps we didn't load from empty maps.

```
