### PR TITLE
cmd/dlv: bugfix: make version command actually print revision number

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,10 +2,13 @@
 UNAME=$(shell uname)
 PREFIX=github.com/derekparker/delve
 GOVERSION=$(shell go version)
+BUILD_SHA=$(shell git rev-parse HEAD)
 LLDB_SERVER=$(shell which lldb-server)
 
 ifeq "$(UNAME)" "Darwin"
-    BUILD_FLAGS=-ldflags="-s"
+    BUILD_FLAGS=-ldflags="-s -X main.Build=$(BUILD_SHA)"
+else
+    BUILD_FLAGS=-ldflags="-X main.Build=$(BUILD_SHA)"
 endif
 
 # Workaround for GO15VENDOREXPERIMENT bug (https://github.com/golang/go/issues/11659)

--- a/cmd/dlv/main.go
+++ b/cmd/dlv/main.go
@@ -9,6 +9,8 @@ import (
 var Build string
 
 func main() {
-	version.DelveVersion.Build = Build
+	if Build != "" {
+		version.DelveVersion.Build = Build
+	}
 	cmds.New(false).Execute()
 }


### PR DESCRIPTION
```
cmd/dlv: bugfix: make version command actually print revision number

```

In the meeting @hyangah pointed out that it's hard to tell which version of delve one is actually running.