### PR TITLE
pkg/proc: return proper error when process has exited

### DIFF
--- a/pkg/proc/disasm.go
+++ b/pkg/proc/disasm.go
@@ -21,6 +21,9 @@ const (
 // If currentGoroutine is set and thread is stopped at a CALL instruction Disassemble will evaluate the argument of the CALL instruction using the thread's registers
 // Be aware that the Bytes field of each returned instruction is a slice of a larger array of size endPC - startPC
 func Disassemble(dbp Process, g *G, startPC, endPC uint64) ([]AsmInstruction, error) {
+	if dbp.Exited() {
+		return nil, &ProcessExitedError{Pid: dbp.Pid()}
+	}
 	if g == nil {
 		ct := dbp.CurrentThread()
 		regs, _ := ct.Registers(false)

--- a/pkg/proc/native/proc.go
+++ b/pkg/proc/native/proc.go
@@ -173,7 +173,7 @@ func (dbp *Process) LoadInformation(path string) error {
 // sends SIGSTOP to all threads.
 func (dbp *Process) RequestManualStop() error {
 	if dbp.exited {
-		return &proc.ProcessExitedError{}
+		return &proc.ProcessExitedError{Pid: dbp.Pid()}
 	}
 	dbp.haltMu.Lock()
 	defer dbp.haltMu.Unlock()
@@ -241,7 +241,7 @@ func (dbp *Process) SetBreakpoint(addr uint64, kind proc.BreakpointKind, cond as
 // ClearBreakpoint clears the breakpoint at addr.
 func (dbp *Process) ClearBreakpoint(addr uint64) (*proc.Breakpoint, error) {
 	if dbp.exited {
-		return nil, &proc.ProcessExitedError{}
+		return nil, &proc.ProcessExitedError{Pid: dbp.Pid()}
 	}
 	bp, ok := dbp.FindBreakpoint(addr)
 	if !ok {
@@ -259,7 +259,7 @@ func (dbp *Process) ClearBreakpoint(addr uint64) (*proc.Breakpoint, error) {
 
 func (dbp *Process) ContinueOnce() (proc.Thread, error) {
 	if dbp.exited {
-		return nil, &proc.ProcessExitedError{}
+		return nil, &proc.ProcessExitedError{Pid: dbp.Pid()}
 	}
 
 	if err := dbp.resume(); err != nil {
@@ -307,7 +307,7 @@ func (dbp *Process) StepInstruction() (err error) {
 	}
 	dbp.allGCache = nil
 	if dbp.exited {
-		return &proc.ProcessExitedError{}
+		return &proc.ProcessExitedError{Pid: dbp.Pid()}
 	}
 	thread.clearBreakpointState()
 	err = thread.StepInstruction()
@@ -327,7 +327,7 @@ func (dbp *Process) StepInstruction() (err error) {
 // SwitchThread changes from current thread to the thread specified by `tid`.
 func (dbp *Process) SwitchThread(tid int) error {
 	if dbp.exited {
-		return &proc.ProcessExitedError{}
+		return &proc.ProcessExitedError{Pid: dbp.Pid()}
 	}
 	if th, ok := dbp.threads[tid]; ok {
 		dbp.currentThread = th
@@ -341,7 +341,7 @@ func (dbp *Process) SwitchThread(tid int) error {
 // running the specified goroutine.
 func (dbp *Process) SwitchGoroutine(gid int) error {
 	if dbp.exited {
-		return &proc.ProcessExitedError{}
+		return &proc.ProcessExitedError{Pid: dbp.Pid()}
 	}
 	g, err := proc.FindGoroutine(dbp, gid)
 	if err != nil {
@@ -361,7 +361,7 @@ func (dbp *Process) SwitchGoroutine(gid int) error {
 // Halt stops all threads.
 func (dbp *Process) Halt() (err error) {
 	if dbp.exited {
-		return &proc.ProcessExitedError{}
+		return &proc.ProcessExitedError{Pid: dbp.Pid()}
 	}
 	for _, th := range dbp.threads {
 		if err := th.Halt(); err != nil {

--- a/pkg/proc/stack.go
+++ b/pkg/proc/stack.go
@@ -42,7 +42,7 @@ type Stackframe struct {
 	Err error
 }
 
-// Stacktrace returns the stack trace for thread.
+// ThreadStacktrace returns the stack trace for thread.
 // Note the locations in the array are return addresses not call addresses.
 func ThreadStacktrace(thread Thread, depth int) ([]Stackframe, error) {
 	regs, err := thread.Registers(false)


### PR DESCRIPTION
Instead of panicing for sending on a closed channel, detect that the
process has exited and return a proper error message.

This patch also cleans up some spots where the Pid is omitted from the
error.

Fixes #920