### PR TITLE
proc/variables: distinguish between nil and empty slices and maps

### DIFF
--- a/_fixtures/testvariables2.go
+++ b/_fixtures/testvariables2.go
@@ -232,6 +232,9 @@ func main() {
 	var tm truncatedMap
 	tm.v = []map[string]astruct{m1}
 
+	emptyslice := []string{}
+	emptymap := make(map[string]string)
+
 	var amb1 = 1
 	runtime.Breakpoint()
 	for amb1 := 0; amb1 < 10; amb1++ {
@@ -239,5 +242,5 @@ func main() {
 	}
 
 	runtime.Breakpoint()
-	fmt.Println(i1, i2, i3, p1, amb1, s1, s3, a1, p2, p3, s2, as1, str1, f1, fn1, fn2, nilslice, nilptr, ch1, chnil, m1, mnil, m2, m3, up1, i4, i5, i6, err1, err2, errnil, iface1, iface2, ifacenil, arr1, parr, cpx1, const1, iface3, iface4, recursive1, recursive1.x, iface5, iface2fn1, iface2fn2, bencharr, benchparr, mapinf, mainMenu, b, b2, sd, anonstruct1, anonstruct2, anoniface1, anonfunc, mapanonstruct1, ifacearr, efacearr, ni8, ni16, ni32, pinf, ninf, nan, zsvmap, zsslice, zsvar, tm, errtypednil)
+	fmt.Println(i1, i2, i3, p1, amb1, s1, s3, a1, p2, p3, s2, as1, str1, f1, fn1, fn2, nilslice, nilptr, ch1, chnil, m1, mnil, m2, m3, up1, i4, i5, i6, err1, err2, errnil, iface1, iface2, ifacenil, arr1, parr, cpx1, const1, iface3, iface4, recursive1, recursive1.x, iface5, iface2fn1, iface2fn2, bencharr, benchparr, mapinf, mainMenu, b, b2, sd, anonstruct1, anonstruct2, anoniface1, anonfunc, mapanonstruct1, ifacearr, efacearr, ni8, ni16, ni32, pinf, ninf, nan, zsvmap, zsslice, zsvar, tm, errtypednil, emptyslice, emptymap)
 }

--- a/service/api/conversions.go
+++ b/service/api/conversions.go
@@ -121,6 +121,7 @@ func ConvertVar(v *proc.Variable) *Variable {
 		Len:      v.Len,
 		Cap:      v.Cap,
 		Flags:    VariableFlags(v.Flags),
+		Base:     v.Base,
 	}
 
 	r.Type = prettyTypeName(v.DwarfType)

--- a/service/api/prettyprint.go
+++ b/service/api/prettyprint.go
@@ -132,6 +132,10 @@ func (v *Variable) writeSliceTo(buf io.Writer, newlines, includeType bool, inden
 	if includeType {
 		fmt.Fprintf(buf, "%s len: %d, cap: %d, ", v.Type, v.Len, v.Cap)
 	}
+	if v.Base == 0 && len(v.Children) == 0 {
+		fmt.Fprintf(buf, "nil")
+		return
+	}
 	v.writeSliceOrArrayTo(buf, newlines, indent)
 }
 
@@ -185,6 +189,10 @@ func (v *Variable) writeStructTo(buf io.Writer, newlines, includeType bool, inde
 func (v *Variable) writeMapTo(buf io.Writer, newlines, includeType bool, indent string) {
 	if includeType {
 		fmt.Fprintf(buf, "%s ", v.Type)
+	}
+	if v.Base == 0 && len(v.Children) == 0 {
+		fmt.Fprintf(buf, "nil")
+		return
 	}
 
 	nl := newlines && (len(v.Children) > 0)

--- a/service/api/types.go
+++ b/service/api/types.go
@@ -197,6 +197,12 @@ type Variable struct {
 	// The other length cap applied to this field is related to maximum recursion depth, when the maximum recursion depth is reached this field is left empty, contrary to the previous one this cap also applies to structs (otherwise structs will always have all their member fields returned)
 	Children []Variable `json:"children"`
 
+	// Base address of arrays, Base address of the backing array for slices (0 for nil slices)
+	// Base address of the backing byte array for strings
+	// address of the struct backing chan and map variables
+	// address of the function entry point for function variables (0 for nil function pointers)
+	Base uintptr `json:"base"`
+
 	// Unreadable addresses will have this field set
 	Unreadable string `json:"unreadable"`
 }

--- a/service/test/variables_test.go
+++ b/service/test/variables_test.go
@@ -642,7 +642,7 @@ func TestEvalExpression(t *testing.T) {
 		{"nil+1", false, "", "", "", fmt.Errorf("operator + can not be applied to \"nil\"")},
 		{"fn1", false, "main.afunc", "main.afunc", "main.functype", nil},
 		{"fn2", false, "nil", "nil", "main.functype", nil},
-		{"nilslice", false, "[]int len: 0, cap: 0, []", "[]int len: 0, cap: 0, []", "[]int", nil},
+		{"nilslice", false, "[]int len: 0, cap: 0, nil", "[]int len: 0, cap: 0, nil", "[]int", nil},
 		{"fn1 == fn2", false, "", "", "", fmt.Errorf("can not compare func variables")},
 		{"fn1 == nil", false, "false", "false", "", nil},
 		{"fn1 != nil", false, "true", "true", "", nil},
@@ -710,6 +710,10 @@ func TestEvalExpression(t *testing.T) {
 		{"zsslice", false, `[]struct {} len: 3, cap: 3, [{},{},{}]`, `[]struct {} len: 3, cap: 3, [...]`, "[]struct {}", nil},
 		{"zsvmap", false, `map[string]struct {} ["testkey": {}, ]`, `map[string]struct {} [...]`, "map[string]struct {}", nil},
 		{"tm", false, "main.truncatedMap {v: []map[string]main.astruct len: 1, cap: 1, [[...]]}", "main.truncatedMap {v: []map[string]main.astruct len: 1, cap: 1, [...]}", "main.truncatedMap", nil},
+
+		{"emptyslice", false, `[]string len: 0, cap: 0, []`, `[]string len: 0, cap: 0, []`, "[]string", nil},
+		{"emptymap", false, `map[string]string []`, `map[string]string []`, "map[string]string", nil},
+		{"mnil", false, `map[string]main.astruct nil`, `map[string]main.astruct nil`, "map[string]main.astruct", nil},
 	}
 
 	ver, _ := goversion.Parse(runtime.Version())


### PR DESCRIPTION
```
proc/variables: distinguish between nil and empty slices and maps

Fixes #959

```
