### PR TITLE
proc: refactor stack.go to use DWARF registers

### DIFF
--- a/pkg/dwarf/frame/entries.go
+++ b/pkg/dwarf/frame/entries.go
@@ -50,12 +50,6 @@ func (fde *FrameDescriptionEntry) EstablishFrame(pc uint64) *FrameContext {
 	return executeDwarfProgramUntilPC(fde, pc)
 }
 
-// Return the offset from the current SP that the return address is stored at.
-func (fde *FrameDescriptionEntry) ReturnAddressOffset(pc uint64) (frameOffset, returnAddressOffset int64) {
-	frame := fde.EstablishFrame(pc)
-	return frame.cfa.offset, frame.regs[fde.CIE.ReturnAddressRegister].offset
-}
-
 type FrameDescriptionEntries []*FrameDescriptionEntry
 
 func NewFrameIndex() FrameDescriptionEntries {

--- a/pkg/dwarf/op/op_test.go
+++ b/pkg/dwarf/op/op_test.go
@@ -7,7 +7,7 @@ func TestExecuteStackProgram(t *testing.T) {
 		instructions = []byte{DW_OP_consts, 0x1c, DW_OP_consts, 0x1c, DW_OP_plus}
 		expected     = int64(56)
 	)
-	actual, err := ExecuteStackProgram(0, instructions)
+	actual, err := ExecuteStackProgram(DwarfRegisters{}, instructions)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/dwarf/op/regs.go
+++ b/pkg/dwarf/op/regs.go
@@ -1,0 +1,95 @@
+package op
+
+import (
+	"bytes"
+	"encoding/binary"
+)
+
+type DwarfRegisters struct {
+	CFA       int64
+	FrameBase int64
+	ObjBase   int64
+	Regs      []*DwarfRegister
+
+	ByteOrder binary.ByteOrder
+	PCRegNum  uint64
+	SPRegNum  uint64
+}
+
+type DwarfRegister struct {
+	Uint64Val uint64
+	Bytes     []byte
+}
+
+// Uint64Val returns the uint64 value of register idx.
+func (regs *DwarfRegisters) Uint64Val(idx uint64) uint64 {
+	reg := regs.Reg(idx)
+	if reg == nil {
+		return 0
+	}
+	return regs.Regs[idx].Uint64Val
+}
+
+// Bytes returns the bytes value of register idx, nil if the register is not
+// defined.
+func (regs *DwarfRegisters) Bytes(idx uint64) []byte {
+	reg := regs.Reg(idx)
+	if reg == nil {
+		return nil
+	}
+	if reg.Bytes == nil {
+		var buf bytes.Buffer
+		binary.Write(&buf, regs.ByteOrder, reg.Uint64Val)
+		reg.Bytes = buf.Bytes()
+	}
+	return reg.Bytes
+}
+
+// Reg returns register idx or nil if the register is not defined.
+func (regs *DwarfRegisters) Reg(idx uint64) *DwarfRegister {
+	if idx >= uint64(len(regs.Regs)) {
+		return nil
+	}
+	return regs.Regs[idx]
+}
+
+func (regs *DwarfRegisters) PC() uint64 {
+	return regs.Uint64Val(regs.PCRegNum)
+}
+
+func (regs *DwarfRegisters) SP() uint64 {
+	return regs.Uint64Val(regs.SPRegNum)
+}
+
+// AddReg adds register idx to regs.
+func (regs *DwarfRegisters) AddReg(idx uint64, reg *DwarfRegister) {
+	if idx >= uint64(len(regs.Regs)) {
+		newRegs := make([]*DwarfRegister, idx+1)
+		copy(newRegs, regs.Regs)
+		regs.Regs = newRegs
+	}
+	regs.Regs[idx] = reg
+}
+
+func DwarfRegisterFromUint64(v uint64) *DwarfRegister {
+	return &DwarfRegister{Uint64Val: v}
+}
+
+func DwarfRegisterFromBytes(bytes []byte) *DwarfRegister {
+	var v uint64
+	switch len(bytes) {
+	case 1:
+		v = uint64(bytes[0])
+	case 2:
+		x := binary.LittleEndian.Uint16(bytes)
+		v = uint64(x)
+	case 4:
+		x := binary.LittleEndian.Uint32(bytes)
+		v = uint64(x)
+	default:
+		if len(bytes) >= 8 {
+			v = binary.LittleEndian.Uint64(bytes[:8])
+		}
+	}
+	return &DwarfRegister{Uint64Val: v, Bytes: bytes}
+}

--- a/pkg/dwarf/reader/reader.go
+++ b/pkg/dwarf/reader/reader.go
@@ -73,7 +73,7 @@ func (reader *Reader) AddrFor(name string) (uint64, error) {
 	if !ok {
 		return 0, fmt.Errorf("type assertion failed")
 	}
-	addr, err := op.ExecuteStackProgram(0, instructions)
+	addr, err := op.ExecuteStackProgram(op.DwarfRegisters{}, instructions)
 	if err != nil {
 		return 0, err
 	}
@@ -99,7 +99,7 @@ func (reader *Reader) AddrForMember(member string, initialInstructions []byte) (
 		if !ok {
 			continue
 		}
-		addr, err := op.ExecuteStackProgram(0, append(initialInstructions, instructions...))
+		addr, err := op.ExecuteStackProgram(op.DwarfRegisters{}, append(initialInstructions, instructions...))
 		return uint64(addr), err
 	}
 }

--- a/pkg/proc/arch.go
+++ b/pkg/proc/arch.go
@@ -1,5 +1,13 @@
 package proc
 
+import (
+	"encoding/binary"
+
+	"github.com/derekparker/delve/pkg/dwarf/frame"
+	"github.com/derekparker/delve/pkg/dwarf/op"
+	"golang.org/x/arch/x86/x86asm"
+)
+
 // Arch defines an interface for representing a
 // CPU architecture.
 type Arch interface {
@@ -7,6 +15,10 @@ type Arch interface {
 	BreakpointInstruction() []byte
 	BreakpointSize() int
 	DerefTLS() bool
+	FixFrameUnwindContext(*frame.FrameContext) *frame.FrameContext
+	RegSize(uint64) int
+	RegistersToDwarfRegisters(Registers) op.DwarfRegisters
+	GoroutineToDwarfRegisters(*G) op.DwarfRegisters
 }
 
 // AMD64 represents the AMD64 CPU architecture.
@@ -18,6 +30,12 @@ type AMD64 struct {
 	hardwareBreakpointUsage []bool
 	goos                    string
 }
+
+const (
+	amd64DwarfIPRegNum uint64 = 16
+	amd64DwarfSPRegNum uint64 = 7
+	amd64DwarfBPRegNum uint64 = 6
+)
 
 // AMD64Arch returns an initialized AMD64
 // struct.
@@ -55,4 +73,183 @@ func (a *AMD64) BreakpointSize() int {
 // pointer to the G struct
 func (a *AMD64) DerefTLS() bool {
 	return a.goos == "windows"
+}
+
+// FixFrameUnwindContext adds default architecture rules to fctxt or returns
+// the default frame unwind context if fctxt is nil.
+func (a *AMD64) FixFrameUnwindContext(fctxt *frame.FrameContext) *frame.FrameContext {
+	if fctxt == nil {
+		// When there's no frame descriptor entry use BP (the frame pointer) instead
+		// - return register is [bp + a.PtrSize()] (i.e. [cfa-a.PtrSize()])
+		// - cfa is bp + a.PtrSize()*2
+		// - bp is [bp] (i.e. [cfa-a.PtrSize()*2])
+		// - sp is cfa
+
+		return &frame.FrameContext{
+			RetAddrReg: amd64DwarfIPRegNum,
+			Regs: map[uint64]frame.DWRule{
+				amd64DwarfIPRegNum: frame.DWRule{
+					Rule:   frame.RuleOffset,
+					Offset: int64(-a.PtrSize()),
+				},
+				amd64DwarfBPRegNum: frame.DWRule{
+					Rule:   frame.RuleOffset,
+					Offset: int64(-2 * a.PtrSize()),
+				},
+				amd64DwarfSPRegNum: frame.DWRule{
+					Rule:   frame.RuleValOffset,
+					Offset: 0,
+				},
+			},
+			CFA: frame.DWRule{
+				Rule:   frame.RuleCFA,
+				Reg:    amd64DwarfBPRegNum,
+				Offset: int64(2 * a.PtrSize()),
+			},
+		}
+	}
+
+	// We assume that RBP is the frame pointer and we want to keep it updated,
+	// so that we can use it to unwind the stack even when we encounter frames
+	// without descriptor entries.
+	// If there isn't a rule already we emit one.
+	if fctxt.Regs[amd64DwarfBPRegNum].Rule == frame.RuleUndefined {
+		fctxt.Regs[amd64DwarfBPRegNum] = frame.DWRule{
+			Rule:   frame.RuleRegOffset,
+			Reg:    amd64DwarfBPRegNum,
+			Offset: 0,
+		}
+	}
+
+	return fctxt
+}
+
+// RegSize returns the size (in bytes) of register regnum.
+// The mapping between hardware registers and DWARF registers is specified
+// in the System V ABI AMD64 Architecture Processor Supplement page 57,
+// figure 3.36
+// https://www.uclibc.org/docs/psABI-x86_64.pdf
+func (a *AMD64) RegSize(regnum uint64) int {
+	// XMM registers
+	if regnum > amd64DwarfIPRegNum && regnum <= 32 {
+		return 16
+	}
+	// x87 registers
+	if regnum >= 33 && regnum <= 40 {
+		return 10
+	}
+	return 8
+}
+
+// The mapping between hardware registers and DWARF registers is specified
+// in the System V ABI AMD64 Architecture Processor Supplement page 57,
+// figure 3.36
+// https://www.uclibc.org/docs/psABI-x86_64.pdf
+
+var asm64DwarfToHardware = map[int]x86asm.Reg{
+	0:  x86asm.RAX,
+	1:  x86asm.RDX,
+	2:  x86asm.RCX,
+	3:  x86asm.RBX,
+	4:  x86asm.RSI,
+	5:  x86asm.RDI,
+	8:  x86asm.R8,
+	9:  x86asm.R9,
+	10: x86asm.R10,
+	11: x86asm.R11,
+	12: x86asm.R12,
+	13: x86asm.R13,
+	14: x86asm.R14,
+	15: x86asm.R15,
+}
+
+var amd64DwarfToName = map[int]string{
+	17: "XMM0",
+	18: "XMM1",
+	19: "XMM2",
+	20: "XMM3",
+	21: "XMM4",
+	22: "XMM5",
+	23: "XMM6",
+	24: "XMM7",
+	25: "XMM8",
+	26: "XMM9",
+	27: "XMM10",
+	28: "XMM11",
+	29: "XMM12",
+	30: "XMM13",
+	31: "XMM14",
+	32: "XMM15",
+	33: "ST(0)",
+	34: "ST(1)",
+	35: "ST(2)",
+	36: "ST(3)",
+	37: "ST(4)",
+	38: "ST(5)",
+	39: "ST(6)",
+	40: "ST(7)",
+	49: "Eflags",
+	50: "Es",
+	51: "Cs",
+	52: "Ss",
+	53: "Ds",
+	54: "Fs",
+	55: "Gs",
+	58: "Fs_base",
+	59: "Gs_base",
+	64: "MXCSR",
+	65: "CW",
+	66: "SW",
+}
+
+func maxAmd64DwarfRegister() int {
+	max := int(amd64DwarfIPRegNum)
+	for i := range asm64DwarfToHardware {
+		if i > max {
+			max = i
+		}
+	}
+	for i := range amd64DwarfToName {
+		if i > max {
+			max = i
+		}
+	}
+	return max
+}
+
+// RegistersToDwarfRegisters converts hardware registers to the format used
+// by the DWARF expression interpreter.
+func (a *AMD64) RegistersToDwarfRegisters(regs Registers) op.DwarfRegisters {
+	dregs := make([]*op.DwarfRegister, maxAmd64DwarfRegister()+1)
+
+	dregs[amd64DwarfIPRegNum] = op.DwarfRegisterFromUint64(regs.PC())
+	dregs[amd64DwarfSPRegNum] = op.DwarfRegisterFromUint64(regs.SP())
+	dregs[amd64DwarfBPRegNum] = op.DwarfRegisterFromUint64(regs.BP())
+
+	for dwarfReg, asmReg := range asm64DwarfToHardware {
+		v, err := regs.Get(int(asmReg))
+		if err == nil {
+			dregs[dwarfReg] = op.DwarfRegisterFromUint64(v)
+		}
+	}
+
+	for _, reg := range regs.Slice() {
+		for dwarfReg, regName := range amd64DwarfToName {
+			if regName == reg.Name {
+				dregs[dwarfReg] = op.DwarfRegisterFromBytes(reg.Bytes)
+			}
+		}
+	}
+
+	return op.DwarfRegisters{Regs: dregs, ByteOrder: binary.LittleEndian, PCRegNum: amd64DwarfIPRegNum, SPRegNum: amd64DwarfSPRegNum}
+}
+
+// GoroutineToDwarfRegisters extract the saved DWARF registers from a parked
+// goroutine in the format used by the DWARF expression interpreter.
+func (a *AMD64) GoroutineToDwarfRegisters(g *G) op.DwarfRegisters {
+	dregs := make([]*op.DwarfRegister, amd64DwarfIPRegNum+1)
+	dregs[amd64DwarfIPRegNum] = op.DwarfRegisterFromUint64(g.PC)
+	dregs[amd64DwarfSPRegNum] = op.DwarfRegisterFromUint64(g.SP)
+	dregs[amd64DwarfBPRegNum] = op.DwarfRegisterFromUint64(g.BP)
+	return op.DwarfRegisters{Regs: dregs, ByteOrder: binary.LittleEndian, PCRegNum: amd64DwarfIPRegNum, SPRegNum: amd64DwarfSPRegNum}
 }

--- a/pkg/proc/proc.go
+++ b/pkg/proc/proc.go
@@ -290,7 +290,7 @@ func StepOut(dbp Process) error {
 	}
 
 	sameGCond := SameGoroutineCondition(selg)
-	retFrameCond := andFrameoffCondition(sameGCond, retframe.CFA-int64(retframe.StackHi))
+	retFrameCond := andFrameoffCondition(sameGCond, retframe.Regs.CFA-int64(retframe.StackHi))
 
 	var deferpc uint64 = 0
 	if filepath.Ext(topframe.Current.File) == ".go" {
@@ -485,12 +485,12 @@ func ConvertEvalScope(dbp Process, gid, frame int) (*EvalScope, error) {
 		return nil, fmt.Errorf("Frame %d does not exist in goroutine %d", frame, gid)
 	}
 
-	PC, CFA := locs[frame].Current.PC, locs[frame].CFA
+	PC, CFA := locs[frame].Current.PC, locs[frame].Regs.CFA
 
 	return &EvalScope{PC, CFA, thread, g.variable, dbp.BinInfo(), g.stackhi}, nil
 }
 
 // FrameToScope returns a new EvalScope for this frame
 func FrameToScope(p Process, frame Stackframe) *EvalScope {
-	return &EvalScope{frame.Current.PC, frame.CFA, p.CurrentThread(), nil, p.BinInfo(), frame.StackHi}
+	return &EvalScope{frame.Current.PC, frame.Regs.CFA, p.CurrentThread(), nil, p.BinInfo(), frame.StackHi}
 }

--- a/pkg/proc/proc_test.go
+++ b/pkg/proc/proc_test.go
@@ -930,7 +930,7 @@ func TestStacktraceGoroutine(t *testing.T) {
 					if locations[i].Call.Fn != nil {
 						name = locations[i].Call.Fn.Name
 					}
-					t.Logf("\t%s:%d %s\n", locations[i].Call.File, locations[i].Call.Line, name)
+					t.Logf("\t%s:%d %s (%#x)\n", locations[i].Call.File, locations[i].Call.Line, name, locations[i].Current.PC)
 				}
 			}
 		}
@@ -2763,7 +2763,7 @@ func TestStacktraceWithBarriers(t *testing.T) {
 				if frame.Current.Fn != nil {
 					name = frame.Current.Fn.Name
 				}
-				t.Logf("\t%s [CFA: %x Ret: %x] at %s:%d", name, frame.CFA, frame.Ret, frame.Current.File, frame.Current.Line)
+				t.Logf("\t%s [CFA: %x Ret: %x] at %s:%d", name, frame.Regs.CFA, frame.Ret, frame.Current.File, frame.Current.Line)
 			}
 
 			if !found {
@@ -2975,6 +2975,9 @@ func TestIssue893(t *testing.T) {
 			return
 		}
 		if _, ok := err.(proc.ThreadBlockedError); ok {
+			return
+		}
+		if _, ok := err.(*proc.NoSourceForPCError); ok {
 			return
 		}
 		assertNoError(err, t, "Next")

--- a/service/debugger/debugger.go
+++ b/service/debugger/debugger.go
@@ -860,7 +860,7 @@ func (d *Debugger) convertStacktrace(rawlocs []proc.Stackframe, cfg *proc.LoadCo
 	for i := range rawlocs {
 		frame := api.Stackframe{
 			Location:    api.ConvertLocation(rawlocs[i].Call),
-			FrameOffset: rawlocs[i].CFA - int64(rawlocs[i].StackHi),
+			FrameOffset: rawlocs[i].Regs.CFA - int64(rawlocs[i].StackHi),
 		}
 		if rawlocs[i].Err != nil {
 			frame.Err = rawlocs[i].Err.Error()


### PR DESCRIPTION
```
proc: refactor stack.go to use DWARF registers

Instead of only tracking a few cherrypicked registers in stack.go track
all DWARF registers.

This is needed for cgo code and for the locationlists emitted by go in
1.10:
* The debug_frame sections emitted by C compilers can not be used
without tracking all registers
* the loclists emitted by go1.10 need all registers of a frame to be
interpreted.
```
