### PR TITLE
proc/eval: support more type casts

### DIFF
--- a/Documentation/cli/expr.md
+++ b/Documentation/cli/expr.md
@@ -5,7 +5,8 @@ Delve can evaluate a subset of go expression language, specifically the followin
 - All (binary and unary) on basic types except <-, ++ and --
 - Comparison operators on any type
 - Type casts between numeric types
-- Type casts of integer constants into any pointer type
+- Type casts of integer constants into any pointer type and vice versa
+- Type casts between string, []byte and []rune
 - Struct member access (i.e. `somevar.memberfield`)
 - Slicing and indexing operators on arrays, slices and strings
 - Map access

--- a/_fixtures/testvariables2.go
+++ b/_fixtures/testvariables2.go
@@ -235,6 +235,9 @@ func main() {
 	emptyslice := []string{}
 	emptymap := make(map[string]string)
 
+	byteslice := []byte{116, 195, 168, 115, 116}
+	runeslice := []rune{116, 232, 115, 116}
+
 	var amb1 = 1
 	runtime.Breakpoint()
 	for amb1 := 0; amb1 < 10; amb1++ {
@@ -242,5 +245,5 @@ func main() {
 	}
 
 	runtime.Breakpoint()
-	fmt.Println(i1, i2, i3, p1, amb1, s1, s3, a1, p2, p3, s2, as1, str1, f1, fn1, fn2, nilslice, nilptr, ch1, chnil, m1, mnil, m2, m3, up1, i4, i5, i6, err1, err2, errnil, iface1, iface2, ifacenil, arr1, parr, cpx1, const1, iface3, iface4, recursive1, recursive1.x, iface5, iface2fn1, iface2fn2, bencharr, benchparr, mapinf, mainMenu, b, b2, sd, anonstruct1, anonstruct2, anoniface1, anonfunc, mapanonstruct1, ifacearr, efacearr, ni8, ni16, ni32, pinf, ninf, nan, zsvmap, zsslice, zsvar, tm, errtypednil, emptyslice, emptymap)
+	fmt.Println(i1, i2, i3, p1, amb1, s1, s3, a1, p2, p3, s2, as1, str1, f1, fn1, fn2, nilslice, nilptr, ch1, chnil, m1, mnil, m2, m3, up1, i4, i5, i6, err1, err2, errnil, iface1, iface2, ifacenil, arr1, parr, cpx1, const1, iface3, iface4, recursive1, recursive1.x, iface5, iface2fn1, iface2fn2, bencharr, benchparr, mapinf, mainMenu, b, b2, sd, anonstruct1, anonstruct2, anoniface1, anonfunc, mapanonstruct1, ifacearr, efacearr, ni8, ni16, ni32, pinf, ninf, nan, zsvmap, zsslice, zsvar, tm, errtypednil, emptyslice, emptymap, byteslice, runeslice)
 }

--- a/pkg/proc/types.go
+++ b/pkg/proc/types.go
@@ -81,6 +81,32 @@ func (bi *BinaryInfo) findTypeExpr(expr ast.Expr) (godwarf.Type, error) {
 		}
 		return pointerTo(ptyp, bi.Arch), nil
 	}
+	if anode, ok := expr.(*ast.ArrayType); ok {
+		// Byte array types (i.e. [N]byte) are only present in DWARF if they are
+		// used by the program, but it's convenient to make all of them available
+		// to the user so that they can be used to read arbitrary memory, byte by
+		// byte.
+
+		alen, litlen := anode.Len.(*ast.BasicLit)
+		if litlen && alen.Kind == token.INT {
+			n, _ := strconv.Atoi(alen.Value)
+			switch exprToString(anode.Elt) {
+			case "byte", "uint8":
+				btyp, err := bi.findType("uint8")
+				if err != nil {
+					return nil, err
+				}
+				return &godwarf.ArrayType{
+					CommonType: godwarf.CommonType{
+						ReflectKind: reflect.Array,
+						ByteSize:    int64(n),
+						Name:        fmt.Sprintf("[%d]uint8", n)},
+					Type:          btyp,
+					StrideBitSize: 8,
+					Count:         int64(n)}, nil
+			}
+		}
+	}
 	return bi.findType(exprToString(expr))
 }
 

