### PR TITLE
Add breakpoint init functions suggestion

### DIFF
--- a/Documentation/cli/locspec.md
+++ b/Documentation/cli/locspec.md
@@ -7,5 +7,6 @@ Several delve commands take a program location as an argument, the syntax accept
 * `<line>` Specifies the line *line* in the current file
 * `+<offset>` Specifies the line *offset* lines after the current one
 * `-<offset>` Specifies the line *offset* lines before the current one
-* `<function>[:<line>]` Specifies the line *line* inside *function*. The full syntax for *function* is `<package>.(*<receiver type>).<function name>` however the only required element is the function name, everything else can be omitted as long as the expression remains unambiguous. 
+* `<function>[:<line>]` Specifies the line *line* inside *function*. The full syntax for *function* is `<package>.(*<receiver type>).<function name>` however the only required element is the function name, everything else can be omitted as long as the expression remains unambiguous. For setting a breakpoint on an init function (ex: main.init), the `<filename>:<line>` syntax should be used to break in the correct init function at the correct location.
+
 * `/<regex>/` Specifies the location of all the functions matching *regex*


### PR DESCRIPTION
This is a "fix" for the issue of being unable to see the source when setting a breakpoint on main.init.

Fixes #922