### PR TITLE
dwarf/line: fix output for the last line of a compile unit

### DIFF
--- a/pkg/dwarf/line/state_machine.go
+++ b/pkg/dwarf/line/state_machine.go
@@ -236,6 +236,9 @@ func (sm *StateMachine) PCToLine(pc uint64) (string, int, bool) {
 			break
 		}
 	}
+	if sm.valid {
+		return sm.file, sm.line, true
+	}
 	return "", 0, false
 }
 


### PR DESCRIPTION
```
dwarf/line: fix output for the last line of a compile unit

The last entry of the debug_line table is supposed to be valid for
every PC address greater than its address.

```
