### PR TITLE
Remove limitation of exit notification only for specific API calls

### DIFF
--- a/_fixtures/pr1055.go
+++ b/_fixtures/pr1055.go
@@ -1,0 +1,13 @@
+package main
+
+import (
+	"fmt"
+	"go/ast"
+	"os"
+)
+
+func main() {
+	a := &ast.CompositeLit{}
+	fmt.Println("demo", a) // set breakpoint here and use next twice
+	os.Exit(2)
+}

--- a/service/debugger/debugger.go
+++ b/service/debugger/debugger.go
@@ -526,7 +526,7 @@ func (d *Debugger) Command(command *api.DebuggerCommand) (*api.DebuggerState, er
 	}
 
 	if err != nil {
-		if exitedErr, exited := err.(proc.ProcessExitedError); (command.Name == api.Continue || command.Name == api.Rewind) && exited {
+		if exitedErr, exited := err.(proc.ProcessExitedError); command.Name != api.SwitchGoroutine && command.Name != api.SwitchThread && exited {
 			state := &api.DebuggerState{}
 			state.Exited = true
 			state.ExitStatus = exitedErr.Status


### PR DESCRIPTION
I've noticed that Delve is inconsistent in marking when a process exits based on the API call which triggered the exit to happen.

In my case, I've noticed this happening for using ` next ` (via RPC).

To have an example to reproduce this

```go
package main

import (
	"fmt"
	"go/ast"
	"os"
)

func main() {
	a := &ast.CompositeLit{}
	fmt.Println("demo", a) // set breakpoint here and use next twice 
	os.Exit(2)
}
```

This allows clients to have a consistent way to handle cases when the process exits.