### PR TITLE
tests: remove rr trace directory after running tests

### DIFF
--- a/pkg/terminal/command_test.go
+++ b/pkg/terminal/command_test.go
@@ -112,8 +112,9 @@ func withTestTerminal(name string, t testing.TB, fn func(*FakeTerminal)) {
 	}
 	client := rpc2.NewClient(listener.Addr().String())
 	defer func() {
+		dir, _ := client.TraceDirectory()
 		client.Detach(true)
-		if dir, _ := client.TraceDirectory(); dir != "" {
+		if dir != "" {
 			test.SafeRemoveAll(dir)
 		}
 	}()

--- a/service/test/integration2_test.go
+++ b/service/test/integration2_test.go
@@ -56,8 +56,9 @@ func withTestClient2(name string, t *testing.T, fn func(c service.Client)) {
 	}
 	client := rpc2.NewClient(listener.Addr().String())
 	defer func() {
+		dir, _ := client.TraceDirectory()
 		client.Detach(true)
-		if dir, _ := client.TraceDirectory(); dir != "" {
+		if dir != "" {
 			protest.SafeRemoveAll(dir)
 		}
 	}()


### PR DESCRIPTION
```
tests: remove rr trace directory after running tests

Can't get the trace directory from the server after we disconnect from
it.

```