--- a/service/api/prettyprint.go
+++ b/service/api/prettyprint.go
@@ -34,7 +34,7 @@ func (v *Variable) writeTo(buf io.Writer, top, newlines, includeType bool, inden
 		return
 	}
 
-	if !top && v.Addr == 0 {
+	if !top && v.Addr == 0 && v.Value == "" {
 		if includeType && v.Type != "void" {
 			fmt.Fprintf(buf, "%s nil", v.Type)
 		} else {

--- a/service/test/variables_test.go
+++ b/service/test/variables_test.go
@@ -714,6 +714,19 @@ func TestEvalExpression(t *testing.T) {
 		{"emptyslice", false, `[]string len: 0, cap: 0, []`, `[]string len: 0, cap: 0, []`, "[]string", nil},
 		{"emptymap", false, `map[string]string []`, `map[string]string []`, "map[string]string", nil},
 		{"mnil", false, `map[string]main.astruct nil`, `map[string]main.astruct nil`, "map[string]main.astruct", nil},
+
+		// conversions between string/[]byte/[]rune (issue #548)
+		{"runeslice", true, `[]int32 len: 4, cap: 4, [116,232,115,116]`, `[]int32 len: 4, cap: 4, [...]`, "[]int32", nil},
+		{"byteslice", true, `[]uint8 len: 5, cap: 5, [116,195,168,115,116]`, `[]uint8 len: 5, cap: 5, [...]`, "[]uint8", nil},
+		{"[]byte(str1)", false, `[]uint8 len: 11, cap: 11, [48,49,50,51,52,53,54,55,56,57,48]`, `[]uint8 len: 11, cap: 11, [48,49,50,51,52,53,54,55,56,57,48]`, "[]uint8", nil},
+		{"[]uint8(str1)", false, `[]uint8 len: 11, cap: 11, [48,49,50,51,52,53,54,55,56,57,48]`, `[]uint8 len: 11, cap: 11, [48,49,50,51,52,53,54,55,56,57,48]`, "[]uint8", nil},
+		{"[]rune(str1)", false, `[]int32 len: 11, cap: 11, [48,49,50,51,52,53,54,55,56,57,48]`, `[]int32 len: 11, cap: 11, [48,49,50,51,52,53,54,55,56,57,48]`, "[]int32", nil},
+		{"[]int32(str1)", false, `[]int32 len: 11, cap: 11, [48,49,50,51,52,53,54,55,56,57,48]`, `[]int32 len: 11, cap: 11, [48,49,50,51,52,53,54,55,56,57,48]`, "[]int32", nil},
+		{"string(byteslice)", false, `"tèst"`, `""`, "string", nil},
+		{"[]int32(string(byteslice))", false, `[]int32 len: 4, cap: 4, [116,232,115,116]`, `[]int32 len: 0, cap: 0, nil`, "[]int32", nil},
+		{"string(runeslice)", false, `"tèst"`, `""`, "string", nil},
+		{"[]byte(string(runeslice))", false, `[]uint8 len: 5, cap: 5, [116,195,168,115,116]`, `[]uint8 len: 0, cap: 0, nil`, "[]uint8", nil},
+		{"*(*[5]byte)(uintptr(&byteslice[0]))", false, `[5]uint8 [116,195,168,115,116]`, `[5]uint8 [...]`, "[5]uint8", nil},
 	}
 
 	ver, _ := goversion.Parse(runtime.Version())


### PR DESCRIPTION
```
proc/eval: support more type casts

* string to []rune
* string to []byte
* []rune to string
* []byte to string
* any pointer to uintptr

The string, []rune, []byte conversion pairs aligns this to the go
language.
The pointer -> uintptr conversion pair is symmetric to the uintptr ->
pointer that we already have.

Also lets the user specify any size for byte array types instead of
just the ones already used by the program, this can be used to read
arbitrary memory.

Fixes #548, #867

```
