### PR TITLE
Go 1.10 support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,9 +21,11 @@ ALL_PACKAGES=$(shell go list ./... | grep -v /vendor/ | grep -v /scripts)
 # unable to execute.
 # See https://github.com/golang/go/issues/11887#issuecomment-126117692.
 ifeq "$(UNAME)" "Darwin"
-	TEST_FLAGS=-exec=$(shell pwd)/scripts/testsign
+	TEST_FLAGS=-count 1 -exec=$(shell pwd)/scripts/testsign
 	export PROCTEST=lldb
 	DARWIN="true"
+else
+	TEST_FLAGS=-count 1
 endif
 
 # If we're on OSX make sure the proper CERT env var is set.
@@ -58,7 +60,7 @@ endif
 test: check-cert
 ifeq "$(TRAVIS)" "true"
 ifdef DARWIN
-	sudo -E go test -p 1 -v $(ALL_PACKAGES)
+	sudo -E go test -p 1 -count 1 -v $(ALL_PACKAGES)
 else
 	go test -p 1 $(TEST_FLAGS) $(BUILD_FLAGS) $(ALL_PACKAGES)
 endif

--- a/_fixtures/consts.go
+++ b/_fixtures/consts.go
@@ -1,0 +1,36 @@
+package main
+
+import (
+	"fmt"
+	"runtime"
+)
+
+type ConstType uint8
+
+const (
+	constZero ConstType = iota
+	constOne
+	constTwo
+	constThree
+)
+
+type BitFieldType uint8
+
+const (
+	bitZero BitFieldType = 1 << iota
+	bitOne
+	bitTwo
+	bitThree
+	bitFour
+)
+
+func main() {
+	a := constTwo
+	b := constThree
+	c := bitZero | bitOne
+	d := BitFieldType(33)
+	e := ConstType(10)
+	f := BitFieldType(0)
+	runtime.Breakpoint()
+	fmt.Println(a, b, c, d, e, f)
+}

--- a/_fixtures/decllinetest.go
+++ b/_fixtures/decllinetest.go
@@ -1,0 +1,15 @@
+package main
+
+import (
+	"fmt"
+	"runtime"
+)
+
+func main() {
+	a := 0
+	runtime.Breakpoint()
+	a++
+	b := 0
+	runtime.Breakpoint()
+	fmt.Println(a, b)
+}

--- a/pkg/proc/bininfo.go
+++ b/pkg/proc/bininfo.go
@@ -72,6 +72,7 @@ type compileUnit struct {
 	Name          string              // univocal name for non-go compile units
 	lineInfo      *line.DebugLineInfo // debug_line segment associated with this compile unit
 	LowPC, HighPC uint64
+	optimized     bool // this compile unit is optimized
 }
 
 // Function describes a function in the target program.
@@ -124,6 +125,11 @@ func (fn *Function) BaseName() string {
 		return fn.Name[i+1:]
 	}
 	return fn.Name
+}
+
+// Optimized returns true if the function was optimized by the compiler.
+func (fn *Function) Optimized() bool {
+	return fn.cu.optimized
 }
 
 type constantsMap map[dwarf.Offset]*constantType

