### PR TITLE
proc: change next to skip deferred functions

### DIFF
--- a/pkg/proc/proc_test.go
+++ b/pkg/proc/proc_test.go
@@ -590,18 +590,12 @@ func TestNextFunctionReturnDefer(t *testing.T) {
 			{5, 6},
 			{6, 9},
 			{9, 10},
-			{10, 6},
-			{6, 7},
-			{7, 8},
 		}
 	} else {
 		testcases = []nextTest{
 			{5, 8},
 			{8, 9},
 			{9, 10},
-			{10, 6},
-			{6, 7},
-			{7, 8},
 		}
 	}
 	protest.AllowRecording(t)
@@ -2132,10 +2126,6 @@ func TestNextDeferReturnAndDirectCall(t *testing.T) {
 		{10, 11},
 		{11, 12},
 		{12, 13},
-		{13, 5},
-		{5, 6},
-		{6, 7},
-		{7, 13},
 		{13, 28}}, "main.callAndDeferReturn", t)
 }
 

--- a/pkg/proc/threads.go
+++ b/pkg/proc/threads.go
@@ -196,7 +196,7 @@ func next(dbp Process, stepInto bool) error {
 					return err
 				}
 			}
-			if bp != nil {
+			if bp != nil && stepInto {
 				bp.DeferReturns = deferreturns
 			}
 		}


### PR DESCRIPTION
```
proc: change next to skip deferred functions

Make 'next' skip deferred functions unless they are called via a panic.
Call to a deferred function through 'return' are predictable, if the
user wants to step into them 'step' can be used but without this change
there is no way to avoid stepping into them.

Implements #956

```
