### PR TITLE
pkg/prog/test: add flag to run target with -race flag

### DIFF
--- a/_fixtures/scopetest.go
+++ b/_fixtures/scopetest.go
@@ -28,7 +28,7 @@ func TestNestedFor() {
 	a := 0
 	f1(a) // a int = 0
 	for i := 0; i < 5; i++ {
-		f2(i) // i int
+		f2(i) // a int = 0, i int
 		for i := 1; i < 5; i++ {
 			f3(i) // a int = 0, i int = 0, i int = 1
 			i++

--- a/pkg/proc/scope_test.go
+++ b/pkg/proc/scope_test.go
@@ -258,8 +258,7 @@ func (check *scopeCheck) Parse(descr string, t *testing.T) {
 func (check *scopeCheck) checkVar(v *proc.Variable, t *testing.T) {
 	var varCheck *varCheck
 	for i := range check.varChecks {
-		varCheck = &check.varChecks[i]
-		if !varCheck.ok && (varCheck.name == v.Name) {
+		if !check.varChecks[i].ok && (check.varChecks[i].name == v.Name) {
 			varCheck = &check.varChecks[i]
 			break
 		}
@@ -267,6 +266,7 @@ func (check *scopeCheck) checkVar(v *proc.Variable, t *testing.T) {
 
 	if varCheck == nil {
 		t.Errorf("%d: unexpected variable %s", check.line, v.Name)
+		return
 	}
 
 	varCheck.check(check.line, v, t, "FunctionArguments+LocalVariables")

--- a/pkg/proc/test/support.go
+++ b/pkg/proc/test/support.go
@@ -3,6 +3,7 @@ package test
 import (
 	"crypto/rand"
 	"encoding/hex"
+	"flag"
 	"fmt"
 	"os"
 	"os/exec"
@@ -12,6 +13,8 @@ import (
 	"sync"
 	"testing"
 )
+
+var EnableRace = flag.Bool("racetarget", false, "Enables race detector on inferior process")
 
 // Fixture is a test binary.
 type Fixture struct {
@@ -72,6 +75,9 @@ func BuildFixture(name string, flags BuildFlags) Fixture {
 		buildFlags = append(buildFlags, "-ldflags=-s")
 	}
 	buildFlags = append(buildFlags, "-gcflags=-N -l", "-o", tmpfile)
+	if *EnableRace {
+		buildFlags = append(buildFlags, "-race")
+	}
 	if path != "" {
 		buildFlags = append(buildFlags, name+".go")
 	}


### PR DESCRIPTION
```
pkg/prog/test: add flag to run target with -race flag

Adds test command line flag to compile target fixtures using the -race flag.
Multiple tests will fail because of https://github.com/golang/go/issues/22600
but eventually this should work.

```
