### PR TITLE
pkg/proc: remove unused types

### DIFF
--- a/pkg/proc/interface.go
+++ b/pkg/proc/interface.go
@@ -92,9 +92,3 @@ type BreakpointManipulation interface {
 	ClearBreakpoint(addr uint64) (*Breakpoint, error)
 	ClearInternalBreakpoints() error
 }
-
-// VariableEval is an interface for dealing with eval scopes.
-type VariableEval interface {
-	FrameToScope(Stackframe) *EvalScope
-	ConvertEvalScope(gid, frame int) (*EvalScope, error)
-}

--- a/pkg/proc/variables.go
+++ b/pkg/proc/variables.go
@@ -92,14 +92,6 @@ type LoadConfig struct {
 var loadSingleValue = LoadConfig{false, 0, 64, 0, 0}
 var loadFullValue = LoadConfig{true, 1, 64, 64, -1}
 
-// M represents a runtime M (OS thread) structure.
-type M struct {
-	procid   int     // Thread ID or port.
-	spinning uint8   // Busy looping.
-	blocked  uint8   // Waiting on futex / semaphore.
-	curg     uintptr // Current G running on this thread.
-}
-
 // G status, from: src/runtime/runtime2.go
 const (
 	Gidle           uint64 = iota // 0


### PR DESCRIPTION
```
pkg/proc: remove unused types

type M struct was never used (as far as I know).
type VariableEval interface was used for a brief period of time during
the refactoring, now both its methods are functions.

```
