### PR TITLE
Small fixes to delve behavior when target is in an unusual state

### DIFF
--- a/pkg/proc/gdbserial/gdbserver.go
+++ b/pkg/proc/gdbserial/gdbserver.go
@@ -642,7 +642,14 @@ func (p *Process) StepInstruction() error {
 	if err != nil {
 		return err
 	}
-	return thread.SetCurrentBreakpoint()
+	err = thread.SetCurrentBreakpoint()
+	if err != nil {
+		return err
+	}
+	if g, _ := proc.GetG(thread); g != nil {
+		p.selectedGoroutine = g
+	}
+	return nil
 }
 
 func (p *Process) SwitchThread(tid int) error {

--- a/pkg/proc/native/proc.go
+++ b/pkg/proc/native/proc.go
@@ -316,7 +316,14 @@ func (dbp *Process) StepInstruction() (err error) {
 	if err != nil {
 		return err
 	}
-	return thread.SetCurrentBreakpoint()
+	err = thread.SetCurrentBreakpoint()
+	if err != nil {
+		return err
+	}
+	if g, _ := proc.GetG(thread); g != nil {
+		dbp.selectedGoroutine = g
+	}
+	return nil
 }
 
 // SwitchThread changes from current thread to the thread specified by `tid`.

--- a/pkg/proc/proc.go
+++ b/pkg/proc/proc.go
@@ -80,12 +80,8 @@ func Next(dbp Process) (err error) {
 	}
 
 	if err = next(dbp, false); err != nil {
-		switch err.(type) {
-		case ThreadBlockedError, NoReturnAddr: // Noop
-		default:
-			dbp.ClearInternalBreakpoints()
-			return
-		}
+		dbp.ClearInternalBreakpoints()
+		return
 	}
 
 	return Continue(dbp)

--- a/pkg/proc/proc_test.go
+++ b/pkg/proc/proc_test.go
@@ -2969,6 +2969,9 @@ func TestIssue893(t *testing.T) {
 		if _, ok := err.(*frame.NoFDEForPCError); ok {
 			return
 		}
+		if _, ok := err.(proc.ThreadBlockedError); ok {
+			return
+		}
 		assertNoError(err, t, "Next")
 	})
 }

