### PR TITLE
service/test: disable TestClientServerConsistentExit for rr backend

### DIFF
--- a/service/test/integration2_test.go
+++ b/service/test/integration2_test.go
@@ -1389,7 +1389,6 @@ func TestClientServer_collectBreakpointInfoError(t *testing.T) {
 }
 
 func TestClientServerConsistentExit(t *testing.T) {
-	protest.AllowRecording(t)
 	// This test is useful because it ensures that Next and Continue operations both
 	// exit with the same exit status and details when the target application terminates.
 	// Other program execution API calls should also behave in the same way.


### PR DESCRIPTION
```
service/test: disable TestClientServerConsistentExit for rr backend

The rr backend doesn't report the exit status (the argument of the W
packet seems to always be 0).

Fixes #1067

```
