### PR TITLE
Solving data races in tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ This project adheres to Semantic Versioning.
 
 All changes mention the author, unless contributed by me (@derekparker).
 
+## [RELEASE TO BE DEFINED] DATE TO BE DEFINED
+
+### Fixed
+
+- Data races in tests (@aarzilli)
+
 ## [1.0.0-rc.2] DATE TO BE DEFINED
 
 ### Added

--- a/pkg/proc/core/core.go
+++ b/pkg/proc/core/core.go
@@ -304,8 +304,7 @@ func (p *Process) Pid() int {
 	return p.core.Pid
 }
 
-func (p *Process) Running() bool {
-	return false
+func (p *Process) ResumeNotify(chan<- struct{}) {
 }
 
 func (p *Process) SelectedGoroutine() *proc.G {

--- a/pkg/proc/gdbserial/gdbserver.go
+++ b/pkg/proc/gdbserial/gdbserver.go
@@ -490,8 +490,8 @@ func (p *Process) Exited() bool {
 	return p.exited
 }
 
-func (p *Process) Running() bool {
-	return p.conn.running
+func (p *Process) ResumeNotify(ch chan<- struct{}) {
+	p.conn.resumeChan = ch
 }
 
 func (p *Process) FindThread(threadID int) (proc.Thread, bool) {

--- a/pkg/proc/gdbserial/gdbserver_conn.go
+++ b/pkg/proc/gdbserial/gdbserver_conn.go
@@ -23,7 +23,8 @@ type gdbConn struct {
 	inbuf  []byte
 	outbuf bytes.Buffer
 
-	running bool
+	running    bool
+	resumeChan chan<- struct{}
 
 	direction proc.Direction // direction of execution
 
@@ -543,6 +544,10 @@ func (conn *gdbConn) resume(sig uint8, tu *threadUpdater) (string, uint8, error)
 	defer func() {
 		conn.running = false
 	}()
+	if conn.resumeChan != nil {
+		close(conn.resumeChan)
+		conn.resumeChan = nil
+	}
 	return conn.waitForvContStop("resume", "-1", tu)
 }
 

--- a/pkg/proc/interface.go
+++ b/pkg/proc/interface.go
@@ -6,6 +6,11 @@ import (
 
 // Process represents the target of the debugger. This
 // target could be a system process, core file, etc.
+//
+// Implementations of Process are not required to be thread safe and users
+// of Process should not assume they are.
+// There is one exception to this rule: it is safe to call RequestManualStop
+// concurrently with ContinueOnce.
 type Process interface {
 	Info
 	ProcessManipulation

--- a/pkg/proc/interface.go
+++ b/pkg/proc/interface.go
@@ -52,8 +52,10 @@ type Checkpoint struct {
 // Info is an interface that provides general information on the target.
 type Info interface {
 	Pid() int
+	// ResumeNotify specifies a channel that will be closed the next time
+	// ContinueOnce finishes resuming the target.
+	ResumeNotify(chan<- struct{})
 	Exited() bool
-	Running() bool
 	BinInfo() *BinaryInfo
 
 	ThreadInfo

--- a/pkg/proc/native/proc.go
+++ b/pkg/proc/native/proc.go
@@ -37,6 +37,7 @@ type Process struct {
 	breakpointIDCounter         int
 	internalBreakpointIDCounter int
 	firstStart                  bool
+	haltMu                      sync.Mutex
 	halt                        bool
 	exited                      bool
 	ptraceChan                  chan func()
@@ -187,6 +188,8 @@ func (dbp *Process) RequestManualStop() error {
 	if dbp.exited {
 		return &proc.ProcessExitedError{}
 	}
+	dbp.haltMu.Lock()
+	defer dbp.haltMu.Unlock()
 	dbp.halt = true
 	return dbp.requestManualStop()
 }

--- a/pkg/proc/native/proc_linux.go
+++ b/pkg/proc/native/proc_linux.go
@@ -236,7 +236,10 @@ func (dbp *Process) trapWait(pid int) (*Thread, error) {
 			// Sometimes we get an unknown thread, ignore it?
 			continue
 		}
-		if status.StopSignal() == sys.SIGTRAP && dbp.halt {
+		dbp.haltMu.Lock()
+		halt := dbp.halt
+		dbp.haltMu.Unlock()
+		if status.StopSignal() == sys.SIGTRAP && halt {
 			th.running = false
 			dbp.halt = false
 			return th, nil

--- a/pkg/proc/proc_unix_test.go
+++ b/pkg/proc/proc_unix_test.go
@@ -25,24 +25,21 @@ func TestIssue419(t *testing.T) {
 		_, err := setFunctionBreakpoint(p, "main.main")
 		assertNoError(err, t, "SetBreakpoint()")
 		assertNoError(proc.Continue(p), t, "Continue()")
+		resumeChan := make(chan struct{})
 		go func() {
-			for {
-				time.Sleep(500 * time.Millisecond)
-				if p.Running() {
-					time.Sleep(2 * time.Second)
-					if p.Pid() <= 0 {
-						// if we don't stop the inferior the test will never finish
-						p.RequestManualStop()
-						p.Kill()
-						t.Fatalf("Pid is zero or negative: %d", p.Pid())
-						return
-					}
-					err := syscall.Kill(p.Pid(), syscall.SIGINT)
-					assertNoError(err, t, "syscall.Kill")
-					return
-				}
+			time.Sleep(500 * time.Millisecond)
+			<-resumeChan
+			if p.Pid() <= 0 {
+				// if we don't stop the inferior the test will never finish
+				p.RequestManualStop()
+				p.Kill()
+				t.Fatalf("Pid is zero or negative: %d", p.Pid())
+				return
 			}
+			err := syscall.Kill(p.Pid(), syscall.SIGINT)
+			assertNoError(err, t, "syscall.Kill")
 		}()
+		p.ResumeNotify(resumeChan)
 		err = proc.Continue(p)
 		if _, exited := err.(proc.ProcessExitedError); !exited {
 			t.Fatalf("Unexpected error after Continue(): %v\n", err)

--- a/service/debugger/debugger.go
+++ b/service/debugger/debugger.go
@@ -200,9 +200,6 @@ func (d *Debugger) Restart(pos string) ([]api.DiscardedBreakpoint, error) {
 	}
 
 	if !d.target.Exited() {
-		if d.target.Running() {
-			d.target.Halt()
-		}
 		// Ensure the process is in a PTRACE_STOP.
 		if err := stopProcess(d.ProcessPid()); err != nil {
 			return nil, err


### PR DESCRIPTION
There were really two sources of data races, one was native.(*Process).Running with native.(*Process).ContinueOnce, which only affected tests. The other was native.(*Process).RequestManualStop with native.(*Process).trapWait, this one could have affected real use, in principle, but only if the compiler applied some extra-aggressive reordering, which it doesn't.

```
proc: document thread safety of Process interface.

proc/*: remove Process.Running

Implementing proc.Process.Running in a thread safe way is complicated
and nothing actually uses it besides tests, so we are better off
rewriting the tests without Running and removing it.

In particular:

* The call to d.target.Running() in service/debugger/debugger.go
(Restart) can never return true because that line executes while
holding processMutex and all continue operations are also executed
while holding processMutex.
* The call to dbp.Running() pkg/proc/native/proc.go (Detach) can never
return true, because it's only called from
debugger.(*Debugger).detach() which is also always called while
holding processMutex.

Since some tests are hard to write correctly without Process.Running a
simpler interface, Process.NotifyResumed, is introduced.

Fixes #830

proc/native: race between RequestManualStop and trapWait

RequestManualStop will run concurrently with trapWait, since one writes
dbp.halt and the other reads it dbp.halt should be protected by a
mutex.

Updates #830

```
