### PR TITLE
proc/native/linux: call waitFast instead of wait in addThread and halt

### DIFF
--- a/pkg/proc/native/proc_linux.go
+++ b/pkg/proc/native/proc_linux.go
@@ -120,7 +120,7 @@ func (dbp *Process) addThread(tid int, attach bool) (*Thread, error) {
 			// if we truly don't have permissions.
 			return nil, fmt.Errorf("could not attach to new thread %d %s", tid, err)
 		}
-		pid, status, err := dbp.wait(tid, 0)
+		pid, status, err := dbp.waitFast(tid)
 		if err != nil {
 			return nil, err
 		}
@@ -131,7 +131,7 @@ func (dbp *Process) addThread(tid int, attach bool) (*Thread, error) {
 
 	dbp.execPtraceFunc(func() { err = syscall.PtraceSetOptions(tid, syscall.PTRACE_O_TRACECLONE) })
 	if err == syscall.ESRCH {
-		if _, _, err = dbp.wait(tid, 0); err != nil {
+		if _, _, err = dbp.waitFast(tid); err != nil {
 			return nil, fmt.Errorf("error while waiting after adding thread: %d %s", tid, err)
 		}
 		dbp.execPtraceFunc(func() { err = syscall.PtraceSetOptions(tid, syscall.PTRACE_O_TRACECLONE) })

--- a/pkg/proc/native/threads_linux.go
+++ b/pkg/proc/native/threads_linux.go
@@ -22,7 +22,7 @@ func (t *Thread) halt() (err error) {
 		err = fmt.Errorf("halt err %s on thread %d", err, t.ID)
 		return
 	}
-	_, _, err = t.dbp.wait(t.ID, 0)
+	_, _, err = t.dbp.waitFast(t.ID)
 	if err != nil {
 		err = fmt.Errorf("wait err %s on thread %d", err, t.ID)
 		return


### PR DESCRIPTION
```
proc/native/linux: call waitFast instead of wait in addThread and halt

The condition that causes waitFast to fail can not happen in addThread
and halt so we don't need to call the slower wait.

```
