### PR TITLE
dwarf/line: handle DW_LNE_end_of_sequence correctly

### DIFF
--- a/pkg/dwarf/line/state_machine.go
+++ b/pkg/dwarf/line/state_machine.go
@@ -272,6 +272,14 @@ func (sm *StateMachine) next() error {
 	if sm.valid {
 		sm.lastAddress, sm.lastFile, sm.lastLine = sm.address, sm.file, sm.line
 	}
+	if sm.endSeq {
+		sm.endSeq = false
+		sm.file = sm.dbl.FileNames[0].Path
+		sm.line = 1
+		sm.column = 0
+		sm.isStmt = false
+		sm.basicBlock = false
+	}
 	b, err := sm.buf.ReadByte()
 	if err != nil {
 		return err

--- a/pkg/proc/proc_test.go
+++ b/pkg/proc/proc_test.go
@@ -3355,3 +3355,22 @@ func TestIssue1034(t *testing.T) {
 		}
 	})
 }
+
+func TestIssue1008(t *testing.T) {
+	// The external linker on macOS inserts "end of sequence" extended opcodes
+	// in debug_line. which we should support correctly.
+	withTestProcess("cgostacktest/", t, func(p proc.Process, fixture protest.Fixture) {
+		_, err := setFunctionBreakpoint(p, "main.main")
+		assertNoError(err, t, "setFunctionBreakpoint()")
+		assertNoError(proc.Continue(p), t, "Continue()")
+		loc, err := p.CurrentThread().Location()
+		assertNoError(err, t, "CurrentThread().Location()")
+		t.Logf("location %v\n", loc)
+		if !strings.HasSuffix(loc.File, "/main.go") {
+			t.Errorf("unexpected location %s:%d\n", loc.File, loc.Line)
+		}
+		if loc.Line > 31 {
+			t.Errorf("unexpected location %s:%d (file only has 30 lines)\n", loc.File, loc.Line)
+		}
+	})
+}


### PR DESCRIPTION
We need to reset the current file and line number.

Fixes #1008