### PR TITLE
proc: better eval support for channels and interfaces

### DIFF
--- a/_fixtures/testvariables2.go
+++ b/_fixtures/testvariables2.go
@@ -108,7 +108,11 @@ func main() {
 	var fn2 functype = nil
 	var nilslice []int = nil
 	var nilptr *int = nil
-	ch1 := make(chan int, 2)
+	ch1 := make(chan int, 10)
+	ch1 <- 1
+	ch1 <- 4
+	ch1 <- 3
+	ch1 <- 2
 	var chnil chan int = nil
 	m1 := map[string]astruct{
 		"Malone":          astruct{2, 3},

--- a/pkg/proc/variables.go
+++ b/pkg/proc/variables.go
@@ -664,6 +664,11 @@ func (v *Variable) structMember(memberName string) (*Variable, error) {
 	case reflect.Chan:
 		v = v.clone()
 		v.RealType = resolveTypedef(&(v.RealType.(*godwarf.ChanType).TypedefType))
+	case reflect.Interface:
+		v.loadInterface(0, false, LoadConfig{})
+		if len(v.Children) > 0 {
+			v = &v.Children[0]
+		}
 	}
 	structVar := v.maybeDereference()
 	structVar.Name = v.Name

--- a/pkg/proc/variables.go
+++ b/pkg/proc/variables.go
@@ -197,6 +197,9 @@ func newVariable(name string, addr uintptr, dwarfType godwarf.Type, bi *BinaryIn
 		}
 	case *godwarf.ChanType:
 		v.Kind = reflect.Chan
+		if v.Addr != 0 {
+			v.loadChanInfo()
+		}
 	case *godwarf.MapType:
 		v.Kind = reflect.Map
 	case *godwarf.StringType:
@@ -657,6 +660,11 @@ func (v *Variable) structMember(memberName string) (*Variable, error) {
 	if v.Unreadable != nil {
 		return v.clone(), nil
 	}
+	switch v.Kind {
+	case reflect.Chan:
+		v = v.clone()
+		v.RealType = resolveTypedef(&(v.RealType.(*godwarf.ChanType).TypedefType))
+	}
 	structVar := v.maybeDereference()
 	structVar.Name = v.Name
 	if structVar.Unreadable != nil {
@@ -1001,6 +1009,66 @@ func (v *Variable) loadSliceInfo(t *godwarf.SliceType) {
 	v.stride = v.fieldType.Size()
 	if t, ok := v.fieldType.(*godwarf.PtrType); ok {
 		v.stride = t.ByteSize
+	}
+}
+
+// loadChanInfo loads the buffer size of the channel and changes the type of
+// the buf field from unsafe.Pointer to an array of the correct type.
+func (v *Variable) loadChanInfo() {
+	chanType, ok := v.RealType.(*godwarf.ChanType)
+	if !ok {
+		v.Unreadable = errors.New("bad channel type")
+		return
+	}
+	sv := v.clone()
+	sv.RealType = resolveTypedef(&(chanType.TypedefType))
+	sv = sv.maybeDereference()
+	if sv.Unreadable != nil || sv.Addr == 0 {
+		return
+	}
+	structType, ok := sv.DwarfType.(*godwarf.StructType)
+	if !ok {
+		v.Unreadable = errors.New("bad channel type")
+		return
+	}
+
+	lenAddr, _ := sv.toField(structType.Field[1])
+	lenAddr.loadValue(loadSingleValue)
+	if lenAddr.Unreadable != nil {
+		v.Unreadable = fmt.Errorf("unreadable length: %v", lenAddr.Unreadable)
+		return
+	}
+	chanLen, _ := constant.Uint64Val(lenAddr.Value)
+
+	newStructType := &godwarf.StructType{}
+	*newStructType = *structType
+	newStructType.Field = make([]*godwarf.StructField, len(structType.Field))
+
+	for i := range structType.Field {
+		field := &godwarf.StructField{}
+		*field = *structType.Field[i]
+		if field.Name == "buf" {
+			stride := chanType.ElemType.Common().ByteSize
+			atyp := &godwarf.ArrayType{
+				CommonType: godwarf.CommonType{
+					ReflectKind: reflect.Array,
+					ByteSize:    int64(chanLen) * stride,
+					Name:        fmt.Sprintf("[%d]%s", chanLen, chanType.ElemType.String())},
+				Type:          chanType.ElemType,
+				StrideBitSize: stride * 8,
+				Count:         int64(chanLen)}
+
+			field.Type = pointerTo(atyp, v.bi.Arch)
+		}
+		newStructType.Field[i] = field
+	}
+
+	v.RealType = &godwarf.ChanType{
+		TypedefType: godwarf.TypedefType{
+			CommonType: chanType.TypedefType.CommonType,
+			Type:       pointerTo(newStructType, v.bi.Arch),
+		},
+		ElemType: chanType.ElemType,
 	}
 }
 

--- a/service/test/variables_test.go
+++ b/service/test/variables_test.go
@@ -552,6 +552,8 @@ func TestEvalExpression(t *testing.T) {
 		{"err2", true, "error(*main.bstruct) *{a: main.astruct {A: 1, B: 2}}", "error(*main.bstruct) 0x…", "error", nil},
 		{"errnil", true, "error nil", "error nil", "error", nil},
 		{"iface1", true, "interface {}(*main.astruct) *{A: 1, B: 2}", "interface {}(*main.astruct) 0x…", "interface {}", nil},
+		{"iface1.A", false, "1", "1", "int", nil},
+		{"iface1.B", false, "2", "2", "int", nil},
 		{"iface2", true, "interface {}(string) \"test\"", "interface {}(string) \"test\"", "interface {}", nil},
 		{"iface3", true, "interface {}(map[string]go/constant.Value) []", "interface {}(map[string]go/constant.Value) []", "interface {}", nil},
 		{"iface4", true, "interface {}([]go/constant.Value) [4]", "interface {}([]go/constant.Value) [...]", "interface {}", nil},

--- a/service/test/variables_test.go
+++ b/service/test/variables_test.go
@@ -534,7 +534,7 @@ func TestEvalExpression(t *testing.T) {
 		{"*p3", false, "", "", "int", fmt.Errorf("nil pointer dereference")},
 
 		// channels
-		{"ch1", true, "chan int 0/2", "chan int 0/2", "chan int", nil},
+		{"ch1", true, "chan int 4/10", "chan int 4/10", "chan int", nil},
 		{"chnil", true, "chan int nil", "chan int nil", "chan int", nil},
 		{"ch1+1", false, "", "", "", fmt.Errorf("can not convert 1 constant to chan int")},
 
@@ -626,8 +626,8 @@ func TestEvalExpression(t *testing.T) {
 		{"len(s3)", false, "0", "0", "", nil},
 		{"cap(nilslice)", false, "0", "0", "", nil},
 		{"len(nilslice)", false, "0", "0", "", nil},
-		{"cap(ch1)", false, "2", "2", "", nil},
-		{"len(ch1)", false, "0", "0", "", nil},
+		{"cap(ch1)", false, "10", "10", "", nil},
+		{"len(ch1)", false, "4", "4", "", nil},
 		{"cap(chnil)", false, "0", "0", "", nil},
 		{"len(chnil)", false, "0", "0", "", nil},
 		{"len(m1)", false, "41", "41", "", nil},
@@ -727,6 +727,12 @@ func TestEvalExpression(t *testing.T) {
 		{"string(runeslice)", false, `"tèst"`, `""`, "string", nil},
 		{"[]byte(string(runeslice))", false, `[]uint8 len: 5, cap: 5, [116,195,168,115,116]`, `[]uint8 len: 0, cap: 0, nil`, "[]uint8", nil},
 		{"*(*[5]byte)(uintptr(&byteslice[0]))", false, `[5]uint8 [116,195,168,115,116]`, `[5]uint8 [...]`, "[5]uint8", nil},
+
+		// access to channel field members
+		{"ch1.qcount", false, "4", "4", "uint", nil},
+		{"ch1.dataqsiz", false, "10", "10", "uint", nil},
+		{"ch1.buf", false, `*[10]int [1,4,3,2,0,0,0,0,0,0]`, `(*[10]int)(…`, "*[10]int", nil},
+		{"ch1.buf[0]", false, "1", "1", "int", nil},
 	}
 
 	ver, _ := goversion.Parse(runtime.Version())


### PR DESCRIPTION
```
proc: automatically dereference interfaces on member access

If 'iv' is an interface variable with a struct as a concrete value let
'iv.A' evaluate to the access to field 'A' of the concrete value of
'iv'.

proc: support access to chan buffers

Replace the unsafe.Pointer type of the buf field of channels with the
appropriate array type, allow expressions accessing member field of the
channel struct.

Fixes #962

```
