### PR TITLE
proc: read G struct offset from runtime.tlsg if possible

### DIFF
--- a/pkg/proc/arch.go
+++ b/pkg/proc/arch.go
@@ -3,11 +3,9 @@ package proc
 // Arch defines an interface for representing a
 // CPU architecture.
 type Arch interface {
-	SetGStructOffset(ver GoVersion, iscgo bool)
 	PtrSize() int
 	BreakpointInstruction() []byte
 	BreakpointSize() int
-	GStructOffset() uint64
 	DerefTLS() bool
 }
 
@@ -35,26 +33,6 @@ func AMD64Arch(goos string) *AMD64 {
 	}
 }
 
-// SetGStructOffset sets the offset of the G struct on the AMD64
-// arch struct. The offset is dependent on the Go compiler Version
-// and whether or not the target program was externally linked.
-func (a *AMD64) SetGStructOffset(ver GoVersion, isextld bool) {
-	switch a.goos {
-	case "darwin":
-		a.gStructOffset = 0x8a0
-	case "linux":
-		a.gStructOffset = 0xfffffffffffffff0
-		if isextld || ver.AfterOrEqual(GoVersion{1, 5, -1, 2, 0, ""}) || ver.IsDevel() {
-			a.gStructOffset += 8
-		}
-	case "windows":
-		// Use ArbitraryUserPointer (0x28) as pointer to pointer
-		// to G struct per:
-		// https://golang.org/src/runtime/cgo/gcc_windows_amd64.c
-		a.gStructOffset = 0x28
-	}
-}
-
 // PtrSize returns the size of a pointer
 // on this architecture.
 func (a *AMD64) PtrSize() int {
@@ -71,12 +49,6 @@ func (a *AMD64) BreakpointInstruction() []byte {
 // breakpoint instruction on this architecture.
 func (a *AMD64) BreakpointSize() int {
 	return a.breakInstructionLen
-}
-
-// GStructOffset returns the offset of the G
-// struct in thread local storage.
-func (a *AMD64) GStructOffset() uint64 {
-	return a.gStructOffset
 }
 
 // If DerefTLS returns true the value of regs.TLS()+GStructOffset() is a

--- a/pkg/proc/core/core.go
+++ b/pkg/proc/core/core.go
@@ -178,13 +178,6 @@ func OpenCore(corePath, exePath string) (*Process, error) {
 		p.currentThread = th
 		break
 	}
-
-	ver, isextld, err := proc.GetGoInformation(p)
-	if err != nil {
-		return nil, err
-	}
-
-	p.bi.Arch.SetGStructOffset(ver, isextld)
 	p.selectedGoroutine, _ = proc.GetG(p.CurrentThread())
 
 	return p, nil

--- a/pkg/proc/native/proc.go
+++ b/pkg/proc/native/proc.go
@@ -398,12 +398,6 @@ func initializeDebugProcess(dbp *Process, path string, attach bool) (*Process, e
 		return nil, err
 	}
 
-	ver, isextld, err := proc.GetGoInformation(dbp)
-	if err != nil {
-		return nil, err
-	}
-
-	dbp.bi.Arch.SetGStructOffset(ver, isextld)
 	// selectedGoroutine can not be set correctly by the call to updateThreadList
 	// because without calling SetGStructOffset we can not read the G struct of currentThread
 	// but without calling updateThreadList we can not examine memory to determine

--- a/pkg/proc/threads.go
+++ b/pkg/proc/threads.go
@@ -302,29 +302,22 @@ func setStepIntoBreakpoint(dbp Process, text []AsmInstruction, cond ast.Expr) er
 }
 
 func getGVariable(thread Thread) (*Variable, error) {
-	arch := thread.Arch()
 	regs, err := thread.Registers(false)
 	if err != nil {
 		return nil, err
 	}
 
-	if arch.GStructOffset() == 0 {
-		// GetG was called through SwitchThread / updateThreadList during initialization
-		// thread.dbp.arch isn't setup yet (it needs a current thread to read global variables from)
-		return nil, fmt.Errorf("g struct offset not initialized")
-	}
-
 	gaddr, hasgaddr := regs.GAddr()
 	if !hasgaddr {
-		gaddrbs := make([]byte, arch.PtrSize())
-		_, err := thread.ReadMemory(gaddrbs, uintptr(regs.TLS()+arch.GStructOffset()))
+		gaddrbs := make([]byte, thread.Arch().PtrSize())
+		_, err := thread.ReadMemory(gaddrbs, uintptr(regs.TLS()+thread.BinInfo().GStructOffset()))
 		if err != nil {
 			return nil, err
 		}
 		gaddr = binary.LittleEndian.Uint64(gaddrbs)
 	}
 
-	return newGVariable(thread, uintptr(gaddr), arch.DerefTLS())
+	return newGVariable(thread, uintptr(gaddr), thread.Arch().DerefTLS())
 }
 
 func newGVariable(thread Thread, gaddr uintptr, deref bool) (*Variable, error) {


### PR DESCRIPTION
When a Go program is externally linked, the external linker is
responsible for picking the TLS offset. It records its decision in the
runtime.tlsg symbol. Read the offset from that rather than guessing -16.

This implementation causes a regression: pre-1.5.2 (I think?) versions
will no longer work, since they apparently had a different default TLS
offset, and reading the version during initialization is quite awkward.
If you still want to support versions that old I can go back to the
previous initialization order. Maybe we should add a DW_AT_producer
attribute so that reading the version is easier.

Fixes issue #468.