### PR TITLE
proc: auto-dereference local variables that escape to the heap

### DIFF
--- a/pkg/proc/variables.go
+++ b/pkg/proc/variables.go
@@ -45,6 +45,11 @@ type VariableFlags uint16
 
 const (
 	// VariableEscaped is set for local variables that escaped to the heap
+	//
+	// The compiler performs escape analysis on local variables, the variables
+	// that may outlive the stack frame are allocated on the heap instead and
+	// only the address is recorded on the stack. These variables will be
+	// marked with this flag.
 	VariableEscaped VariableFlags = (1 << iota)
 	// VariableShadowed is set for local variables that are shadowed by a
 	// variable with the same name in another scope

--- a/service/api/types.go
+++ b/service/api/types.go
@@ -152,6 +152,11 @@ type VariableFlags uint16
 
 const (
 	// VariableEscaped is set for local variables that escaped to the heap
+	//
+	// The compiler performs escape analysis on local variables, the variables
+	// that may outlive the stack frame are allocated on the heap instead and
+	// only the address is recorded on the stack. These variables will be
+	// marked with this flag.
 	VariableEscaped = VariableFlags(proc.VariableEscaped)
 
 	// VariableShadowed is set for local variables that are shadowed by a


### PR DESCRIPTION
```
proc: auto-dereference local variables that escape to the heap

The compiler a variable 'v' that escapes to the heap with a '&v' entry.
Auto dereference those local variables.

Fixe #871

```
