### PR TITLE
core_test: fix TestCoreFpRegisters on go1.9

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: go
-sudo: false
+sudo: required
 
 os:
   - linux

--- a/pkg/proc/core/core_test.go
+++ b/pkg/proc/core/core_test.go
@@ -243,7 +243,7 @@ func TestCoreFpRegisters(t *testing.T) {
 			if frames[i].Current.Fn == nil {
 				continue
 			}
-			if frames[i].Current.Fn.Name == "runtime.crash" {
+			if frames[i].Current.Fn.Name == "main.main" {
 				regs, err = thread.Registers(true)
 				if err != nil {
 					t.Fatalf("Could not get registers for thread %x, %v", thread.ThreadID(), err)


### PR DESCRIPTION
```
core_test: fix TestCoreFpRegisters on go1.9

It was broken by 7bec20e5fca48552b004fc8776dd9e6502a11706

```