--- a/pkg/proc/dwarf_expr_test.go
+++ b/pkg/proc/dwarf_expr_test.go
@@ -177,7 +177,7 @@ func TestDwarfExprComposite(t *testing.T) {
 	scope := dwarfExprCheck(t, mem, dwarfRegisters(&regs), bi, testCases)
 
 	thevar, err := scope.EvalExpression("s", normalLoadConfig)
-	assertNoError(err, t, fmt.Sprintf("EvalExpression(s)", "s"))
+	assertNoError(err, t, fmt.Sprintf("EvalExpression(%s)", "s"))
 	if thevar.Unreadable != nil {
 		t.Errorf("variable \"s\" unreadable: %v", thevar.Unreadable)
 	} else {

--- a/pkg/proc/eval.go
+++ b/pkg/proc/eval.go
@@ -184,7 +184,7 @@ func (scope *EvalScope) evalAST(t ast.Expr) (*Variable, error) {
 				return scope.Gvar.clone(), nil
 			} else if maybePkg.Name == "runtime" && node.Sel.Name == "frameoff" {
 				return newConstant(constant.MakeInt64(scope.frameOffset), scope.Mem), nil
-			} else if v, err := scope.packageVarAddr(maybePkg.Name + "." + node.Sel.Name); err == nil {
+			} else if v, err := scope.findGlobal(maybePkg.Name + "." + node.Sel.Name); err == nil {
 				return v, nil
 			}
 		}
@@ -586,7 +586,7 @@ func (scope *EvalScope) evalIdent(node *ast.Ident) (*Variable, error) {
 	// if it's not a local variable then it could be a package variable w/o explicit package name
 	_, _, fn := scope.BinInfo.PCToLine(scope.PC)
 	if fn != nil {
-		if v, err := scope.packageVarAddr(fn.PackageName() + "." + node.Name); err == nil {
+		if v, err := scope.findGlobal(fn.PackageName() + "." + node.Name); err == nil {
 			v.Name = node.Name
 			return v, nil
 		}

--- a/pkg/proc/moduledata.go
+++ b/pkg/proc/moduledata.go
@@ -17,7 +17,7 @@ func loadModuleData(bi *BinaryInfo, mem MemoryReadWriter) (err error) {
 	bi.loadModuleDataOnce.Do(func() {
 		scope := &EvalScope{0, op.DwarfRegisters{}, mem, nil, bi, 0}
 		var md *Variable
-		md, err = scope.packageVarAddr("runtime.firstmoduledata")
+		md, err = scope.findGlobal("runtime.firstmoduledata")
 		if err != nil {
 			return
 		}
@@ -122,7 +122,7 @@ func resolveNameOff(bi *BinaryInfo, typeAddr uintptr, off uintptr, mem MemoryRea
 
 func reflectOffsMapAccess(bi *BinaryInfo, off uintptr, mem MemoryReadWriter) (*Variable, error) {
 	scope := &EvalScope{0, op.DwarfRegisters{}, mem, nil, bi, 0}
-	reflectOffs, err := scope.packageVarAddr("runtime.reflectOffs")
+	reflectOffs, err := scope.findGlobal("runtime.reflectOffs")
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/proc/types.go
+++ b/pkg/proc/types.go
@@ -204,6 +204,10 @@ func (bi *BinaryInfo) loadDebugInfoMaps(debugLineBytes []byte, wg *sync.WaitGrou
 			if lineInfoOffset >= 0 && lineInfoOffset < int64(len(debugLineBytes)) {
 				cu.lineInfo = line.Parse(compdir, bytes.NewBuffer(debugLineBytes[lineInfoOffset:]))
 			}
+			if producer, _ := entry.Val(dwarf.AttrProducer).(string); cu.isgo && producer != "" {
+				semicolon := strings.Index(producer, ";")
+				cu.optimized = semicolon < 0 || !strings.Contains(producer[semicolon:], "-N") || !strings.Contains(producer[semicolon:], "-l")
+			}
 			bi.compileUnits = append(bi.compileUnits, cu)
 
 		case dwarf.TagArrayType, dwarf.TagBaseType, dwarf.TagClassType, dwarf.TagStructType, dwarf.TagUnionType, dwarf.TagConstType, dwarf.TagVolatileType, dwarf.TagRestrictType, dwarf.TagEnumerationType, dwarf.TagPointerType, dwarf.TagSubroutineType, dwarf.TagTypedef, dwarf.TagUnspecifiedType:

--- a/pkg/proc/types.go
+++ b/pkg/proc/types.go
@@ -177,6 +177,7 @@ func (bi *BinaryInfo) loadDebugInfoMaps(debugLineBytes []byte, wg *sync.WaitGrou
 	bi.packageVars = make(map[string]dwarf.Offset)
 	bi.Functions = []Function{}
 	bi.compileUnits = []*compileUnit{}
+	bi.consts = make(map[dwarf.Offset]*constantType)
 	reader := bi.DwarfReader()
 	var cu *compileUnit = nil
 	for entry, err := reader.Next(); entry != nil; entry, err = reader.Next() {
@@ -222,6 +223,22 @@ func (bi *BinaryInfo) loadDebugInfoMaps(debugLineBytes []byte, wg *sync.WaitGrou
 					n = "C." + n
 				}
 				bi.packageVars[n] = entry.Offset
+			}
+
+		case dwarf.TagConstant:
+			name, okName := entry.Val(dwarf.AttrName).(string)
+			typ, okType := entry.Val(dwarf.AttrType).(dwarf.Offset)
+			val, okVal := entry.Val(dwarf.AttrConstValue).(int64)
+			if okName && okType && okVal {
+				if !cu.isgo {
+					name = "C." + name
+				}
+				ct := bi.consts[typ]
+				if ct == nil {
+					ct = &constantType{}
+					bi.consts[typ] = ct
+				}
+				ct.values = append(ct.values, constantValue{name: name, fullName: name, value: val})
 			}
 
 		case dwarf.TagSubprogram:

--- a/pkg/proc/variables.go
+++ b/pkg/proc/variables.go
@@ -54,6 +54,8 @@ const (
 	// VariableShadowed is set for local variables that are shadowed by a
 	// variable with the same name in another scope
 	VariableShadowed
+	// VariableConstant means this variable is a constant value
+	VariableConstant
 )
 
 // Variable represents a variable. It contains the address, name,
@@ -291,6 +293,7 @@ func newConstant(val constant.Value, mem MemoryReadWriter) *Variable {
 		v.Kind = reflect.String
 		v.Len = int64(len(constant.StringVal(val)))
 	}
+	v.Flags |= VariableConstant
 	return v
 }
 
@@ -642,7 +645,7 @@ func (scope *EvalScope) PackageVariables(cfg LoadConfig) ([]*Variable, error) {
 	return vars, nil
 }
 
-func (scope *EvalScope) packageVarAddr(name string) (*Variable, error) {
+func (scope *EvalScope) findGlobal(name string) (*Variable, error) {
 	for n, off := range scope.BinInfo.packageVars {
 		if n == name || strings.HasSuffix(n, "/"+name) {
 			reader := scope.DwarfReader()
@@ -652,6 +655,28 @@ func (scope *EvalScope) packageVarAddr(name string) (*Variable, error) {
 				return nil, err
 			}
 			return scope.extractVarInfoFromEntry(entry)
+		}
+	}
+	for offset, ctyp := range scope.BinInfo.consts {
+		for _, cval := range ctyp.values {
+			if cval.fullName == name {
+				t, err := scope.Type(offset)
+				if err != nil {
+					return nil, err
+				}
+				v := scope.newVariable(name, 0x0, t, scope.Mem)
+				switch v.Kind {
+				case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
+					v.Value = constant.MakeInt64(cval.value)
+				case reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64, reflect.Uintptr:
+					v.Value = constant.MakeUint64(uint64(cval.value))
+				default:
+					return nil, fmt.Errorf("unsupported constant kind %v", v.Kind)
+				}
+				v.Flags |= VariableConstant
+				v.loaded = true
+				return v, nil
+			}
 		}
 	}
 	return nil, fmt.Errorf("could not find symbol value for %s", name)
@@ -1724,6 +1749,100 @@ func (v *Variable) loadInterface(recurseLevel int, loadData bool, cfg LoadConfig
 	}
 }
 
+// ConstDescr describes the value of v using constants.
+func (v *Variable) ConstDescr() string {
+	if v.bi == nil || (v.Flags&VariableConstant != 0) {
+		return ""
+	}
+	ctyp := v.bi.consts.Get(v.DwarfType)
+	if ctyp == nil {
+		return ""
+	}
+	if typename := v.DwarfType.Common().Name; strings.Index(typename, ".") < 0 || strings.HasPrefix(typename, "C.") {
+		// only attempt to use constants for user defined type, otherwise every
+		// int variable with value 1 will be described with os.SEEK_CUR and other
+		// similar problems.
+		return ""
+	}
+
+	switch v.Kind {
+	case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
+		fallthrough
+	case reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64, reflect.Uintptr:
+		n, _ := constant.Int64Val(v.Value)
+		return ctyp.describe(n)
+	}
+	return ""
+}
+
+// popcnt is the number of bits set to 1 in x.
+// It's the same as math/bits.OnesCount64, copied here so that we can build
+// on versions of go that don't have math/bits.
+func popcnt(x uint64) int {
+	const m0 = 0x5555555555555555 // 01010101 ...
+	const m1 = 0x3333333333333333 // 00110011 ...
+	const m2 = 0x0f0f0f0f0f0f0f0f // 00001111 ...
+	const m = 1<<64 - 1
+	x = x>>1&(m0&m) + x&(m0&m)
+	x = x>>2&(m1&m) + x&(m1&m)
+	x = (x>>4 + x) & (m2 & m)
+	x += x >> 8
+	x += x >> 16
+	x += x >> 32
+	return int(x) & (1<<7 - 1)
+}
+
+func (cm constantsMap) Get(typ godwarf.Type) *constantType {
+	ctyp := cm[typ.Common().Offset]
+	if ctyp == nil {
+		return nil
+	}
+	typepkg := packageName(typ.String()) + "."
+	if !ctyp.initialized {
+		ctyp.initialized = true
+		sort.Sort(constantValuesByValue(ctyp.values))
+		for i := range ctyp.values {
+			if strings.HasPrefix(ctyp.values[i].name, typepkg) {
+				ctyp.values[i].name = ctyp.values[i].name[len(typepkg):]
+			}
+			if popcnt(uint64(ctyp.values[i].value)) == 1 {
+				ctyp.values[i].singleBit = true
+			}
+		}
+	}
+	return ctyp
+}
+
+func (ctyp *constantType) describe(n int64) string {
+	for _, val := range ctyp.values {
+		if val.value == n {
+			return val.name
+		}
+	}
+
+	if n == 0 {
+		return ""
+	}
+
+	// If all the values for this constant only have one bit set we try to
+	// represent the value as a bitwise or of constants.
+
+	fields := []string{}
+	for _, val := range ctyp.values {
+		if !val.singleBit {
+			continue
+		}
+		if n&val.value != 0 {
+			fields = append(fields, val.name)
+			n = n & ^val.value
+		}
+	}
+	if n == 0 {
+		return strings.Join(fields, "|")
+	}
+	return ""
+}
+
 type variablesByDepth struct {
 	vars   []*Variable
 	depths []int
@@ -1833,3 +1952,9 @@ func (scope *EvalScope) variablesByTag(tag dwarf.Tag, cfg *LoadConfig) ([]*Varia
 
 	return vars, nil
 }
+
+type constantValuesByValue []constantValue
+
+func (v constantValuesByValue) Len() int               { return len(v) }
+func (v constantValuesByValue) Less(i int, j int) bool { return v[i].value < v[j].value }
+func (v constantValuesByValue) Swap(i int, j int)      { v[i], v[j] = v[j], v[i] }

--- a/pkg/proc/variables.go
+++ b/pkg/proc/variables.go
@@ -1745,9 +1745,11 @@ func (scope *EvalScope) variablesByTag(tag dwarf.Tag, cfg *LoadConfig) ([]*Varia
 		return nil, errors.New("unable to find function context")
 	}
 
+	_, line, _ := scope.BinInfo.PCToLine(scope.PC)
+
 	var vars []*Variable
 	var depths []int
-	varReader := reader.Variables(scope.BinInfo.dwarf, fn.offset, scope.PC, tag == dwarf.TagVariable)
+	varReader := reader.Variables(scope.BinInfo.dwarf, fn.offset, scope.PC, line, tag == dwarf.TagVariable)
 	hasScopes := false
 	for varReader.Next() {
 		entry := varReader.Entry()

--- a/pkg/terminal/command.go
+++ b/pkg/terminal/command.go
@@ -23,6 +23,8 @@ import (
 	"github.com/derekparker/delve/service/debugger"
 )
 
+const optimizedFunctionWarning = "Warning: debugging optimized function"
+
 type cmdPrefix int
 
 const (
@@ -1353,6 +1355,9 @@ func printcontextThread(t *Term, th *api.Thread) {
 
 	if th.Breakpoint == nil {
 		fmt.Printf("> %s() %s:%d (PC: %#v)\n", fn.Name, ShortenFilePath(th.File), th.Line, th.PC)
+		if th.Function != nil && th.Function.Optimized {
+			fmt.Println(optimizedFunctionWarning)
+		}
 		return
 	}
 
@@ -1390,6 +1395,9 @@ func printcontextThread(t *Term, th *api.Thread) {
 			th.Line,
 			th.Breakpoint.TotalHitCount,
 			th.PC)
+	}
+	if th.Function != nil && th.Function.Optimized {
+		fmt.Println(optimizedFunctionWarning)
 	}
 
 	if th.BreakpointInfo != nil {

--- a/service/api/conversions.go
+++ b/service/api/conversions.go
@@ -139,7 +139,10 @@ func ConvertVar(v *proc.Variable) *Variable {
 		case reflect.String, reflect.Func:
 			r.Value = constant.StringVal(v.Value)
 		default:
-			r.Value = v.Value.String()
+			r.Value = v.ConstDescr()
+			if r.Value == "" {
+				r.Value = v.Value.String()
+			}
 		}
 	}
 

--- a/service/api/conversions.go
+++ b/service/api/conversions.go
@@ -212,10 +212,11 @@ func ConvertFunction(fn *proc.Function) *Function {
 	// those fields is not documented their value was replaced with 0 when
 	// gosym.Func was replaced by debug_info entries.
 	return &Function{
-		Name:   fn.Name,
-		Type:   0,
-		Value:  fn.Entry,
-		GoType: 0,
+		Name:      fn.Name,
+		Type:      0,
+		Value:     fn.Entry,
+		GoType:    0,
+		Optimized: fn.Optimized(),
 	}
 }
 

--- a/service/api/types.go
+++ b/service/api/types.go
@@ -165,6 +165,9 @@ const (
 	// VariableShadowed is set for local variables that are shadowed by a
 	// variable with the same name in another scope
 	VariableShadowed = VariableFlags(proc.VariableShadowed)
+
+	// VariableConstant means this variable is a constant value
+	VariableConstant
 )
 
 // Variable describes a variable.

--- a/service/api/types.go
+++ b/service/api/types.go
@@ -148,6 +148,8 @@ type Function struct {
 	Value  uint64 `json:"value"`
 	Type   byte   `json:"type"`
 	GoType uint64 `json:"goType"`
+	// Optimized is true if the function was optimized
+	Optimized bool `json:"optimized"`
 }
 
 // VariableFlags is the type of the Flags field of Variable.

--- a/service/test/variables_test.go
+++ b/service/test/variables_test.go
@@ -949,3 +949,30 @@ func TestPackageRenames(t *testing.T) {
 		}
 	})
 }
+
+func TestConstants(t *testing.T) {
+	testcases := []varTest{
+		{"a", true, "constTwo", "", "main.ConstType", nil},
+		{"b", true, "constThree", "", "main.ConstType", nil},
+		{"c", true, "bitZero|bitOne", "", "main.BitFieldType", nil},
+		{"d", true, "33", "", "main.BitFieldType", nil},
+		{"e", true, "10", "", "main.ConstType", nil},
+		{"f", true, "0", "", "main.BitFieldType", nil},
+		{"bitZero", true, "1", "", "main.BitFieldType", nil},
+		{"bitOne", true, "2", "", "main.BitFieldType", nil},
+		{"constTwo", true, "2", "", "main.ConstType", nil},
+	}
+	ver, _ := goversion.Parse(runtime.Version())
+	if ver.Major > 0 && !ver.AfterOrEqual(goversion.GoVersion{1, 10, -1, 0, 0, ""}) {
+		// Not supported on 1.9 or earlier
+		return
+	}
+	withTestProcess("consts", t, func(p proc.Process, fixture protest.Fixture) {
+		assertNoError(proc.Continue(p), t, "Continue")
+		for _, testcase := range testcases {
+			variable, err := evalVariable(p, testcase.name, pnormalLoadConfig)
+			assertNoError(err, t, fmt.Sprintf("EvalVariable(%s)", testcase.name))
+			assertVariable(t, variable, testcase)
+		}
+	})
+}

--- a/service/test/variables_test.go
+++ b/service/test/variables_test.go
@@ -965,7 +965,7 @@ func TestConstants(t *testing.T) {
 	ver, _ := goversion.Parse(runtime.Version())
 	if ver.Major > 0 && !ver.AfterOrEqual(goversion.GoVersion{1, 10, -1, 0, 0, ""}) {
 		// Not supported on 1.9 or earlier
-		return
+		t.Skip("constants added in go 1.10")
 	}
 	withTestProcess("consts", t, func(p proc.Process, fixture protest.Fixture) {
 		assertNoError(proc.Continue(p), t, "Continue")


### PR DESCRIPTION
- Changes command line options of `go build` and `go test -c` to take advantage of go 1.10 new caching
- Use DW_AT_producer to warn user about debugging optimized functions
- Use DW_TAG_constants to describe variable values
- Use DW_AT_decl_line to determine variable visibility (fixes #186, #83)
- Miscellaneous test fixes for go1.10.