### PR TITLE
miscellaneous proc/native cleanups

### DIFF
--- a/_fixtures/issue1101.go
+++ b/_fixtures/issue1101.go
@@ -1,0 +1,20 @@
+package main
+
+import (
+	"os"
+	"sync"
+)
+
+var wg sync.WaitGroup
+
+func f(from string) {
+	defer wg.Done()
+	return
+}
+
+func main() {
+	wg.Add(1)
+	go f("goroutine")
+	wg.Wait()
+	os.Exit(2)
+}

--- a/pkg/proc/core/core.go
+++ b/pkg/proc/core/core.go
@@ -302,10 +302,6 @@ func (p *Process) AllGCache() *[]*proc.G {
 	return &p.allGCache
 }
 
-func (p *Process) Halt() error {
-	return nil
-}
-
 func (p *Process) Pid() int {
 	return p.core.Pid
 }

--- a/pkg/proc/core/core.go
+++ b/pkg/proc/core/core.go
@@ -306,10 +306,6 @@ func (p *Process) Halt() error {
 	return nil
 }
 
-func (p *Process) Kill() error {
-	return nil
-}
-
 func (p *Process) Pid() int {
 	return p.core.Pid
 }

--- a/pkg/proc/gdbserial/gdbserver.go
+++ b/pkg/proc/gdbserial/gdbserver.go
@@ -745,24 +745,14 @@ func (p *Process) Halt() error {
 	return p.conn.sendCtrlC()
 }
 
