### PR TITLE
pkg/terminal: print DWARF location expression with whatis

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -39,6 +39,10 @@ type Config struct {
 	// MaxArrayValues is the maximum number of array items that the commands
 	// print, locals, args and vars should read (in verbose mode).
 	MaxArrayValues *int `yaml:"max-array-values,omitempty"`
+
+	// If ShowLocationExpr is true whatis will print the DWARF location
+	// expression for its argument.
+	ShowLocationExpr bool `yaml:"show-location-expr"`
 }
 
 // LoadConfig attempts to populate a Config object from the config.yml file.
@@ -139,6 +143,15 @@ aliases:
 # commands.
 substitute-path:
   # - {from: path, to: path}
+  
+# Maximum number of elements loaded from an array.
+# max-array-values: 64
+
+# Maximum loaded string length.
+# max-string-len: 64
+
+# Uncomment the following line to make the whatis command also print the DWARF location expression of its argument.
+# show-location-expr: true
 `)
 	return err
 }

--- a/pkg/proc/stack.go
+++ b/pkg/proc/stack.go
@@ -332,7 +332,7 @@ func (it *stackIterator) frameBase(fn *Function) int64 {
 	if err != nil {
 		return 0
 	}
-	fb, _, _ := it.bi.Location(e, dwarf.AttrFrameBase, it.pc, it.regs)
+	fb, _, _, _ := it.bi.Location(e, dwarf.AttrFrameBase, it.pc, it.regs)
 	return fb
 }
 

--- a/pkg/proc/variables.go
+++ b/pkg/proc/variables.go
@@ -95,6 +95,8 @@ type Variable struct {
 
 	loaded     bool
 	Unreadable error
+
+	LocationExpr string // location expression
 }
 
 type LoadConfig struct {
@@ -777,7 +779,7 @@ func (scope *EvalScope) extractVarInfoFromEntry(entry *dwarf.Entry) (*Variable, 
 		return nil, err
 	}
 
-	addr, pieces, err := scope.BinInfo.Location(entry, dwarf.AttrLocation, scope.PC, scope.Regs)
+	addr, pieces, descr, err := scope.BinInfo.Location(entry, dwarf.AttrLocation, scope.PC, scope.Regs)
 	mem := scope.Mem
 	if pieces != nil {
 		addr = fakeAddress
@@ -785,6 +787,7 @@ func (scope *EvalScope) extractVarInfoFromEntry(entry *dwarf.Entry) (*Variable, 
 	}
 
 	v := scope.newVariable(n, uintptr(addr), t, mem)
+	v.LocationExpr = descr
 	if err != nil {
 		v.Unreadable = err
 	}

--- a/pkg/terminal/command.go
+++ b/pkg/terminal/command.go
@@ -981,6 +981,9 @@ func whatisCommand(t *Term, ctx callContext, args string) error {
 	if val.Kind == reflect.Interface && len(val.Children) > 0 {
 		fmt.Printf("Concrete type: %s\n", val.Children[0].Type)
 	}
+	if t.conf.ShowLocationExpr && val.LocationExpr != "" {
+		fmt.Printf("location: %s\n", val.LocationExpr)
+	}
 	return nil
 }
 

--- a/pkg/terminal/config.go
+++ b/pkg/terminal/config.go
@@ -73,14 +73,14 @@ func configureList(t *Term) error {
 			continue
 		}
 
-		if !field.IsNil() {
-			if field.Kind() == reflect.Ptr {
+		if field.Kind() == reflect.Ptr {
+			if !field.IsNil() {
 				fmt.Fprintf(w, "%s\t%v\n", fieldName, field.Elem())
 			} else {
-				fmt.Fprintf(w, "%s\t%v\n", fieldName, field)
+				fmt.Fprintf(w, "%s\t<not defined>\n", fieldName)
 			}
 		} else {
-			fmt.Fprintf(w, "%s\t<not defined>\n", fieldName)
+			fmt.Fprintf(w, "%s\t%v\n", fieldName, field)
 		}
 	}
 	return w.Flush()
@@ -116,6 +116,9 @@ func configureSet(t *Term, args string) error {
 				return reflect.ValueOf(nil), fmt.Errorf("argument to %q must be a number", cfgname)
 			}
 			return reflect.ValueOf(&n), nil
+		case reflect.Bool:
+			v := rest == "true"
+			return reflect.ValueOf(&v), nil
 		default:
 			return reflect.ValueOf(nil), fmt.Errorf("unsupported type for configuration key %q", cfgname)
 		}

--- a/service/api/conversions.go
+++ b/service/api/conversions.go
@@ -121,6 +121,8 @@ func ConvertVar(v *proc.Variable) *Variable {
 		Cap:      v.Cap,
 		Flags:    VariableFlags(v.Flags),
 		Base:     v.Base,
+
+		LocationExpr: v.LocationExpr,
 	}
 
 	r.Type = prettyTypeName(v.DwarfType)

--- a/service/api/types.go
+++ b/service/api/types.go
@@ -213,6 +213,9 @@ type Variable struct {
 
 	// Unreadable addresses will have this field set
 	Unreadable string `json:"unreadable"`
+
+	// LocationExpr describes the location expression of this variable's address
+	LocationExpr string
 }
 
 // LoadConfig describes how to load values from target's memory


### PR DESCRIPTION
Split out of https://github.com/derekparker/delve/pull/958.

Another possibility is to make &x return a string with the location expression of x when it doesn't have a phisical address.

```
pkg/terminal: print DWARF location expression with whatis

Adds a configuration option (show-location-expr) that when activated
will cause the whatis command to also print the DWARF location
expression for a variable.
```
