### PR TITLE
proc/native/linux: ignore ENODEV when retrieving fp registers

### DIFF
--- a/pkg/proc/native/ptrace_linux.go
+++ b/pkg/proc/native/ptrace_linux.go
@@ -59,7 +59,8 @@ func PtracePeekUser(tid int, off uintptr) (uintptr, error) {
 // and Section 13.1 (and following) of Intel® 64 and IA-32 Architectures Software Developer’s Manual, Volume 1: Basic Architecture
 func PtraceGetRegset(tid int) (regset proc.LinuxX86Xstate, err error) {
 	_, _, err = syscall.Syscall6(syscall.SYS_PTRACE, sys.PTRACE_GETFPREGS, uintptr(tid), uintptr(0), uintptr(unsafe.Pointer(&regset.PtraceFpRegs)), 0, 0)
-	if err == syscall.Errno(0) {
+	if err == syscall.Errno(0) || err == syscall.ENODEV {
+		// ignore ENODEV, it just means this CPU doesn't have X87 registers (??)
 		err = nil
 	}
 
@@ -67,6 +68,10 @@ func PtraceGetRegset(tid int) (regset proc.LinuxX86Xstate, err error) {
 	iov := sys.Iovec{Base: &xstateargs[0], Len: _X86_XSTATE_MAX_SIZE}
 	_, _, err = syscall.Syscall6(syscall.SYS_PTRACE, sys.PTRACE_GETREGSET, uintptr(tid), _NT_X86_XSTATE, uintptr(unsafe.Pointer(&iov)), 0, 0)
 	if err != syscall.Errno(0) {
+		if err == syscall.ENODEV {
+			// ignore ENODEV, it just means this CPU or kernel doesn't support XSTATE, see https://github.com/derekparker/delve/issues/1022
+			err = nil
+		}
 		return
 	} else {
 		err = nil

--- a/pkg/proc/native/registers_linux_amd64.go
+++ b/pkg/proc/native/registers_linux_amd64.go
@@ -1,6 +1,8 @@
 package native
 
 import (
+	"fmt"
+
 	"golang.org/x/arch/x86/x86asm"
 	sys "golang.org/x/sys/unix"
 
@@ -285,5 +287,8 @@ func (thread *Thread) fpRegisters() (regs []proc.Register, err error) {
 	var fpregs proc.LinuxX86Xstate
 	thread.dbp.execPtraceFunc(func() { fpregs, err = PtraceGetRegset(thread.ID) })
 	regs = fpregs.Decode()
+	if err != nil {
+		err = fmt.Errorf("could not get floating point registers: %v", err.Error())
+	}
 	return
 }


### PR DESCRIPTION
```
proc/native/linux: ignore ENODEV when retrieving fp registers

Either the CPU or the kernel may not support the calls we do when
retrieving floating point registers, this isn't an error we should
propagate.
Also improve the error reporint of pkg/proc/native.fpRegisters.

Fixes #1022

```