-func (p *Process) Kill() error {
-	if p.exited {
-		return nil
-	}
-	err := p.conn.kill()
-	if _, exited := err.(proc.ProcessExitedError); exited {
-		p.exited = true
-		return nil
-	}
-	return err
-}
-
 func (p *Process) Detach(kill bool) error {
-	if kill {
-		if err := p.Kill(); err != nil {
+	if kill && !p.exited {
+		err := p.conn.kill()
+		if err != nil {
 			if _, exited := err.(proc.ProcessExitedError); !exited {
 				return err
 			}
+			p.exited = true
 		}
 	}
 	if !p.exited {

--- a/pkg/proc/gdbserial/gdbserver.go
+++ b/pkg/proc/gdbserial/gdbserver.go
@@ -737,14 +737,6 @@ func (p *Process) getCtrlC() bool {
 	return p.ctrlC
 }
 
-func (p *Process) Halt() error {
-	if p.exited {
-		return nil
-	}
-	p.setCtrlC(true)
-	return p.conn.sendCtrlC()
-}
-
 func (p *Process) Detach(kill bool) error {
 	if kill && !p.exited {
 		err := p.conn.kill()

--- a/pkg/proc/gdbserial/rr_test.go
+++ b/pkg/proc/gdbserial/rr_test.go
@@ -26,7 +26,6 @@ func withTestRecording(name string, t testing.TB, fn func(p *gdbserial.Process, 
 	t.Logf("replaying %q", tracedir)
 
 	defer func() {
-		p.Halt()
 		p.Detach(true)
 		if tracedir != "" {
 			protest.SafeRemoveAll(tracedir)

--- a/pkg/proc/interface.go
+++ b/pkg/proc/interface.go
@@ -90,7 +90,6 @@ type ProcessManipulation interface {
 	// CheckAndClearManualStopRequest returns true the first time it's called
 	// after a call to RequestManualStop.
 	CheckAndClearManualStopRequest() bool
-	Halt() error
 	Detach(bool) error
 }
 

--- a/pkg/proc/interface.go
+++ b/pkg/proc/interface.go
@@ -91,7 +91,6 @@ type ProcessManipulation interface {
 	// after a call to RequestManualStop.
 	CheckAndClearManualStopRequest() bool
 	Halt() error
-	Kill() error
 	Detach(bool) error
 }
 

--- a/pkg/proc/native/proc.go
+++ b/pkg/proc/native/proc.go
@@ -246,10 +246,7 @@ func (dbp *Process) ContinueOnce() (proc.Thread, error) {
 	if err != nil {
 		return nil, err
 	}
-	if err := dbp.Halt(); err != nil {
-		return nil, dbp.exitGuard(err)
-	}
-	if err := dbp.setCurrentBreakpoints(trapthread); err != nil {
+	if err := dbp.stop(trapthread); err != nil {
 		return nil, err
 	}
 	return trapthread, err
@@ -321,19 +318,6 @@ func (dbp *Process) SwitchGoroutine(gid int) error {
 		return dbp.SwitchThread(g.Thread.ThreadID())
 	}
 	dbp.selectedGoroutine = g
-	return nil
-}
-
-// Halt stops all threads.
-func (dbp *Process) Halt() (err error) {
-	if dbp.exited {
-		return &proc.ProcessExitedError{Pid: dbp.Pid()}
-	}
-	for _, th := range dbp.threads {
-		if err := th.Halt(); err != nil {
-			return err
-		}
-	}
 	return nil
 }
 

--- a/pkg/proc/native/proc.go
+++ b/pkg/proc/native/proc.go
@@ -79,7 +79,7 @@ func (dbp *Process) Detach(kill bool) (err error) {
 		return nil
 	}
 	if kill && dbp.childProcess {
-		err := dbp.Kill()
+		err := dbp.kill()
 		if err != nil {
 			return err
 		}

--- a/pkg/proc/native/proc.go
+++ b/pkg/proc/native/proc.go
@@ -32,8 +32,7 @@ type Process struct {
 	allGCache           []*proc.G
 	os                  *OSProcessDetails
 	firstStart          bool
-	haltMu              sync.Mutex
-	halt                bool
+	stopMu              sync.Mutex
 	resumeChan          chan<- struct{}
 	exited              bool
 	ptraceChan          chan func()
@@ -176,18 +175,17 @@ func (dbp *Process) RequestManualStop() error {
 	if dbp.exited {
 		return &proc.ProcessExitedError{Pid: dbp.Pid()}
 	}
-	dbp.haltMu.Lock()
-	defer dbp.haltMu.Unlock()
+	dbp.stopMu.Lock()
+	defer dbp.stopMu.Unlock()
 	dbp.manualStopRequested = true
-	dbp.halt = true
 	return dbp.requestManualStop()
 }
 
 func (dbp *Process) CheckAndClearManualStopRequest() bool {
-	dbp.haltMu.Lock()
+	dbp.stopMu.Lock()
 	msr := dbp.manualStopRequested
 	dbp.manualStopRequested = false
-	dbp.haltMu.Unlock()
+	dbp.stopMu.Unlock()
 	return msr
 }
 

--- a/pkg/proc/native/proc_darwin.go
+++ b/pkg/proc/native/proc_darwin.go
@@ -166,7 +166,7 @@ func Attach(pid int) (*Process, error) {
 }
 
 // Kill kills the process.
-func (dbp *Process) Kill() (err error) {
+func (dbp *Process) kill() (err error) {
 	if dbp.exited {
 		return nil
 	}

--- a/pkg/proc/native/proc_darwin.go
+++ b/pkg/proc/native/proc_darwin.go
@@ -435,7 +435,6 @@ func (dbp *Process) stop(trapthread *Thread) (err error) {
 				return dbp.exitGuard(err)
 			}
 		}
-		th.running = false
 	}
 
 	ports, err := dbp.waitForStop()

--- a/pkg/proc/native/proc_linux.go
+++ b/pkg/proc/native/proc_linux.go
@@ -240,8 +240,8 @@ func (dbp *Process) trapWait(pid int) (*Thread, error) {
 			dbp.haltMu.Unlock()
 			if halt {
 				dbp.halt = false
-				th.running = false
-				dbp.threads[int(wpid)].running = false
+				th.os.running = false
+				dbp.threads[int(wpid)].os.running = false
 				return nil, nil
 			}
 			if err = th.Continue(); err != nil {
@@ -267,12 +267,12 @@ func (dbp *Process) trapWait(pid int) (*Thread, error) {
 		halt := dbp.halt
 		dbp.haltMu.Unlock()
 		if halt && (status.StopSignal() == sys.SIGTRAP || status.StopSignal() == sys.SIGSTOP) {
-			th.running = false
+			th.os.running = false
 			dbp.halt = false
 			return th, nil
 		}
 		if status.StopSignal() == sys.SIGTRAP {
-			th.running = false
+			th.os.running = false
 			return th, nil
 		}
 		if th != nil {
@@ -425,7 +425,7 @@ func (dbp *Process) stop(trapthread *Thread) (err error) {
 	for {
 		allstopped := true
 		for _, th := range dbp.threads {
-			if th.running {
+			if th.os.running {
 				allstopped = false
 				break
 			}

--- a/pkg/proc/native/proc_linux.go
+++ b/pkg/proc/native/proc_linux.go
@@ -98,8 +98,8 @@ func Attach(pid int) (*Process, error) {
 	return dbp, nil
 }
 
-// Kill kills the target process.
-func (dbp *Process) Kill() (err error) {
+// kill kills the target process.
+func (dbp *Process) kill() (err error) {
 	if dbp.exited {
 		return nil
 	}

--- a/pkg/proc/native/proc_windows.go
+++ b/pkg/proc/native/proc_windows.go
@@ -404,7 +404,6 @@ func (dbp *Process) resume() error {
 	}
 
 	for _, thread := range dbp.threads {
-		thread.running = true
 		_, err := _ResumeThread(thread.os.hThread)
 		if err != nil {
 			return err
@@ -418,9 +417,6 @@ func (dbp *Process) resume() error {
 func (dbp *Process) stop(trapthread *Thread) (err error) {
 	if dbp.exited {
 		return &proc.ProcessExitedError{Pid: dbp.Pid()}
-	}
-	for _, th := range dbp.threads {
-		th.running = false
 	}
 
 	// While the debug event that stopped the target was being propagated
@@ -439,7 +435,6 @@ func (dbp *Process) stop(trapthread *Thread) (err error) {
 	}
 
 	for _, thread := range dbp.threads {
-		thread.running = false
 		_, err := _SuspendThread(thread.os.hThread)
 		if err != nil {
 			return err

--- a/pkg/proc/native/proc_windows.go
+++ b/pkg/proc/native/proc_windows.go
@@ -170,8 +170,8 @@ func Attach(pid int) (*Process, error) {
 	return dbp, nil
 }
 
-// Kill kills the process.
-func (dbp *Process) Kill() error {
+// kill kills the process.
+func (dbp *Process) kill() error {
 	if dbp.exited {
 		return nil
 	}

--- a/pkg/proc/native/threads.go
+++ b/pkg/proc/native/threads.go
@@ -113,13 +113,6 @@ func (thread *Thread) SetPC(pc uint64) error {
 	return regs.SetPC(thread, pc)
 }
 
-// Stopped returns whether the thread is stopped at
-// the operating system level. Actual implementation
-// is OS dependant, look in OS thread file.
-func (thread *Thread) Stopped() bool {
-	return thread.stopped()
-}
-
 // SetCurrentBreakpoint sets the current breakpoint that this
 // thread is stopped at as CurrentBreakpoint on the thread struct.
 func (thread *Thread) SetCurrentBreakpoint() error {

--- a/pkg/proc/native/threads.go
+++ b/pkg/proc/native/threads.go
@@ -120,22 +120,6 @@ func (thread *Thread) Stopped() bool {
 	return thread.stopped()
 }
 
-// Halt stops this thread from executing. Actual
-// implementation is OS dependant. Look in OS
-// thread file.
-func (thread *Thread) Halt() (err error) {
-	defer func() {
-		if err == nil {
-			thread.running = false
-		}
-	}()
-	if thread.Stopped() {
-		return
-	}
-	err = thread.halt()
-	return
-}
-
 // SetCurrentBreakpoint sets the current breakpoint that this
 // thread is stopped at as CurrentBreakpoint on the thread struct.
 func (thread *Thread) SetCurrentBreakpoint() error {

--- a/pkg/proc/native/threads.go
+++ b/pkg/proc/native/threads.go
@@ -18,7 +18,6 @@ type Thread struct {
 
 	dbp            *Process
 	singleStepping bool
-	running        bool
 	os             *OSSpecificDetails
 }
 
@@ -49,11 +48,9 @@ func (thread *Thread) Continue() error {
 // execute the instruction, and then replace the breakpoint.
 // Otherwise we simply execute the next instruction.
 func (thread *Thread) StepInstruction() (err error) {
-	thread.running = true
 	thread.singleStepping = true
 	defer func() {
 		thread.singleStepping = false
-		thread.running = false
 	}()
 	pc, err := thread.PC()
 	if err != nil {

--- a/pkg/proc/native/threads_darwin.go
+++ b/pkg/proc/native/threads_darwin.go
@@ -27,20 +27,6 @@ type OSSpecificDetails struct {
 // be continued.
 var ErrContinueThread = fmt.Errorf("could not continue thread")
 
-// Halt stops this thread from executing.
-func (thread *Thread) Halt() (err error) {
-	defer func() {
-		if err == nil {
-			thread.running = false
-		}
-	}()
-	if thread.Stopped() {
-		return
-	}
-	err = thread.halt()
-	return
-}
-
 func (t *Thread) halt() (err error) {
 	kret := C.thread_suspend(t.os.threadAct)
 	if kret != C.KERN_SUCCESS {
@@ -116,7 +102,9 @@ func (t *Thread) Blocked() bool {
 	}
 }
 
-func (t *Thread) stopped() bool {
+// Stopped returns whether the thread is stopped at
+// the operating system level.
+func (t *Thread) Stopped() bool {
 	return C.thread_blocked(t.os.threadAct) > C.int(0)
 }
 

--- a/pkg/proc/native/threads_darwin.go
+++ b/pkg/proc/native/threads_darwin.go
@@ -69,7 +69,6 @@ func (t *Thread) singleStep() error {
 }
 
 func (t *Thread) resume() error {
-	t.running = true
 	// TODO(dp) set flag for ptrace stops
 	var err error
 	t.dbp.execPtraceFunc(func() { err = PtraceCont(t.dbp.pid, 0) })

--- a/pkg/proc/native/threads_darwin.go
+++ b/pkg/proc/native/threads_darwin.go
@@ -27,7 +27,7 @@ type OSSpecificDetails struct {
 // be continued.
 var ErrContinueThread = fmt.Errorf("could not continue thread")
 
-func (t *Thread) halt() (err error) {
+func (t *Thread) stop() (err error) {
 	kret := C.thread_suspend(t.os.threadAct)
 	if kret != C.KERN_SUCCESS {
 		errStr := C.GoString(C.mach_error_string(C.mach_error_t(kret)))

--- a/pkg/proc/native/threads_darwin.go
+++ b/pkg/proc/native/threads_darwin.go
@@ -27,6 +27,20 @@ type OSSpecificDetails struct {
 // be continued.
 var ErrContinueThread = fmt.Errorf("could not continue thread")
 
+// Halt stops this thread from executing.
+func (thread *Thread) Halt() (err error) {
+	defer func() {
+		if err == nil {
+			thread.running = false
+		}
+	}()
+	if thread.Stopped() {
+		return
+	}
+	err = thread.halt()
+	return
+}
+
 func (t *Thread) halt() (err error) {
 	kret := C.thread_suspend(t.os.threadAct)
 	if kret != C.KERN_SUCCESS {

--- a/pkg/proc/native/threads_linux.go
+++ b/pkg/proc/native/threads_linux.go
@@ -16,15 +16,6 @@ type OSSpecificDetails struct {
 	registers sys.PtraceRegs
 }
 
-// Halt stops this thread from executing.
-func (thread *Thread) Halt() (err error) {
-	if thread.Stopped() {
-		return
-	}
-	err = thread.halt()
-	return
-}
-
 func (t *Thread) halt() (err error) {
 	err = sys.Tgkill(t.dbp.pid, t.ID, sys.SIGSTOP)
 	if err != nil {
@@ -34,7 +25,9 @@ func (t *Thread) halt() (err error) {
 	return
 }
 
-func (t *Thread) stopped() bool {
+// Stopped returns whether the thread is stopped at
+// the operating system level.
+func (t *Thread) Stopped() bool {
 	state := status(t.ID, t.dbp.os.comm)
 	return state == StatusTraceStop || state == StatusTraceStopT
 }

--- a/pkg/proc/native/threads_linux.go
+++ b/pkg/proc/native/threads_linux.go
@@ -16,15 +16,19 @@ type OSSpecificDetails struct {
 	registers sys.PtraceRegs
 }
 
+// Halt stops this thread from executing.
+func (thread *Thread) Halt() (err error) {
+	if thread.Stopped() {
+		return
+	}
+	err = thread.halt()
+	return
+}
+
 func (t *Thread) halt() (err error) {
 	err = sys.Tgkill(t.dbp.pid, t.ID, sys.SIGSTOP)
 	if err != nil {
 		err = fmt.Errorf("halt err %s on thread %d", err, t.ID)
-		return
-	}
-	_, _, err = t.dbp.waitFast(t.ID)
-	if err != nil {
-		err = fmt.Errorf("wait err %s on thread %d", err, t.ID)
 		return
 	}
 	return

--- a/pkg/proc/native/threads_linux.go
+++ b/pkg/proc/native/threads_linux.go
@@ -14,6 +14,7 @@ type WaitStatus sys.WaitStatus
 // process details.
 type OSSpecificDetails struct {
 	registers sys.PtraceRegs
+	running   bool
 }
 
 func (t *Thread) halt() (err error) {
@@ -37,7 +38,7 @@ func (t *Thread) resume() error {
 }
 
 func (t *Thread) resumeWithSig(sig int) (err error) {
-	t.running = true
+	t.os.running = true
 	t.dbp.execPtraceFunc(func() { err = PtraceCont(t.ID, sig) })
 	return
 }

--- a/pkg/proc/native/threads_linux.go
+++ b/pkg/proc/native/threads_linux.go
@@ -17,10 +17,10 @@ type OSSpecificDetails struct {
 	running   bool
 }
 
-func (t *Thread) halt() (err error) {
+func (t *Thread) stop() (err error) {
 	err = sys.Tgkill(t.dbp.pid, t.ID, sys.SIGSTOP)
 	if err != nil {
-		err = fmt.Errorf("halt err %s on thread %d", err, t.ID)
+		err = fmt.Errorf("stop err %s on thread %d", err, t.ID)
 		return
 	}
 	return

--- a/pkg/proc/native/threads_windows.go
+++ b/pkg/proc/native/threads_windows.go
@@ -18,6 +18,20 @@ type OSSpecificDetails struct {
 	hThread syscall.Handle
 }
 
+// Halt stops this thread from executing.
+func (thread *Thread) Halt() (err error) {
+	defer func() {
+		if err == nil {
+			thread.running = false
+		}
+	}()
+	if thread.Stopped() {
+		return
+	}
+	err = thread.halt()
+	return
+}
+
 func (t *Thread) halt() (err error) {
 	// Ignore the request to halt. On Windows, all threads are halted
 	// on return from WaitForDebugEvent.

--- a/pkg/proc/native/threads_windows.go
+++ b/pkg/proc/native/threads_windows.go
@@ -18,30 +18,6 @@ type OSSpecificDetails struct {
 	hThread syscall.Handle
 }
 
-// Halt stops this thread from executing.
-func (thread *Thread) Halt() (err error) {
-	defer func() {
-		if err == nil {
-			thread.running = false
-		}
-	}()
-	if thread.Stopped() {
-		return
-	}
-	err = thread.halt()
-	return
-}
-
-func (t *Thread) halt() (err error) {
-	// Ignore the request to halt. On Windows, all threads are halted
-	// on return from WaitForDebugEvent.
-	return nil
-
-	// TODO - This may not be correct in all usages of dbp.Halt.  There
-	// are some callers who use dbp.Halt() to stop the process when it is not
-	// already broken on a debug event.
-}
-
 func (t *Thread) singleStep() error {
 	context := newCONTEXT()
 	context.ContextFlags = _CONTEXT_ALL
@@ -140,9 +116,9 @@ func (t *Thread) Blocked() bool {
 	}
 }
 
-func (t *Thread) stopped() bool {
-	// TODO: We are assuming that threads are always stopped
-	// during command execution.
+// Stopped returns whether the thread is stopped at the operating system
+// level. On windows this always returns true.
+func (t *Thread) Stopped() bool {
 	return true
 }
 

--- a/pkg/proc/native/threads_windows.go
+++ b/pkg/proc/native/threads_windows.go
@@ -86,7 +86,6 @@ func (t *Thread) singleStep() error {
 }
 
 func (t *Thread) resume() error {
-	t.running = true
 	var err error
 	t.dbp.execPtraceFunc(func() {
 		//TODO: Note that we are ignoring the thread we were asked to continue and are continuing the

--- a/pkg/proc/proc_test.go
+++ b/pkg/proc/proc_test.go
@@ -75,7 +75,6 @@ func withTestProcessArgs(name string, t testing.TB, wd string, args []string, bu
 	}
 
 	defer func() {
-		p.Halt()
 		p.Detach(true)
 		if tracedir != "" {
 			protest.SafeRemoveAll(tracedir)

--- a/pkg/proc/proc_test.go
+++ b/pkg/proc/proc_test.go
@@ -969,20 +969,6 @@ func TestKill(t *testing.T) {
 		return
 	}
 	withTestProcess("testprog", t, func(p proc.Process, fixture protest.Fixture) {
-		if err := p.Kill(); err != nil {
-			t.Fatal(err)
-		}
-		if !p.Exited() {
-			t.Fatal("expected process to have exited")
-		}
-		if runtime.GOOS == "linux" {
-			_, err := os.Open(fmt.Sprintf("/proc/%d/", p.Pid()))
-			if err == nil {
-				t.Fatal("process has not exited", p.Pid())
-			}
-		}
-	})
-	withTestProcess("testprog", t, func(p proc.Process, fixture protest.Fixture) {
 		if err := p.Detach(true); err != nil {
 			t.Fatal(err)
 		}
@@ -2086,8 +2072,7 @@ func TestUnsupportedArch(t *testing.T) {
 	case proc.UnsupportedLinuxArchErr, proc.UnsupportedWindowsArchErr, proc.UnsupportedDarwinArchErr:
 		// all good
 	case nil:
-		p.Halt()
-		p.Kill()
+		p.Detach(true)
 		t.Fatal("Launch is expected to fail, but succeeded")
 	default:
 		t.Fatal(err)

--- a/pkg/proc/proc_unix_test.go
+++ b/pkg/proc/proc_unix_test.go
@@ -46,7 +46,7 @@ func TestIssue419(t *testing.T) {
 			if p.Pid() <= 0 {
 				// if we don't stop the inferior the test will never finish
 				p.RequestManualStop()
-				err := p.Kill()
+				err := p.Detach(true)
 				errChan <- errIssue419{pid: p.Pid(), err: err}
 				return
 			}
@@ -57,7 +57,7 @@ func TestIssue419(t *testing.T) {
 		errChan <- proc.Continue(p)
 	})
 
-	for i :=0; i<2; i++ {
+	for i := 0; i < 2; i++ {
 		err := <-errChan
 
 		if v, ok := err.(errIssue419); ok {

--- a/service/test/variables_test.go
+++ b/service/test/variables_test.go
@@ -128,7 +128,6 @@ func withTestProcess(name string, t *testing.T, fn func(p proc.Process, fixture 
 	}
 
 	defer func() {
-		p.Halt()
 		p.Detach(true)
 		if tracedir != "" {
 			protest.SafeRemoveAll(tracedir)


### PR DESCRIPTION
* Removes proc.Process.Kill, it was only used by tests at this point
* Removes proc.Process.Halt, fuses the Halt in proc/native with native's setCurrentBreakpoints into a single stop method. Halt wasn't used outside of native and some tests, and it was redundant with RequestManualStop.
* Moves the fields Process.halt and Thread.running in native to os specific structs and removes them from all operating system implementations that don't actually make use of them.