### PR TITLE
proc/gdbserial: automatically retrieve exe path on attach on macOS

### DIFF
--- a/service/debugger/debugger.go
+++ b/service/debugger/debugger.go
@@ -136,15 +136,9 @@ func (d *Debugger) Attach(pid int, path string) (proc.Process, error) {
 	case "native":
 		return native.Attach(pid)
 	case "lldb":
-		if runtime.GOOS == "darwin" && path == "" {
-			return nil, ErrNoAttachPath
-		}
 		return gdbserial.LLDBAttach(pid, path)
 	case "default":
 		if runtime.GOOS == "darwin" {
-			if path == "" {
-				return nil, ErrNoAttachPath
-			}
 			return gdbserial.LLDBAttach(pid, path)
 		}
 		return native.Attach(pid)


### PR DESCRIPTION
```
proc/gdbserial: automatically retrieve exe path on attach on macOS

debugserver doesn't support qXfer:exec-file:read, and it doesn't return
the executable path in the response to qProcessInfoPID, however we can
find out the executable path by using jGetLoadedDynamicLibrariesInfos.

```
