### PR TITLE
proc_test: deflake TestSystemstackOnRuntimeNewstack

### DIFF
--- a/pkg/proc/proc_test.go
+++ b/pkg/proc/proc_test.go
@@ -3365,11 +3365,21 @@ func TestSystemstackOnRuntimeNewstack(t *testing.T) {
 		_, err := setFunctionBreakpoint(p, "main.main")
 		assertNoError(err, t, "setFunctionBreakpoint(main.main)")
 		assertNoError(proc.Continue(p), t, "first continue")
-		_, err = setFunctionBreakpoint(p, "runtime.newstack")
-		assertNoError(err, t, "setFunctionBreakpoint(runtime.newstack)")
-		assertNoError(proc.Continue(p), t, "second continue")
+
 		g, err := proc.GetG(p.CurrentThread())
 		assertNoError(err, t, "GetG")
+		mainGoroutineID := g.ID
+
+		_, err = setFunctionBreakpoint(p, "runtime.newstack")
+		assertNoError(err, t, "setFunctionBreakpoint(runtime.newstack)")
+		for {
+			assertNoError(proc.Continue(p), t, "second continue")
+			g, err = proc.GetG(p.CurrentThread())
+			assertNoError(err, t, "GetG")
+			if g.ID == mainGoroutineID {
+				break
+			}
+		}
 		frames, err := g.Stacktrace(100)
 		assertNoError(err, t, "stacktrace")
 		logStacktrace(t, frames)


### PR DESCRIPTION
```
proc_test: deflake TestSystemstackOnRuntimeNewstack

Depending on how the runtime schedules our goroutines we can get
unlucky and have the first call to runtime.newstack we intercept be for
a different goroutine (usually the garbage collector).
Only check stacktraces that happen on the same goroutine that executed
main.main.

```
