### PR TITLE
proc: fix interaction of RequestManualStop and conditional breakpoints

### DIFF
--- a/pkg/proc/core/core.go
+++ b/pkg/proc/core/core.go
@@ -269,6 +269,10 @@ func (p *Process) RequestManualStop() error {
 	return nil
 }
 
+func (p *Process) ManualStopRequested() bool {
+	return false
+}
+
 func (p *Process) CurrentThread() proc.Thread {
 	return &Thread{p.currentThread, p}
 }

--- a/pkg/proc/gdbserial/gdbserver.go
+++ b/pkg/proc/gdbserial/gdbserver.go
@@ -1155,8 +1155,11 @@ func (t *Thread) Blocked() bool {
 		return false
 	}
 	pc := regs.PC()
-	fn := t.BinInfo().PCToFunc(pc)
+	f, ln, fn := t.BinInfo().PCToLine(pc)
 	if fn == nil {
+		if f == "" && ln == 0 {
+			return true
+		}
 		return false
 	}
 	switch fn.Name {
@@ -1332,6 +1335,12 @@ func (t *Thread) reloadGAtPC() error {
 
 	_, _, err = t.p.conn.step(t.strID, nil)
 	if err != nil {
+		if err == threadBlockedError {
+			t.regs.tls = 0
+			t.regs.gaddr = 0
+			t.regs.hasgaddr = true
+			return nil
+		}
 		return err
 	}
 
@@ -1379,6 +1388,12 @@ func (t *Thread) reloadGAlloc() error {
 
 	_, _, err = t.p.conn.step(t.strID, nil)
 	if err != nil {
+		if err == threadBlockedError {
+			t.regs.tls = 0
+			t.regs.gaddr = 0
+			t.regs.hasgaddr = true
+			return nil
+		}
 		return err
 	}
 

--- a/pkg/proc/interface.go
+++ b/pkg/proc/interface.go
@@ -87,6 +87,9 @@ type ProcessManipulation interface {
 	SwitchThread(int) error
 	SwitchGoroutine(int) error
 	RequestManualStop() error
+	// ManualStopRequested returns true the first time it's called after a call
+	// to RequestManualStop.
+	ManualStopRequested() bool
 	Halt() error
 	Kill() error
 	Detach(bool) error

--- a/pkg/proc/native/proc.go
+++ b/pkg/proc/native/proc.go
@@ -44,6 +44,7 @@ type Process struct {
 	ptraceChan                  chan func()
 	ptraceDoneChan              chan interface{}
 	childProcess                bool // this process was launched, not attached to
+	manualStopRequested         bool
 }
 
 // New returns an initialized Process struct. Before returning,
@@ -179,8 +180,17 @@ func (dbp *Process) RequestManualStop() error {
 	}
 	dbp.haltMu.Lock()
 	defer dbp.haltMu.Unlock()
+	dbp.manualStopRequested = true
 	dbp.halt = true
 	return dbp.requestManualStop()
+}
+
+func (dbp *Process) ManualStopRequested() bool {
+	dbp.haltMu.Lock()
+	msr := dbp.manualStopRequested
+	dbp.manualStopRequested = false
+	dbp.haltMu.Unlock()
+	return msr
 }
 
 // SetBreakpoint sets a breakpoint at addr, and stores it in the process wide

--- a/pkg/proc/proc.go
+++ b/pkg/proc/proc.go
@@ -95,7 +95,11 @@ func Next(dbp Process) (err error) {
 // process. It will continue until it hits a breakpoint
 // or is otherwise stopped.
 func Continue(dbp Process) error {
+	dbp.ManualStopRequested()
 	for {
+		if dbp.ManualStopRequested() {
+			return nil
+		}
 		trapthread, err := dbp.ContinueOnce()
 		if err != nil {
 			return err


### PR DESCRIPTION
```
proc: fix interaction of RequestManualStop and conditional breakpoints

A conditional breakpoint that is hit but has the condition evaluate to
false can block a RequestManualStop from working. If the conditional
breakpoint is set on an instruction that is executed very frequently by
multiple goroutines (or many conditional breakpoints are set) it could
prevent all calls to RequestManualStop from working.

This commit fixes the problem by changing proc.Continue to exit
unconditionally after a RequestManualStop is called.

```
