### PR TITLE
proc/tests: fix intermittent test stall on windows

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -65,7 +65,7 @@ endif
 else
 	go test -p 1 $(TEST_FLAGS) $(BUILD_FLAGS) $(ALL_PACKAGES)
 endif
-ifneq "$(shell which lldb-server)" ""
+ifneq "$(shell which lldb-server 2>/dev/null)" ""
 	@echo
 	@echo 'Testing LLDB backend (proc)'
 	go test $(TEST_FLAGS) $(BUILD_FLAGS) $(PREFIX)/pkg/proc -backend=lldb
@@ -76,7 +76,7 @@ ifneq "$(shell which lldb-server)" ""
 	@echo 'Testing LLDB backend (terminal)'
 	go test $(TEST_FLAGS) $(BUILD_FLAGS) $(PREFIX)/pkg/terminal -backend=lldb
 endif
-ifneq "$(shell which rr)" ""
+ifneq "$(shell which rr 2>/dev/null)" ""
 	@echo
 	@echo 'Testing Mozilla RR backend (proc)'
 	go test $(TEST_FLAGS) $(BUILD_FLAGS) $(PREFIX)/pkg/proc -backend=rr

--- a/pkg/proc/native/proc_windows.go
+++ b/pkg/proc/native/proc_windows.go
@@ -186,7 +186,7 @@ func (dbp *Process) Kill() error {
 	_ = syscall.TerminateProcess(dbp.os.hProcess, 1)
 
 	dbp.execPtraceFunc(func() {
-		dbp.waitForDebugEvent(waitBlocking)
+		dbp.waitForDebugEvent(waitBlocking | waitDontHandleExceptions)
 	})
 
 	p.Wait()
@@ -237,6 +237,7 @@ type waitForDebugEventFlags int
 const (
 	waitBlocking waitForDebugEventFlags = 1 << iota
 	waitSuspendNewThreads
+	waitDontHandleExceptions
 )
 
 func (dbp *Process) waitForDebugEvent(flags waitForDebugEventFlags) (threadID, exitCode int, err error) {
@@ -300,6 +301,10 @@ func (dbp *Process) waitForDebugEvent(flags waitForDebugEventFlags) (threadID, e
 		case _RIP_EVENT:
 			break
 		case _EXCEPTION_DEBUG_EVENT:
+			if flags&waitDontHandleExceptions != 0 {
+				continueStatus = _DBG_EXCEPTION_NOT_HANDLED
+				break
+			}
 			exception := (*_EXCEPTION_DEBUG_INFO)(unionPtr)
 			tid := int(debugEvent.ThreadId)
 


### PR DESCRIPTION
```
proc/tests: fix intermittent test stall on windows

While we are waiting for the process to exit in native.(*Process).Kill
we could receive queued exception events, those must be continued or
the wait will never finish.

```
