### PR TITLE
proc: handle DW_TAG_subprogram with a nochildren abbrev

### DIFF
--- a/pkg/dwarf/reader/variables.go
+++ b/pkg/dwarf/reader/variables.go
@@ -55,7 +55,7 @@ func (vrdr *VariableReader) Next() bool {
 				}
 			}
 
-			if recur {
+			if recur && vrdr.entry.Children {
 				vrdr.depth++
 			} else {
 				if vrdr.depth == 0 {


### PR DESCRIPTION
On macOS, externally linked programs will have an abbrev for
DW_TAG_subprogram without the haschildren flag set. We should handle
this case instead of expecting all DW_TAG_subprogram entries to have
list of children.

Fixes #1034