### PR TITLE
proc/native: make sure debugged executable can be deleted on windows

### DIFF
--- a/cmd/dlv/dlv_test.go
+++ b/cmd/dlv/dlv_test.go
@@ -135,6 +135,7 @@ func testIssue398(t *testing.T, dlvbin string, cmds []string) (stdout, stderr []
 	return
 }
 
+// TestIssue398 verifies that the debug executable is removed after exit.
 func TestIssue398(t *testing.T) {
 	tmpdir, err := ioutil.TempDir("", "TestIssue398")
 	if err != nil {

--- a/cmd/dlv/dlv_test.go
+++ b/cmd/dlv/dlv_test.go
@@ -150,7 +150,7 @@ func TestIssue398(t *testing.T) {
 
 	testIssue398(t, dlvbin, []string{"exit"})
 
-	const hello = "hello world!\n"
+	const hello = "hello world!"
 	stdout, _ := testIssue398(t, dlvbin, []string{"continue", "exit"})
 	if !strings.Contains(string(stdout), hello) {
 		t.Errorf("stdout %q should contain %q", stdout, hello)

--- a/pkg/proc/native/proc.go
+++ b/pkg/proc/native/proc.go
@@ -4,7 +4,6 @@ import (
 	"errors"
 	"fmt"
 	"go/ast"
-	"os"
 	"runtime"
 	"sync"
 
@@ -14,9 +13,8 @@ import (
 // Process represents all of the information the debugger
 // is holding onto regarding the process we are debugging.
 type Process struct {
-	bi      proc.BinaryInfo
-	pid     int         // Process Pid
-	Process *os.Process // Pointer to process struct for the actual process we are debugging
+	bi  proc.BinaryInfo
+	pid int // Process Pid
 
 	// Breakpoint table, holds information on breakpoints.
 	// Maps instruction address to Breakpoint struct.
@@ -371,13 +369,7 @@ func (dbp *Process) FindBreakpoint(pc uint64) (*proc.Breakpoint, bool) {
 
 // Returns a new Process struct.
 func initializeDebugProcess(dbp *Process, path string) (*Process, error) {
-	process, err := os.FindProcess(dbp.pid)
-	if err != nil {
-		return nil, err
-	}
-
-	dbp.Process = process
-	err = dbp.LoadInformation(path)
+	err := dbp.LoadInformation(path)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/proc/native/proc.go
+++ b/pkg/proc/native/proc.go
@@ -444,6 +444,7 @@ func (dbp *Process) postExit() {
 	dbp.exited = true
 	close(dbp.ptraceChan)
 	close(dbp.ptraceDoneChan)
+	dbp.bi.Close()
 }
 
 func (dbp *Process) writeSoftwareBreakpoint(thread *Thread, addr uint64) error {

--- a/pkg/proc/native/proc_windows.go
+++ b/pkg/proc/native/proc_windows.go
@@ -177,7 +177,10 @@ func (dbp *Process) Kill() error {
 	// but some tests appear to Kill twice causing
 	// this to fail on second attempt.
 	_ = syscall.TerminateProcess(dbp.os.hProcess, 1)
-	dbp.exited = true
+	dbp.execPtraceFunc(func() {
+		dbp.waitForDebugEvent(waitBlocking)
+	})
+	dbp.postExit()
 	return nil
 }
 

--- a/pkg/proc/native/proc_windows.go
+++ b/pkg/proc/native/proc_windows.go
@@ -473,5 +473,7 @@ func killProcess(pid int) error {
 	if err != nil {
 		return err
 	}
+	defer p.Release()
+
 	return p.Kill()
 }


### PR DESCRIPTION
Delve opens debugged executable to read binary info it
contains, but it never closes the file. Windows will not
let you delete file that is opened. So close Process.bi
in Process.postExit, and actually call Process.postExit
from windows Process.Kill.

Also Windows sends some debugging events
(EXIT_PROCESS_DEBUG_EVENT event in particular) after Delve
calls TerminateProcess. The events need to be consumed by
debugger before debugged process will be released by
Windows. So call Process.waitForDebugEvent after
TerminateProcess in Process.Kill.

Fixes #398