### PR TITLE
proc/gdbserial: automatically retrieve exe path on attach on macOS

### DIFF
--- a/pkg/proc/gdbserial/gdbserver_conn.go
+++ b/pkg/proc/gdbserial/gdbserver_conn.go
@@ -3,6 +3,8 @@ package gdbserial
 import (
 	"bufio"
 	"bytes"
+	"debug/macho"
+	"encoding/json"
 	"encoding/xml"
 	"errors"
 	"fmt"
@@ -582,7 +584,7 @@ func (conn *gdbConn) waitForvContStop(context string, threadID string, tu *threa
 	failed := false
 	for {
 		conn.conn.SetReadDeadline(time.Now().Add(heartbeatInterval))
-		resp, err := conn.recv(nil, context)
+		resp, err := conn.recv(nil, context, false)
 		conn.conn.SetReadDeadline(time.Time{})
 		if neterr, isneterr := err.(net.Error); isneterr && neterr.Timeout() {
 			// Debugserver sometimes forgets to inform us that inferior stopped,
@@ -935,6 +937,36 @@ func (conn *gdbConn) qRRCmd(args ...string) (string, error) {
 	return string(data), nil
 }
 
+type imageList struct {
+	Images []imageDescription `json:"images"`
+}
+
+type imageDescription struct {
+	Pathname   string     `json:"pathname"`
+	MachHeader machHeader `json:"mach_header"`
+}
+
+type machHeader struct {
+	FileType macho.Type `json:"filetype"`
+}
+
+// getLoadedDynamicLibraries executes jGetLoadedDynamicLibrariesInfos which
+// returns the list of loaded dynamic libraries
+func (conn *gdbConn) getLoadedDynamicLibraries() ([]imageDescription, error) {
+	cmd := []byte("$jGetLoadedDynamicLibrariesInfos:{\"fetch_all_solibs\":true}")
+	if err := conn.send(cmd); err != nil {
+		return nil, err
+	}
+	resp, err := conn.recv(cmd, "get dynamic libraries", true)
+	if err != nil {
+		return nil, err
+	}
+	var images imageList
+	err = json.Unmarshal(resp, &images)
+	fmt.Printf("err %v\n", err)
+	return images.Images, err
+}
+
 // exec executes a message to the stub and reads a response.
 // The details of the wire protocol are described here:
 //  https://sourceware.org/gdb/onlinedocs/gdb/Overview.html#Overview
@@ -942,8 +974,7 @@ func (conn *gdbConn) exec(cmd []byte, context string) ([]byte, error) {
 	if err := conn.send(cmd); err != nil {
 		return nil, err
 	}
-	return conn.recv(cmd, context)
-
+	return conn.recv(cmd, context, false)
 }
 
 var hexdigit = []byte{'0', '1', '2', '3', '4', '5', '6', '7', '8', '9', 'a', 'b', 'c', 'd', 'e', 'f'}
@@ -988,7 +1019,7 @@ func (conn *gdbConn) send(cmd []byte) error {
 	return nil
 }
 
-func (conn *gdbConn) recv(cmd []byte, context string) (resp []byte, err error) {
+func (conn *gdbConn) recv(cmd []byte, context string, binary bool) (resp []byte, err error) {
 	attempt := 0
 	for {
 		var err error
@@ -1044,7 +1075,11 @@ func (conn *gdbConn) recv(cmd []byte, context string) (resp []byte, err error) {
 		conn.sendack('-')
 	}
 
-	conn.inbuf, resp = wiredecode(resp, conn.inbuf)
+	if binary {
+		conn.inbuf, resp = binarywiredecode(resp, conn.inbuf)
+	} else {
+		conn.inbuf, resp = wiredecode(resp, conn.inbuf)
+	}
 
 	if len(resp) == 0 || resp[0] == 'E' {
 		cmdstr := ""
@@ -1101,6 +1136,7 @@ func wiredecode(in, buf []byte) (newbuf, msg []byte) {
 				buf = append(buf, ch)
 			} else {
 				buf = append(buf, in[i+1]^0x20)
+				i++
 			}
 		case ':':
 			buf = append(buf, ch)
@@ -1121,6 +1157,36 @@ func wiredecode(in, buf []byte) (newbuf, msg []byte) {
 				}
 				i++
 			}
+		default:
+			buf = append(buf, ch)
+		}
+	}
+	return buf, buf[start:]
+}
+
+// binarywiredecode is like wiredecode but decodes the wire encoding for
+// binary packets, such as the 'x' and 'X' packets as well as all the json
+// packets used by lldb/debugserver.
+func binarywiredecode(in, buf []byte) (newbuf, msg []byte) {
+	if buf != nil {
+		buf = buf[:0]
+	} else {
+		buf = make([]byte, 0, 256)
+	}
+
+	start := 1
+
+	for i := 0; i < len(in); i++ {
+		switch ch := in[i]; ch {
+		case '}': // escape
+			if i+1 >= len(in) {
+				buf = append(buf, ch)
+			} else {
+				buf = append(buf, in[i+1]^0x20)
+				i++
+			}
+		case '#': // end of packet
+			return buf, buf[start:]
 		default:
 			buf = append(buf, ch)
 		}

--- a/service/debugger/debugger.go
+++ b/service/debugger/debugger.go
@@ -136,15 +136,9 @@ func (d *Debugger) Attach(pid int, path string) (proc.Process, error) {
 	case "native":
 		return native.Attach(pid)
 	case "lldb":
-		if runtime.GOOS == "darwin" && path == "" {
-			return nil, ErrNoAttachPath
-		}
 		return gdbserial.LLDBAttach(pid, path)
 	case "default":
 		if runtime.GOOS == "darwin" {
-			if path == "" {
-				return nil, ErrNoAttachPath
-			}
 			return gdbserial.LLDBAttach(pid, path)
 		}
 		return native.Attach(pid)


### PR DESCRIPTION
```
proc/gdbserial: automatically retrieve exe path on attach on macOS

debugserver doesn't support qXfer:exec-file:read, and it doesn't return
the executable path in the response to qProcessInfoPID, however we can
find out the executable path by using jGetLoadedDynamicLibrariesInfos.

```
