### PR TITLE
Documentation: After the go1.9 support PR delve no longer builds on <1.7.

### DIFF
--- a/Documentation/installation/README.md
+++ b/Documentation/installation/README.md
@@ -1,6 +1,6 @@
 # Installation
 
-Directions for installing Delve on all supported platforms is provided here. Please note you *must* have Go 1.5 or higher installed. Also, if using Go 1.5 you must set `GO15VENDOREXPERIMENT=1` before attempting to install.
+Directions for installing Delve on all supported platforms is provided here. Please note you *must* have Go 1.7 or higher installed.
 
 - [OSX](osx/install.md)
 - [Linux](linux/install.md)


### PR DESCRIPTION
```
Documentation: After the go1.9 support PR delve no longer builds on <1.7.

```
