### PR TITLE
proc/gdbserial: wait for a connection from stub as long as stub lives

### DIFF
--- a/pkg/proc/gdbserial/rr.go
+++ b/pkg/proc/gdbserial/rr.go
@@ -70,14 +70,14 @@ func Replay(tracedir string, quiet bool) (*Process, error) {
 		rrcmd.Process.Kill()
 		return nil, err
 	}
-	p, err := Connect(nil, init.port, init.exe, 0, maxConnectAttempts)
+
+	p := New(rrcmd.Process)
+	p.tracedir = tracedir
+	err = p.Dial(init.port, init.exe, 0)
 	if err != nil {
 		rrcmd.Process.Kill()
 		return nil, err
 	}
-
-	p.process = rrcmd
-	p.tracedir = tracedir
 
 	return p, nil
 }


### PR DESCRIPTION
I think most of the problems in issue #838 may actually be due to people not noticing debugserver's authorization prompt, since debugserver won't connect back to us until user authorization is given we should wait forever for a connection as long as the debugserver process remains alive.

Waiting for a fixed amount of time was an ugly solution anyway.

PS. 20% of the code causes 80% of the bugs.

```
proc/gdbserial: wait for a connection from stub as long as stub lives

The authorization prompt on macOS can take a long time to be
acknowledged by the user, we should keep waiting for a connection as
long as the debugserver instance we launched remains alive.

```
