### PR TITLE
Makefile: handle empty GOPATH on darwin

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,7 @@
 .DEFAULT_GOAL=test
 UNAME=$(shell uname)
 PREFIX=github.com/derekparker/delve
+GOPATH=$(shell go env GOPATH)
 GOVERSION=$(shell go version)
 BUILD_SHA=$(shell git rev-parse HEAD)
 LLDB_SERVER=$(shell which lldb-server)


### PR DESCRIPTION
As of Go 1.8, allows empty GOPATH environment variable.
Fall back `make install` when GOPATH is not set on darwin OS.