### PR TITLE
proc/gdbserial: fix passing arguments to target via debugserver

### DIFF
--- a/pkg/proc/gdbserial/gdbserver.go
+++ b/pkg/proc/gdbserial/gdbserver.go
@@ -332,8 +332,8 @@ func LLDBLaunch(cmd []string, wd string) (*Process, error) {
 			return nil, err
 		}
 		listener.(*net.TCPListener).SetDeadline(time.Now().Add(maxConnectAttempts * time.Second))
-		args := make([]string, 0, len(cmd)+3)
-		args = append(args, "-F", "-R", fmt.Sprintf("127.0.0.1:%d", listener.Addr().(*net.TCPAddr).Port))
+		args := make([]string, 0, len(cmd)+4)
+		args = append(args, "-F", "-R", fmt.Sprintf("127.0.0.1:%d", listener.Addr().(*net.TCPAddr).Port), "--")
 		args = append(args, cmd...)
 
 		isDebugserver = true

--- a/pkg/proc/proc_test.go
+++ b/pkg/proc/proc_test.go
@@ -1910,6 +1910,7 @@ func TestCmdLineArgs(t *testing.T) {
 
 	// make sure multiple arguments (including one with spaces) are passed to the binary correctly
 	withTestProcessArgs("testargs", t, ".", expectSuccess, []string{"test"})
+	withTestProcessArgs("testargs", t, ".", expectPanic, []string{"-test"})
 	withTestProcessArgs("testargs", t, ".", expectSuccess, []string{"test", "pass flag"})
 	// check that arguments with spaces are *only* passed correctly when correctly called
 	withTestProcessArgs("testargs", t, ".", expectPanic, []string{"test pass", "flag"})


### PR DESCRIPTION
```
proc/gdbserial: fix passing arguments to target via debugserver

Debugserver does not work as documented, "--" needs to be specified to
pass arguments to the target process (but only if it's an argument that
starts with a dash).

Fixes #839

```
