### PR TITLE
debugger: collect breakpoint information on next/step/stepout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,12 +5,6 @@ This project adheres to Semantic Versioning.
 
 All changes mention the author, unless contributed by me (@derekparker).
 
-## [RELEASE TO BE DEFINED] DATE TO BE DEFINED
-
-### Fixed
-
-- Data races in tests (@aarzilli)
-
 ## [1.0.0-rc.2] DATE TO BE DEFINED
 
 ### Added
@@ -23,11 +17,13 @@ All changes mention the author, unless contributed by me (@derekparker).
 - Fix behavior of next, step and stepout with recursive functions (@aarzilli)
 - Parsing of maps with zero sized values (@aarzilli)
 - Typo in the documentation of `types` command (@custa)
+- Data races in tests (@aarzilli)
 
 ### Changed
 
 - Switched from godeps to glide (@derekparker)
 - Better performance of linux native backend (@aarzilli)
+- Collect breakpoints information if necessary after a next, step or stepout command (@aarzilli)
 
 ## [1.0.0-rc.1] 2017-05-05
 


### PR DESCRIPTION
```
debugger: collect breakpoint information on next/step/stepout

A next/step/stepout command could hit a normal breakpoint, decorated
with a list of variables to evaluate, if that happens the variable
should be evaluated just as if the breakpoint was hit by a continue.

```
