### PR TITLE
debugger/locations: if locspec isn't found try interpreting it as expr

### DIFF
--- a/_fixtures/locationsprog.go
+++ b/_fixtures/locationsprog.go
@@ -36,3 +36,13 @@ func main() {
 	anotherFunction()
 	ioutil.ReadFile("nonexistent.file.txt")
 }
+
+var amap map[string]func()
+
+func init() {
+	amap = map[string]func(){
+		"k": func() {
+			fmt.Printf("hello world")
+		},
+	}
+}

--- a/service/debugger/locations.go
+++ b/service/debugger/locations.go
@@ -362,7 +362,15 @@ func (loc *NormalLocationSpec) Find(d *Debugger, scope *proc.EvalScope, locStr s
 	}
 
 	if matching := len(candidateFiles) + len(candidateFuncs); matching == 0 {
-		return nil, fmt.Errorf("Location %q not found", locStr)
+		// if no result was found treat this locations string could be an
+		// expression that the user forgot to prefix with '*', try treating it as
+		// such.
+		addrSpec := &AddrLocationSpec{locStr}
+		locs, err := addrSpec.Find(d, scope, locStr)
+		if err != nil {
+			return nil, fmt.Errorf("Location \"%s\" not found", locStr)
+		}
+		return locs, nil
 	} else if matching > 1 {
 		return nil, AmbiguousLocationError{Location: locStr, CandidatesString: append(candidateFiles, candidateFuncs...)}
 	}

--- a/service/test/common_test.go
+++ b/service/test/common_test.go
@@ -94,7 +94,7 @@ func findLocationHelper(t *testing.T, c LocationFinder, loc string, shouldErr bo
 	}
 
 	if checkAddr != 0 && checkAddr != locs[0].PC {
-		t.Fatalf("Wrong address returned for location <%s> (got %v, epected %v)", loc, locs[0].PC, checkAddr)
+		t.Fatalf("Wrong address returned for location <%s> (got %#x, epected %#x)", loc, locs[0].PC, checkAddr)
 	}
 
 	addrs := make([]uint64, len(locs))

--- a/service/test/integration2_test.go
+++ b/service/test/integration2_test.go
@@ -657,6 +657,8 @@ func TestClientServer_FindLocations(t *testing.T) {
 		findLocationHelper(t, c, "+1", false, 1, locationsprog35Addr)
 		findLocationHelper(t, c, "35", false, 1, locationsprog35Addr)
 		findLocationHelper(t, c, "-1", false, 1, findLocationHelper(t, c, "locationsprog.go:33", false, 1, 0)[0])
+
+		findLocationHelper(t, c, `*amap["k"]`, false, 1, findLocationHelper(t, c, `amap["k"]`, false, 1, 0)[0])
 	})
 
 	withTestClient2("testnextdefer", t, func(c service.Client) {


### PR DESCRIPTION
```
debugger/locations: if locspec isn't found try interpreting it as expr

If the user tries to list the contents of a function pointer but
forgets the '*' operator the location lookup will fail and result in a
unhelpful "location not found" error.

Instead if the location lookup fails we should try interpreting the
locspec as if it was preceded by '*'.

```
