### PR TITLE
Add vim-delve and clean up editor support page

### DIFF
--- a/Documentation/EditorIntegration.md
+++ b/Documentation/EditorIntegration.md
@@ -1,12 +1,30 @@
+## Editor plugins
+
 The following editor plugins for delve are available:
 
-* [Golang Plugin for IntelliJ IDEA](https://github.com/go-lang-plugin-org/go-lang-idea-plugin)
-* [JetBrains Gogland](https://www.jetbrains.com/go) - "early access" builds so far
-* [Go for Visual Studio Code](https://github.com/Microsoft/vscode-go)
-* [Emacs plugin](https://github.com/benma/go-dlv.el/)
-* [LiteIDE](https://github.com/visualfc/liteide)
+**Atom**
 * [Go Debugger for Atom](https://github.com/lloiser/go-debug)
-* [Go Debugger for NeoVim](https://github.com/jodosha/vim-godebug)
+
+**Emacs**
+* [Emacs plugin](https://github.com/benma/go-dlv.el/)
+
+**Gogland**
+* [JetBrains Gogland](https://www.jetbrains.com/go) - "early access" builds so far
+
+**IntelliJ IDEA**
+* [Golang Plugin for IntelliJ IDEA](https://github.com/go-lang-plugin-org/go-lang-idea-plugin)
+
+**Neovim**
+* [vim-delve](https://github.com/sebdah/vim-godebug)
+* [vim-godebug](https://github.com/jodosha/vim-godebug)
+
+**LiteIDE**
+* [LiteIDE](https://github.com/visualfc/liteide)
+
+**VisualStudio Code**
+* [Go for Visual Studio Code](https://github.com/Microsoft/vscode-go)
+
+## Alternative UIs
 
 The following alternative UIs for delve are available:
 


### PR DESCRIPTION
This pull request is introducing [vim-delve](https://github.com/sebdah/vim-delve) to the editor support page. It's also sorting the editors alphabetically and increases the documentation readability with more structure.