### PR TITLE
proc: next should not skip lines with conditional bps

### DIFF
--- a/_fixtures/nextcond.go
+++ b/_fixtures/nextcond.go
@@ -1,0 +1,12 @@
+package main
+
+var n = 10
+
+func f1(x int) {
+}
+
+func main() {
+	f1(n)
+	f1(n)
+	f1(n)
+}

--- a/pkg/proc/core/core.go
+++ b/pkg/proc/core/core.go
@@ -222,8 +222,8 @@ func (t *Thread) Location() (*proc.Location, error) {
 	return &proc.Location{PC: t.th.Reg.Rip, File: f, Line: l, Fn: fn}, nil
 }
 
-func (t *Thread) Breakpoint() (*proc.Breakpoint, bool, error) {
-	return nil, false, nil
+func (t *Thread) Breakpoint() proc.BreakpointState {
+	return proc.BreakpointState{}
 }
 
 func (t *Thread) ThreadID() int {

--- a/pkg/proc/core/core.go
+++ b/pkg/proc/core/core.go
@@ -144,7 +144,7 @@ func (r *OffsetReaderAt) ReadMemory(buf []byte, addr uintptr) (n int, err error)
 type Process struct {
 	bi                proc.BinaryInfo
 	core              *Core
-	breakpoints       map[uint64]*proc.Breakpoint
+	breakpoints       proc.BreakpointMap
 	currentThread     *Thread
 	selectedGoroutine *proc.G
 	allGCache         []*proc.G
@@ -167,7 +167,7 @@ func OpenCore(corePath, exePath string) (*Process, error) {
 	}
 	p := &Process{
 		core:        core,
-		breakpoints: make(map[uint64]*proc.Breakpoint),
+		breakpoints: proc.NewBreakpointMap(),
 		bi:          proc.NewBinaryInfo("linux", "amd64"),
 	}
 	for _, thread := range core.Threads {
@@ -258,8 +258,8 @@ func (t *Thread) SetCurrentBreakpoint() error {
 	return nil
 }
 
-func (p *Process) Breakpoints() map[uint64]*proc.Breakpoint {
-	return p.breakpoints
+func (p *Process) Breakpoints() *proc.BreakpointMap {
+	return &p.breakpoints
 }
 
 func (p *Process) ClearBreakpoint(addr uint64) (*proc.Breakpoint, error) {

--- a/pkg/proc/disasm.go
+++ b/pkg/proc/disasm.go
@@ -40,7 +40,7 @@ func Disassemble(dbp Process, g *G, startPC, endPC uint64) ([]AsmInstruction, er
 	return disassemble(mem, regs, dbp.Breakpoints(), dbp.BinInfo(), startPC, endPC)
 }
 
-func disassemble(memrw MemoryReadWriter, regs Registers, breakpoints map[uint64]*Breakpoint, bi *BinaryInfo, startPC, endPC uint64) ([]AsmInstruction, error) {
+func disassemble(memrw MemoryReadWriter, regs Registers, breakpoints *BreakpointMap, bi *BinaryInfo, startPC, endPC uint64) ([]AsmInstruction, error) {
 	mem := make([]byte, int(endPC-startPC))
 	_, err := memrw.ReadMemory(mem, uintptr(startPC))
 	if err != nil {
@@ -56,7 +56,7 @@ func disassemble(memrw MemoryReadWriter, regs Registers, breakpoints map[uint64]
 	}
 
 	for len(mem) > 0 {
-		bp, atbp := breakpoints[pc]
+		bp, atbp := breakpoints.M[pc]
 		if atbp {
 			for i := range bp.OriginalData {
 				mem[i] = bp.OriginalData[i]

--- a/pkg/proc/interface.go
+++ b/pkg/proc/interface.go
@@ -97,7 +97,7 @@ type ProcessManipulation interface {
 
 // BreakpointManipulation is an interface for managing breakpoints.
 type BreakpointManipulation interface {
-	Breakpoints() map[uint64]*Breakpoint
+	Breakpoints() *BreakpointMap
 	SetBreakpoint(addr uint64, kind BreakpointKind, cond ast.Expr) (*Breakpoint, error)
 	ClearBreakpoint(addr uint64) (*Breakpoint, error)
 	ClearInternalBreakpoints() error

--- a/pkg/proc/native/proc.go
+++ b/pkg/proc/native/proc.go
@@ -210,8 +210,7 @@ func (dbp *Process) writeBreakpoint(addr uint64) (string, int, *proc.Function, [
 }
 
 // SetBreakpoint sets a breakpoint at addr, and stores it in the process wide
-// break point table. Setting a break point must be thread specific due to
-// ptrace actions needing the thread to be in a signal-delivery-stop.
+// break point table.
 func (dbp *Process) SetBreakpoint(addr uint64, kind proc.BreakpointKind, cond ast.Expr) (*proc.Breakpoint, error) {
 	return dbp.breakpoints.Set(addr, kind, cond, dbp.writeBreakpoint)
 }
@@ -235,7 +234,7 @@ func (dbp *Process) ContinueOnce() (proc.Thread, error) {
 
 	dbp.allGCache = nil
 	for _, th := range dbp.threads {
-		th.clearBreakpointState()
+		th.CurrentBreakpoint.Clear()
 	}
 
 	if dbp.resumeChan != nil {
@@ -276,7 +275,7 @@ func (dbp *Process) StepInstruction() (err error) {
 	if dbp.exited {
 		return &proc.ProcessExitedError{Pid: dbp.Pid()}
 	}
-	thread.clearBreakpointState()
+	thread.CurrentBreakpoint.Clear()
 	err = thread.StepInstruction()
 	if err != nil {
 		return err
@@ -386,8 +385,8 @@ func (dbp *Process) ClearInternalBreakpoints() error {
 			return err
 		}
 		for _, thread := range dbp.threads {
-			if thread.CurrentBreakpoint == bp {
-				thread.CurrentBreakpoint = nil
+			if thread.CurrentBreakpoint.Breakpoint == bp {
+				thread.CurrentBreakpoint.Clear()
 			}
 		}
 		return nil

--- a/pkg/proc/native/proc_darwin.go
+++ b/pkg/proc/native/proc_darwin.go
@@ -99,7 +99,7 @@ func Launch(cmd []string, wd string) (*Process, error) {
 
 	dbp.allGCache = nil
 	for _, th := range dbp.threads {
-		th.clearBreakpointState()
+		th.CurrentBreakpoint.Clear()
 	}
 
 	trapthread, err := dbp.trapWait(-1)
@@ -425,11 +425,11 @@ func (dbp *Process) exitGuard(err error) error {
 func (dbp *Process) resume() error {
 	// all threads stopped over a breakpoint are made to step over it
 	for _, thread := range dbp.threads {
-		if thread.CurrentBreakpoint != nil {
+		if thread.CurrentBreakpoint.Breakpoint != nil {
 			if err := thread.StepInstruction(); err != nil {
 				return err
 			}
-			thread.CurrentBreakpoint = nil
+			thread.CurrentBreakpoint.Clear()
 		}
 	}
 	// everything is resumed

--- a/pkg/proc/native/proc_linux.go
+++ b/pkg/proc/native/proc_linux.go
@@ -369,7 +369,7 @@ func (dbp *Process) wait(pid, options int) (int, *sys.WaitStatus, error) {
 
 func (dbp *Process) setCurrentBreakpoints(trapthread *Thread) error {
 	for _, th := range dbp.threads {
-		if th.CurrentBreakpoint == nil {
+		if th.CurrentBreakpoint.Breakpoint == nil {
 			if err := th.SetCurrentBreakpoint(); err != nil {
 				if err == sys.ESRCH {
 					// This thread quit between the point where we received the breakpoint and
@@ -399,11 +399,11 @@ func (dbp *Process) exitGuard(err error) error {
 func (dbp *Process) resume() error {
 	// all threads stopped over a breakpoint are made to step over it
 	for _, thread := range dbp.threads {
-		if thread.CurrentBreakpoint != nil {
+		if thread.CurrentBreakpoint.Breakpoint != nil {
 			if err := thread.StepInstruction(); err != nil {
 				return err
 			}
-			thread.CurrentBreakpoint = nil
+			thread.CurrentBreakpoint.Clear()
 		}
 	}
 	// everything is resumed

--- a/pkg/proc/native/proc_windows.go
+++ b/pkg/proc/native/proc_windows.go
@@ -447,11 +447,11 @@ func (dbp *Process) exitGuard(err error) error {
 
 func (dbp *Process) resume() error {
 	for _, thread := range dbp.threads {
-		if thread.CurrentBreakpoint != nil {
+		if thread.CurrentBreakpoint.Breakpoint != nil {
 			if err := thread.StepInstruction(); err != nil {
 				return err
 			}
-			thread.CurrentBreakpoint = nil
+			thread.CurrentBreakpoint.Clear()
 		}
 	}
 

--- a/pkg/proc/native/threads.go
+++ b/pkg/proc/native/threads.go
@@ -65,7 +65,7 @@ func (thread *Thread) StepInstruction() (err error) {
 	bp, ok := thread.dbp.FindBreakpoint(pc)
 	if ok {
 		// Clear the breakpoint so that we can continue execution.
-		_, err = thread.ClearBreakpoint(bp)
+		err = thread.ClearBreakpoint(bp)
 		if err != nil {
 			return err
 		}
@@ -177,11 +177,11 @@ func (th *Thread) ThreadID() int {
 }
 
 // ClearBreakpoint clears the specified breakpoint.
-func (thread *Thread) ClearBreakpoint(bp *proc.Breakpoint) (*proc.Breakpoint, error) {
+func (thread *Thread) ClearBreakpoint(bp *proc.Breakpoint) error {
 	if _, err := thread.WriteMemory(uintptr(bp.Addr), bp.OriginalData); err != nil {
-		return nil, fmt.Errorf("could not clear breakpoint %s", err)
+		return fmt.Errorf("could not clear breakpoint %s", err)
 	}
-	return bp, nil
+	return nil
 }
 
 // Registers obtains register values from the debugged process.

--- a/pkg/proc/proc.go
+++ b/pkg/proc/proc.go
@@ -68,10 +68,8 @@ func Next(dbp Process) (err error) {
 	if dbp.Exited() {
 		return &ProcessExitedError{Pid: dbp.Pid()}
 	}
-	for _, bp := range dbp.Breakpoints().M {
-		if bp.Internal() {
-			return fmt.Errorf("next while nexting")
-		}
+	if dbp.Breakpoints().HasInternalBreakpoints() {
+		return fmt.Errorf("next while nexting")
 	}
 
 	if err = next(dbp, false); err != nil {
@@ -106,10 +104,10 @@ func Continue(dbp Process) error {
 		}
 
 		curthread := dbp.CurrentThread()
-		curbp, curbpActive, _ := curthread.Breakpoint()
+		curbp := curthread.Breakpoint()
 
 		switch {
-		case curbp == nil:
+		case curbp.Breakpoint == nil:
 			// runtime.Breakpoint or manual stop
 			if recorded, _ := dbp.Recorded(); onRuntimeBreakpoint(curthread) && !recorded {
 				// Single-step current thread until we exit runtime.breakpoint and
@@ -127,7 +125,7 @@ func Continue(dbp Process) error {
 				}
 			}
 			return conditionErrors(threads)
-		case curbpActive && curbp.Internal():
+		case curbp.Active && curbp.Internal:
 			if curbp.Kind == StepBreakpoint {
 				// See description of proc.(*Process).next for the meaning of StepBreakpoints
 				if err := conditionErrors(threads); err != nil {
@@ -154,7 +152,7 @@ func Continue(dbp Process) error {
 				}
 				return conditionErrors(threads)
 			}
-		case curbpActive:
+		case curbp.Active:
 			onNextGoroutine, err := onNextGoroutine(curthread, dbp.Breakpoints())
 			if err != nil {
 				return err
@@ -178,9 +176,9 @@ func Continue(dbp Process) error {
 func conditionErrors(threads []Thread) error {
 	var condErr error
 	for _, th := range threads {
-		if bp, _, bperr := th.Breakpoint(); bp != nil && bperr != nil {
+		if bp := th.Breakpoint(); bp.Breakpoint != nil && bp.CondError != nil {
 			if condErr == nil {
-				condErr = bperr
+				condErr = bp.CondError
 			} else {
 				return fmt.Errorf("multiple errors evaluating conditions")
 			}
@@ -195,15 +193,15 @@ func conditionErrors(threads []Thread) error {
 // 	- trapthread
 func pickCurrentThread(dbp Process, trapthread Thread, threads []Thread) error {
 	for _, th := range threads {
-		if bp, active, _ := th.Breakpoint(); active && bp.Internal() {
+		if bp := th.Breakpoint(); bp.Active && bp.Internal {
 			return dbp.SwitchThread(th.ThreadID())
 		}
 	}
-	if _, active, _ := trapthread.Breakpoint(); active {
+	if bp := trapthread.Breakpoint(); bp.Active {
 		return dbp.SwitchThread(trapthread.ThreadID())
 	}
 	for _, th := range threads {
-		if _, active, _ := th.Breakpoint(); active {
+		if bp := th.Breakpoint(); bp.Active {
 			return dbp.SwitchThread(th.ThreadID())
 		}
 	}
@@ -216,10 +214,8 @@ func Step(dbp Process) (err error) {
 	if dbp.Exited() {
 		return &ProcessExitedError{Pid: dbp.Pid()}
 	}
-	for _, bp := range dbp.Breakpoints().M {
-		if bp.Internal() {
-			return fmt.Errorf("next while nexting")
-		}
+	if dbp.Breakpoints().HasInternalBreakpoints() {
+		return fmt.Errorf("next while nexting")
 	}
 
 	if err = next(dbp, true); err != nil {
@@ -336,7 +332,7 @@ func StepOut(dbp Process) error {
 		}
 	}
 
-	if bp, _, _ := curthread.Breakpoint(); bp == nil {
+	if bp := curthread.Breakpoint(); bp.Breakpoint == nil {
 		curthread.SetCurrentBreakpoint()
 	}
 

--- a/pkg/proc/proc.go
+++ b/pkg/proc/proc.go
@@ -68,7 +68,7 @@ func Next(dbp Process) (err error) {
 	if dbp.Exited() {
 		return &ProcessExitedError{Pid: dbp.Pid()}
 	}
-	for _, bp := range dbp.Breakpoints() {
+	for _, bp := range dbp.Breakpoints().M {
 		if bp.Internal() {
 			return fmt.Errorf("next while nexting")
 		}
@@ -216,7 +216,7 @@ func Step(dbp Process) (err error) {
 	if dbp.Exited() {
 		return &ProcessExitedError{Pid: dbp.Pid()}
 	}
-	for _, bp := range dbp.Breakpoints() {
+	for _, bp := range dbp.Breakpoints().M {
 		if bp.Internal() {
 			return fmt.Errorf("next while nexting")
 		}

--- a/pkg/proc/proc_test.go
+++ b/pkg/proc/proc_test.go
@@ -361,7 +361,7 @@ type nextTest struct {
 
 func countBreakpoints(p proc.Process) int {
 	bpcount := 0
-	for _, bp := range p.Breakpoints() {
+	for _, bp := range p.Breakpoints().M {
 		if bp.ID >= 0 {
 			bpcount++
 		}
@@ -422,7 +422,7 @@ func testseq(program string, contFunc contFunc, testcases []nextTest, initialLoc
 		}
 
 		if countBreakpoints(p) != 0 {
-			t.Fatal("Not all breakpoints were cleaned up", len(p.Breakpoints()))
+			t.Fatal("Not all breakpoints were cleaned up", len(p.Breakpoints().M))
 		}
 	})
 }
@@ -2272,7 +2272,7 @@ func TestStepConcurrentDirect(t *testing.T) {
 		_, err = p.ClearBreakpoint(bp.Addr)
 		assertNoError(err, t, "ClearBreakpoint()")
 
-		for _, b := range p.Breakpoints() {
+		for _, b := range p.Breakpoints().M {
 			if b.Name == proc.UnrecoveredPanic {
 				_, err := p.ClearBreakpoint(b.Addr)
 				assertNoError(err, t, "ClearBreakpoint(unrecovered-panic)")
@@ -2327,7 +2327,7 @@ func TestStepConcurrentDirect(t *testing.T) {
 }
 
 func nextInProgress(p proc.Process) bool {
-	for _, bp := range p.Breakpoints() {
+	for _, bp := range p.Breakpoints().M {
 		if bp.Internal() {
 			return true
 		}
@@ -2343,7 +2343,7 @@ func TestStepConcurrentPtr(t *testing.T) {
 		_, err = p.SetBreakpoint(pc, proc.UserBreakpoint, nil)
 		assertNoError(err, t, "SetBreakpoint()")
 
-		for _, b := range p.Breakpoints() {
+		for _, b := range p.Breakpoints().M {
 			if b.Name == proc.UnrecoveredPanic {
 				_, err := p.ClearBreakpoint(b.Addr)
 				assertNoError(err, t, "ClearBreakpoint(unrecovered-panic)")

--- a/pkg/proc/scope_test.go
+++ b/pkg/proc/scope_test.go
@@ -86,7 +86,7 @@ func TestScope(t *testing.T) {
 				}
 				assertNoError(err, t, "Continue()")
 			}
-			bp, _, _ := p.CurrentThread().Breakpoint()
+			bp := p.CurrentThread().Breakpoint()
 
 			scopeCheck := findScopeCheck(scopeChecks, bp.Line)
 			if scopeCheck == nil {

--- a/pkg/proc/threads.go
+++ b/pkg/proc/threads.go
@@ -411,11 +411,11 @@ func onRuntimeBreakpoint(thread Thread) bool {
 }
 
 // onNextGorutine returns true if this thread is on the goroutine requested by the current 'next' command
-func onNextGoroutine(thread Thread, breakpoints map[uint64]*Breakpoint) (bool, error) {
+func onNextGoroutine(thread Thread, breakpoints *BreakpointMap) (bool, error) {
 	var bp *Breakpoint
-	for i := range breakpoints {
-		if breakpoints[i].Internal() && breakpoints[i].Cond != nil {
-			bp = breakpoints[i]
+	for i := range breakpoints.M {
+		if breakpoints.M[i].Internal() && breakpoints.M[i].Cond != nil {
+			bp = breakpoints.M[i]
 			break
 		}
 	}

--- a/service/api/conversions.go
+++ b/service/api/conversions.go
@@ -64,8 +64,8 @@ func ConvertThread(th proc.Thread) *Thread {
 
 	var bp *Breakpoint
 
-	if b, active, _ := th.Breakpoint(); active {
-		bp = ConvertBreakpoint(b)
+	if b := th.Breakpoint(); b.Active {
+		bp = ConvertBreakpoint(b.Breakpoint)
 	}
 
 	if g, _ := proc.GetG(th); g != nil {

--- a/service/debugger/debugger.go
+++ b/service/debugger/debugger.go
@@ -264,12 +264,7 @@ func (d *Debugger) state() (*api.DebuggerState, error) {
 		}
 	}
 
-	for _, bp := range d.target.Breakpoints().M {
-		if bp.Internal() {
-			state.NextInProgress = true
-			break
-		}
-	}
+	state.NextInProgress = d.target.Breakpoints().HasInternalBreakpoints()
 
 	if recorded, _ := d.target.Recorded(); recorded {
 		state.When, _ = d.target.When()
@@ -399,10 +394,9 @@ func (d *Debugger) Breakpoints() []*api.Breakpoint {
 func (d *Debugger) breakpoints() []*api.Breakpoint {
 	bps := []*api.Breakpoint{}
 	for _, bp := range d.target.Breakpoints().M {
-		if bp.Internal() {
-			continue
+		if bp.IsUser() {
+			bps = append(bps, api.ConvertBreakpoint(bp))
 		}
-		bps = append(bps, api.ConvertBreakpoint(bp))
 	}
 	return bps
 }

--- a/service/debugger/debugger.go
+++ b/service/debugger/debugger.go
@@ -264,7 +264,7 @@ func (d *Debugger) state() (*api.DebuggerState, error) {
 		}
 	}
 
-	for _, bp := range d.target.Breakpoints() {
+	for _, bp := range d.target.Breakpoints().M {
 		if bp.Internal() {
 			state.NextInProgress = true
 			break
@@ -398,7 +398,7 @@ func (d *Debugger) Breakpoints() []*api.Breakpoint {
 
 func (d *Debugger) breakpoints() []*api.Breakpoint {
 	bps := []*api.Breakpoint{}
-	for _, bp := range d.target.Breakpoints() {
+	for _, bp := range d.target.Breakpoints().M {
 		if bp.Internal() {
 			continue
 		}
@@ -420,7 +420,7 @@ func (d *Debugger) FindBreakpoint(id int) *api.Breakpoint {
 }
 
 func (d *Debugger) findBreakpoint(id int) *proc.Breakpoint {
-	for _, bp := range d.target.Breakpoints() {
+	for _, bp := range d.target.Breakpoints().M {
 		if bp.ID == id {
 			return bp
 		}


### PR DESCRIPTION
```
proc: next should not skip lines with conditional bps

Conditional breakpoints with unmet conditions would cause next and step
to skip the line.

This breakpoint changes the Kind field of proc.Breakpoint from a single
value to a bit field, each breakpoint object can represent
simultaneously a user breakpoint and one internal breakpoint (of which
we have several different kinds).

The breakpoint condition for internal breakpoints is stored in the new
internalCond field of proc.Breakpoint so that it will not conflict with
user specified conditions.

The breakpoint setting code is changed to allow overlapping one
internal breakpoint on a user breakpoint, or a user breakpoint on an
existing internal breakpoint. All other combinations are rejected. The
breakpoint clearing code is changed to clear the UserBreakpoint bit and
only remove the phisical breakpoint if no other bits are set in the
Kind field. ClearInternalBreakpoints does the same thing but clearing
all bits that aren't the UserBreakpoint bit.

Fixes #844

proc: breakpoints refactoring

Move some duplicate code, related to breakpoints, that was in both
backends into a single place.
This is in preparation to solve issue #844 (conditional breakpoints
make step and next fail) which will make this common breakpoint code
more complicated.

```
