### PR TITLE
proc/eval: optimize variable lookup

### DIFF
--- a/pkg/proc/bininfo.go
+++ b/pkg/proc/bininfo.go
@@ -34,6 +34,7 @@ type BinaryInfo struct {
 	lineInfo      line.DebugLines
 	goSymTable    *gosym.Table
 	types         map[string]dwarf.Offset
+	packageVars   map[string]dwarf.Offset
 	functions     []functionDebugInfo
 	gStructOffset uint64
 

--- a/pkg/proc/variables.go
+++ b/pkg/proc/variables.go
@@ -650,18 +650,14 @@ func (scope *EvalScope) PackageVariables(cfg LoadConfig) ([]*Variable, error) {
 }
 
 func (scope *EvalScope) packageVarAddr(name string) (*Variable, error) {
-	reader := scope.DwarfReader()
-	for entry, err := reader.NextPackageVariable(); entry != nil; entry, err = reader.NextPackageVariable() {
-		if err != nil {
-			return nil, err
-		}
-
-		n, ok := entry.Val(dwarf.AttrName).(string)
-		if !ok {
-			continue
-		}
-
+	for n, off := range scope.BinInfo.packageVars {
 		if n == name || strings.HasSuffix(n, "/"+name) {
+			reader := scope.DwarfReader()
+			reader.Seek(off)
+			entry, err := reader.Next()
+			if err != nil {
+				return nil, err
+			}
 			return scope.extractVarInfoFromEntry(entry, reader)
 		}
 	}


### PR DESCRIPTION
```
proc/eval: optimize variable lookup

Variable lookup is slow because it requires a full scan of debug_info
to check for package variables, this doesn't matter much in interactive
use but can slow down evaluation of breakpoint conditions
significantly.

Providing benchmark proof for this is hard since this effect doesn't
show for small programs with small debug_info sections.

```
