### PR TITLE
Added key `-u` for `go get` in linux installation readme 

### DIFF
--- a/Documentation/installation/linux/install.md
+++ b/Documentation/installation/linux/install.md
@@ -5,7 +5,7 @@ Please use the following steps to build and install Delve on Linux.
 There are two ways to install on Linux. First is the standard `go get` method:
 
 ```
-go get github.com/derekparker/delve/cmd/dlv
+go get -u github.com/derekparker/delve/cmd/dlv
 ```
 
 Alternatively, you can clone the repo and run:

--- a/Documentation/installation/windows/install.md
+++ b/Documentation/installation/windows/install.md
@@ -3,7 +3,7 @@
 Please use the standard `go get` command to build and install Delve on Windows.
 
 ```
-go get github.com/derekparker/delve/cmd/dlv
+go get -u github.com/derekparker/delve/cmd/dlv
 ```
 
 Note: If you are using Go 1.5 you must set `GO15VENDOREXPERIMENT=1` before continuing. The `GO15VENDOREXPERIMENT` env var simply opts into the [Go 1.5 Vendor Experiment](https://docs.google.com/document/d/1Bz5-UB7g2uPBdOx-rw5t9MxJwkfpx90cqG9AFL0JAYo/).


### PR DESCRIPTION
`go get` needs key `-u` to use network. Mentioned `go get github.com/dereparker/delve/cmd/dlv` without `-u` didn't work for me on debian 9.