### PR TITLE
api: add FrameOffset to Stackframe

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ This project adheres to Semantic Versioning.
 
 All changes mention the author, unless contributed by me (@derekparker).
 
+## [RELEASE TO BE DEFINED] DATE TO BE DEFINED
+
+### Added
+
+- Add FrameOffset field to api.Stackframe (@aarzilli)
+
 ## [1.0.0-rc.2] DATE TO BE DEFINED
 
 ### Added

--- a/pkg/terminal/command_test.go
+++ b/pkg/terminal/command_test.go
@@ -216,7 +216,7 @@ func TestExecuteFile(t *testing.T) {
 
 func TestIssue354(t *testing.T) {
 	printStack([]api.Stackframe{}, "")
-	printStack([]api.Stackframe{{api.Location{PC: 0, File: "irrelevant.go", Line: 10, Function: nil}, nil, nil}}, "")
+	printStack([]api.Stackframe{{api.Location{PC: 0, File: "irrelevant.go", Line: 10, Function: nil}, nil, nil, 0}}, "")
 }
 
 func TestIssue411(t *testing.T) {

--- a/service/api/types.go
+++ b/service/api/types.go
@@ -118,8 +118,9 @@ type Location struct {
 
 type Stackframe struct {
 	Location
-	Locals    []Variable
-	Arguments []Variable
+	Locals      []Variable
+	Arguments   []Variable
+	FrameOffset int64
 }
 
 func (frame *Stackframe) Var(name string) *Variable {

--- a/service/debugger/debugger.go
+++ b/service/debugger/debugger.go
@@ -870,7 +870,10 @@ func (d *Debugger) Stacktrace(goroutineID, depth int, cfg *proc.LoadConfig) ([]a
 func (d *Debugger) convertStacktrace(rawlocs []proc.Stackframe, cfg *proc.LoadConfig) ([]api.Stackframe, error) {
 	locations := make([]api.Stackframe, 0, len(rawlocs))
 	for i := range rawlocs {
-		frame := api.Stackframe{Location: api.ConvertLocation(rawlocs[i].Call)}
+		frame := api.Stackframe{
+			Location:    api.ConvertLocation(rawlocs[i].Call),
+			FrameOffset: rawlocs[i].CFA - int64(rawlocs[i].StackHi),
+		}
 		if cfg != nil && rawlocs[i].Current.Fn != nil {
 			var err error
 			scope := proc.FrameToScope(d.target, rawlocs[i])


### PR DESCRIPTION
```
api: add FrameOffset to Stackframe

Other debuggers can be instructed to decorate the stacktrace with the
value of SP. Our SP equivalent is the frame offset, since we can add it
to the Stackframe structure without incurring into added costs we
should, so that frontends can use it if they want.

```