--- a/pkg/proc/threads.go
+++ b/pkg/proc/threads.go
@@ -407,7 +407,7 @@ func onRuntimeBreakpoint(thread Thread) bool {
 func onNextGoroutine(thread Thread, breakpoints map[uint64]*Breakpoint) (bool, error) {
 	var bp *Breakpoint
 	for i := range breakpoints {
-		if breakpoints[i].Internal() {
+		if breakpoints[i].Internal() && breakpoints[i].Cond != nil {
 			bp = breakpoints[i]
 			break
 		}

--- a/pkg/proc/threads.go
+++ b/pkg/proc/threads.go
@@ -112,7 +112,8 @@ func next(dbp Process, stepInto bool) error {
 		}
 	}()
 
-	csource := filepath.Ext(topframe.Current.File) != ".go"
+	ext := filepath.Ext(topframe.Current.File)
+	csource := ext != ".go" && ext != ".s"
 	var thread MemoryReadWriter = curthread
 	var regs Registers
 	if selg != nil && selg.Thread != nil {

--- a/pkg/proc/threads.go
+++ b/pkg/proc/threads.go
@@ -4,7 +4,6 @@ import (
 	"debug/gosym"
 	"encoding/binary"
 	"errors"
-	"fmt"
 	"go/ast"
 	"go/token"
 	"path/filepath"
@@ -127,12 +126,6 @@ func next(dbp Process, stepInto bool) error {
 	text, err := disassemble(thread, regs, dbp.Breakpoints(), dbp.BinInfo(), topframe.FDE.Begin(), topframe.FDE.End())
 	if err != nil && stepInto {
 		return err
-	}
-
-	for i := range text {
-		if text[i].Inst == nil {
-			fmt.Printf("error at instruction %d\n", i)
-		}
 	}
 
 	sameGCond := SameGoroutineCondition(selg)

--- a/pkg/proc/threads.go
+++ b/pkg/proc/threads.go
@@ -250,10 +250,11 @@ func next(dbp Process, stepInto bool) error {
 				// this frame and on the return frame.
 				bp.Cond = sameOrRetFrameCond
 			}
-		} else {
-			return err
 		}
+		// Return address could be wrong, if we are unable to set a breakpoint
+		// there it's ok.
 	}
+
 	if bp, _, _ := curthread.Breakpoint(); bp == nil {
 		curthread.SetCurrentBreakpoint()
 	}

--- a/pkg/terminal/command.go
+++ b/pkg/terminal/command.go
@@ -1210,6 +1210,10 @@ func printStack(stack []api.Stackframe, ind string) {
 	s := ind + strings.Repeat(" ", d+2+len(ind))
 
 	for i := range stack {
+		if stack[i].Err != "" {
+			fmt.Printf("%serror: %s\n", s, stack[i].Err)
+			continue
+		}
 		name := "(nil)"
 		if stack[i].Function != nil {
 			name = stack[i].Function.Name

--- a/pkg/terminal/command_test.go
+++ b/pkg/terminal/command_test.go
@@ -216,7 +216,7 @@ func TestExecuteFile(t *testing.T) {
 
 func TestIssue354(t *testing.T) {
 	printStack([]api.Stackframe{}, "")
-	printStack([]api.Stackframe{{api.Location{PC: 0, File: "irrelevant.go", Line: 10, Function: nil}, nil, nil, 0, nil}}, "")
+	printStack([]api.Stackframe{{api.Location{PC: 0, File: "irrelevant.go", Line: 10, Function: nil}, nil, nil, 0, ""}}, "")
 }
 
 func TestIssue411(t *testing.T) {

--- a/pkg/terminal/command_test.go
+++ b/pkg/terminal/command_test.go
@@ -216,7 +216,7 @@ func TestExecuteFile(t *testing.T) {
 
 func TestIssue354(t *testing.T) {
 	printStack([]api.Stackframe{}, "")
-	printStack([]api.Stackframe{{api.Location{PC: 0, File: "irrelevant.go", Line: 10, Function: nil}, nil, nil, 0}}, "")
+	printStack([]api.Stackframe{{api.Location{PC: 0, File: "irrelevant.go", Line: 10, Function: nil}, nil, nil, 0, nil}}, "")
 }
 
 func TestIssue411(t *testing.T) {

--- a/service/api/types.go
+++ b/service/api/types.go
@@ -121,6 +121,7 @@ type Stackframe struct {
 	Locals      []Variable
 	Arguments   []Variable
 	FrameOffset int64
+	Err         string
 }
 
 func (frame *Stackframe) Var(name string) *Variable {

--- a/service/debugger/debugger.go
+++ b/service/debugger/debugger.go
@@ -538,7 +538,7 @@ func (d *Debugger) Command(command *api.DebuggerCommand) (*api.DebuggerState, er
 	}
 
 	if err != nil {
-		if exitedErr, exited := err.(proc.ProcessExitedError); withBreakpointInfo && exited {
+		if exitedErr, exited := err.(proc.ProcessExitedError); (command.Name == api.Continue || command.Name == api.Rewind) && exited {
 			state := &api.DebuggerState{}
 			state.Exited = true
 			state.ExitStatus = exitedErr.Status

--- a/service/debugger/debugger.go
+++ b/service/debugger/debugger.go
@@ -857,6 +857,9 @@ func (d *Debugger) convertStacktrace(rawlocs []proc.Stackframe, cfg *proc.LoadCo
 			Location:    api.ConvertLocation(rawlocs[i].Call),
 			FrameOffset: rawlocs[i].CFA - int64(rawlocs[i].StackHi),
 		}
+		if rawlocs[i].Err != nil {
+			frame.Err = rawlocs[i].Err.Error()
+		}
 		if cfg != nil && rawlocs[i].Current.Fn != nil {
 			var err error
 			scope := proc.FrameToScope(d.target, rawlocs[i])

--- a/service/test/integration2_test.go
+++ b/service/test/integration2_test.go
@@ -1371,3 +1371,16 @@ func TestClientServer_collectBreakpointInfoOnNext(t *testing.T) {
 		}
 	})
 }
+
+func TestClientServer_collectBreakpointInfoError(t *testing.T) {
+	protest.AllowRecording(t)
+	withTestClient2("testnextprog", t, func(c service.Client) {
+		_, err := c.CreateBreakpoint(&api.Breakpoint{
+			Addr:       findLocationHelper(t, c, "testnextprog.go:23", false, 1, 0)[0],
+			Variables:  []string{"nonexistentvariable", "j"},
+			LoadLocals: &normalLoadConfig})
+		assertNoError(err, t, "CreateBreakpoint()")
+		state := <-c.Continue()
+		assertNoError(state.Err, t, "Continue()")
+	})
+}


### PR DESCRIPTION
This mostly came out of issue #893. I don't think it's plausible that a user will be able to next all the way from the start of the process to main, while the runtime is setting up the environment (too many unusual things happen), however there were some legitimate bugs there.

This also fixes issue #868 which is mostly harmless but sometimes makes travis fail.

```
proc: treat assembly files like go code in Next

proc/native,proc/gdbserial: set selectedGoroutine after StepInstruction

When stepping through runtime sometimes the current goroutine will
change. It is impossible to handle this in Next, Step and StepOut but
StepInstruction can reset the current goroutine correctly.

service/debugger: revert Next/StepOut/Step behavior on exit

When the process exits during we used to return an error, but after
commit 8bbcc89711f4263e7bb2b6d9c00fa96d0294e56f we move the error into
state.Err. Revert this behavior change.

proc: in Next return address could be invalid, ignore errors setting it

Updates #893

proc/native, proc/gdbserial: StepInstruction without goroutine

proc.Process.StepInstruction should work even if there is no goroutine
selected.

debugger: do not fail continue when breakpoint var can't be evaluated

If one of the expressions that are automatically evaluated when a
breakpoint is hit can't be evaluated breakpoint information collection
should continue and the error should be returned for that specific
expression instead of the whole command.

proc: bugfix: onNextGoroutine and breakpoints with nil condition

Next will add internal breakpoints with nil condition if it can't find
the current goroutine (possibly because there isn't a current goroutine
because the runtime hasn't been initialized yet).
onNextGoroutine should skip breakpoints with nil condition, otherwise
we'll end up with an internal debugger error trying to walk a nil
expression.

Updates #893

proc: tolerate memory read errors during stacktrace

When there's a error reading the stack trace the call stack itself
could be corrupted and we should return the partial stacktrace that we
have.

Fixes #868

```
