### PR TITLE
[WIP] Improve trace subcommand to show returns

### DIFF
--- a/pkg/proc/breakpoints.go
+++ b/pkg/proc/breakpoints.go
@@ -16,6 +16,7 @@ type Breakpoint struct {
 	FunctionName string
 	File         string
 	Line         int
+	AtReturn     bool
 
 	Addr         uint64 // Address breakpoint is set for.
 	OriginalData []byte // If software breakpoint, the data we replace with breakpoint instruction.
@@ -30,14 +31,15 @@ type Breakpoint struct {
 	Kind BreakpointKind
 
 	// Breakpoint information
-	Tracepoint    bool     // Tracepoint flag
-	Goroutine     bool     // Retrieve goroutine information
-	Stacktrace    int      // Number of stack frames to retrieve
-	Variables     []string // Variables to evaluate
-	LoadArgs      *LoadConfig
-	LoadLocals    *LoadConfig
-	HitCount      map[int]uint64 // Number of times a breakpoint has been reached in a certain goroutine
-	TotalHitCount uint64         // Number of times a breakpoint has been reached
+	Tracepoint     bool     // Tracepoint flag
+	Goroutine      bool     // Retrieve goroutine information
+	Stacktrace     int      // Number of stack frames to retrieve
+	Variables      []string // Variables to evaluate
+	LoadArgs       *LoadConfig
+	LoadReturnVals *LoadConfig
+	LoadLocals     *LoadConfig
+	HitCount       map[int]uint64 // Number of times a breakpoint has been reached in a certain goroutine
+	TotalHitCount  uint64         // Number of times a breakpoint has been reached
 
 	// DeferReturns: when kind == NextDeferBreakpoint this breakpoint
 	// will also check if the caller is runtime.gopanic or if the return

--- a/pkg/proc/gdbserial/gdbserver.go
+++ b/pkg/proc/gdbserial/gdbserver.go
@@ -313,7 +313,7 @@ func (p *Process) Connect(conn net.Conn, path string, pid int) error {
 
 	p.selectedGoroutine, _ = proc.GetG(p.CurrentThread())
 
-	panicpc, err := proc.FindFunctionLocation(p, "runtime.startpanic", true, 0)
+	panicpc, err := proc.FindFunctionLocation(p, "runtime.startpanic", true, false, 0)
 	if err == nil {
 		bp, err := p.breakpoints.SetWithID(-1, panicpc, p.writeBreakpoint)
 		if err == nil {

--- a/pkg/proc/gdbserial/rr_test.go
+++ b/pkg/proc/gdbserial/rr_test.go
@@ -44,7 +44,7 @@ func assertNoError(err error, t testing.TB, s string) {
 }
 
 func setFunctionBreakpoint(p proc.Process, t *testing.T, fname string) *proc.Breakpoint {
-	addr, err := proc.FindFunctionLocation(p, fname, true, 0)
+	addr, err := proc.FindFunctionLocation(p, fname, true, false, 0)
 	assertNoError(err, t, fmt.Sprintf("FindFunctionLocation(%s)", fname))
 	bp, err := p.SetBreakpoint(addr, proc.UserBreakpoint, nil)
 	assertNoError(err, t, fmt.Sprintf("SetBreakpoint(%#x) function %s", addr, fname))

--- a/pkg/proc/native/proc.go
+++ b/pkg/proc/native/proc.go
@@ -349,7 +349,7 @@ func initializeDebugProcess(dbp *Process, path string) (*Process, error) {
 	// the offset of g struct inside TLS
 	dbp.selectedGoroutine, _ = proc.GetG(dbp.currentThread)
 
-	panicpc, err := proc.FindFunctionLocation(dbp, "runtime.startpanic", true, 0)
+	panicpc, err := proc.FindFunctionLocation(dbp, "runtime.startpanic", true, false, 0)
 	if err == nil {
 		bp, err := dbp.breakpoints.SetWithID(-1, panicpc, dbp.writeBreakpoint)
 		if err == nil {

--- a/pkg/proc/proc.go
+++ b/pkg/proc/proc.go
@@ -45,7 +45,7 @@ func FindFileLocation(p Process, fileName string, lineno int) (uint64, error) {
 // Pass lineOffset == 0 and firstLine == false if you want the address for the function's entry point
 // Note that setting breakpoints at that address will cause surprising behavior:
 // https://github.com/derekparker/delve/issues/170
-func FindFunctionLocation(p Process, funcName string, firstLine bool, lineOffset int) (uint64, error) {
+func FindFunctionLocation(p Process, funcName string, firstLine bool, end bool, lineOffset int) (uint64, error) {
 	bi := p.BinInfo()
 	origfn := bi.LookupFunc[funcName]
 	if origfn == nil {
@@ -54,6 +54,8 @@ func FindFunctionLocation(p Process, funcName string, firstLine bool, lineOffset
 
 	if firstLine {
 		return FirstPCAfterPrologue(p, origfn, false)
+	} else if end {
+		return origfn.End - 32, nil
 	} else if lineOffset > 0 {
 		filename, lineno := origfn.cu.lineInfo.PCToLine(origfn.Entry, origfn.Entry)
 		breakAddr, _, err := bi.LineToPC(filename, lineno+lineOffset)

--- a/pkg/proc/proc_test.go
+++ b/pkg/proc/proc_test.go
@@ -169,7 +169,7 @@ func TestExitAfterContinue(t *testing.T) {
 }
 
 func setFunctionBreakpoint(p proc.Process, fname string) (*proc.Breakpoint, error) {
-	addr, err := proc.FindFunctionLocation(p, fname, true, 0)
+	addr, err := proc.FindFunctionLocation(p, fname, true, false, 0)
 	if err != nil {
 		return nil, err
 	}
@@ -234,7 +234,7 @@ func TestHalt(t *testing.T) {
 func TestStep(t *testing.T) {
 	protest.AllowRecording(t)
 	withTestProcess("testprog", t, func(p proc.Process, fixture protest.Fixture) {
-		helloworldaddr, err := proc.FindFunctionLocation(p, "main.helloworld", false, 0)
+		helloworldaddr, err := proc.FindFunctionLocation(p, "main.helloworld", false, false, 0)
 		assertNoError(err, t, "FindFunctionLocation")
 
 		_, err = p.SetBreakpoint(helloworldaddr, proc.UserBreakpoint, nil)
@@ -257,7 +257,7 @@ func TestStep(t *testing.T) {
 func TestBreakpoint(t *testing.T) {
 	protest.AllowRecording(t)
 	withTestProcess("testprog", t, func(p proc.Process, fixture protest.Fixture) {
-		helloworldaddr, err := proc.FindFunctionLocation(p, "main.helloworld", false, 0)
+		helloworldaddr, err := proc.FindFunctionLocation(p, "main.helloworld", false, false, 0)
 		assertNoError(err, t, "FindFunctionLocation")
 
 		bp, err := p.SetBreakpoint(helloworldaddr, proc.UserBreakpoint, nil)
@@ -282,7 +282,7 @@ func TestBreakpoint(t *testing.T) {
 func TestBreakpointInSeparateGoRoutine(t *testing.T) {
 	protest.AllowRecording(t)
 	withTestProcess("testthreads", t, func(p proc.Process, fixture protest.Fixture) {
-		fnentry, err := proc.FindFunctionLocation(p, "main.anotherthread", false, 0)
+		fnentry, err := proc.FindFunctionLocation(p, "main.anotherthread", false, false, 0)
 		assertNoError(err, t, "FindFunctionLocation")
 
 		_, err = p.SetBreakpoint(fnentry, proc.UserBreakpoint, nil)
@@ -312,7 +312,7 @@ func TestBreakpointWithNonExistantFunction(t *testing.T) {
 
 func TestClearBreakpointBreakpoint(t *testing.T) {
 	withTestProcess("testprog", t, func(p proc.Process, fixture protest.Fixture) {
-		fnentry, err := proc.FindFunctionLocation(p, "main.sleepytime", false, 0)
+		fnentry, err := proc.FindFunctionLocation(p, "main.sleepytime", false, false, 0)
 		assertNoError(err, t, "FindFunctionLocation")
 		bp, err := p.SetBreakpoint(fnentry, proc.UserBreakpoint, nil)
 		assertNoError(err, t, "SetBreakpoint()")
@@ -710,7 +710,7 @@ func TestFindReturnAddressTopOfStackFn(t *testing.T) {
 	protest.AllowRecording(t)
 	withTestProcess("testreturnaddress", t, func(p proc.Process, fixture protest.Fixture) {
 		fnName := "runtime.rt0_go"
-		fnentry, err := proc.FindFunctionLocation(p, fnName, false, 0)
+		fnentry, err := proc.FindFunctionLocation(p, fnName, false, false, 0)
 		assertNoError(err, t, "FindFunctionLocation")
 		if _, err := p.SetBreakpoint(fnentry, proc.UserBreakpoint, nil); err != nil {
 			t.Fatal(err)
@@ -732,7 +732,7 @@ func TestSwitchThread(t *testing.T) {
 		if err == nil {
 			t.Fatal("Expected error for invalid thread id")
 		}
-		pc, err := proc.FindFunctionLocation(p, "main.main", true, 0)
+		pc, err := proc.FindFunctionLocation(p, "main.main", true, false, 0)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -778,7 +778,7 @@ func TestCGONext(t *testing.T) {
 
 	protest.AllowRecording(t)
 	withTestProcess("cgotest", t, func(p proc.Process, fixture protest.Fixture) {
-		pc, err := proc.FindFunctionLocation(p, "main.main", true, 0)
+		pc, err := proc.FindFunctionLocation(p, "main.main", true, false, 0)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -1764,9 +1764,9 @@ func TestIssue332_Part2(t *testing.T) {
 		regs, err := p.CurrentThread().Registers(false)
 		assertNoError(err, t, "Registers()")
 		pc := regs.PC()
-		pcAfterPrologue, err := proc.FindFunctionLocation(p, "main.changeMe", true, -1)
+		pcAfterPrologue, err := proc.FindFunctionLocation(p, "main.changeMe", true, false, -1)
 		assertNoError(err, t, "FindFunctionLocation()")
-		pcEntry, err := proc.FindFunctionLocation(p, "main.changeMe", false, 0)
+		pcEntry, err := proc.FindFunctionLocation(p, "main.changeMe", false, false, 0)
 		if err != nil {
 			t.Fatalf("got error while finding function location: %v", err)
 		}
@@ -1789,7 +1789,7 @@ func TestIssue332_Part2(t *testing.T) {
 
 func TestIssue396(t *testing.T) {
 	withTestProcess("callme", t, func(p proc.Process, fixture protest.Fixture) {
-		_, err := proc.FindFunctionLocation(p, "main.init", true, -1)
+		_, err := proc.FindFunctionLocation(p, "main.init", true, false, -1)
 		assertNoError(err, t, "FindFunctionLocation()")
 	})
 }
@@ -2083,7 +2083,7 @@ func TestIssue573(t *testing.T) {
 	// of the function and the internal breakpoint set by StepInto may be missed.
 	protest.AllowRecording(t)
 	withTestProcess("issue573", t, func(p proc.Process, fixture protest.Fixture) {
-		fentry, _ := proc.FindFunctionLocation(p, "main.foo", false, 0)
+		fentry, _ := proc.FindFunctionLocation(p, "main.foo", false, false, 0)
 		_, err := p.SetBreakpoint(fentry, proc.UserBreakpoint, nil)
 		assertNoError(err, t, "SetBreakpoint()")
 		assertNoError(proc.Continue(p), t, "Continue()")
@@ -2095,9 +2095,9 @@ func TestIssue573(t *testing.T) {
 
 func TestTestvariables2Prologue(t *testing.T) {
 	withTestProcess("testvariables2", t, func(p proc.Process, fixture protest.Fixture) {
-		addrEntry, err := proc.FindFunctionLocation(p, "main.main", false, 0)
+		addrEntry, err := proc.FindFunctionLocation(p, "main.main", false, false, 0)
 		assertNoError(err, t, "FindFunctionLocation - entrypoint")
-		addrPrologue, err := proc.FindFunctionLocation(p, "main.main", true, 0)
+		addrPrologue, err := proc.FindFunctionLocation(p, "main.main", true, false, 0)
 		assertNoError(err, t, "FindFunctionLocation - postprologue")
 		if addrEntry == addrPrologue {
 			t.Fatalf("Prologue detection failed on testvariables2.go/main.main")

--- a/pkg/proc/variables.go
+++ b/pkg/proc/variables.go
@@ -97,6 +97,9 @@ type Variable struct {
 	Unreadable error
 
 	LocationExpr string // location expression
+
+	// whether var is a function return value
+	functionReturn bool
 }
 
 type LoadConfig struct {
@@ -617,7 +620,32 @@ func (scope *EvalScope) LocalVariables(cfg LoadConfig) ([]*Variable, error) {
 
 // FunctionArguments returns the name, value, and type of all current function arguments.
 func (scope *EvalScope) FunctionArguments(cfg LoadConfig) ([]*Variable, error) {
-	return scope.variablesByTag(dwarf.TagFormalParameter, &cfg)
+	vars, err := scope.variablesByTag(dwarf.TagFormalParameter, &cfg)
+	if err != nil {
+		return nil, err
+	}
+	args := make([]*Variable, 0, len(vars))
+	for _, v := range vars {
+		if !v.functionReturn {
+			args = append(args, v)
+		}
+	}
+	return args, nil
+}
+
+// FunctionReturnVals returns the name, value, and type of all current function return values.
+func (scope *EvalScope) FunctionReturnVals(cfg LoadConfig) ([]*Variable, error) {
+	vars, err := scope.variablesByTag(dwarf.TagFormalParameter, &cfg)
+	if err != nil {
+		return nil, err
+	}
+	rets := make([]*Variable, 0, len(vars))
+	for _, v := range vars {
+		if v.functionReturn {
+			rets = append(rets, v)
+		}
+	}
+	return rets, nil
 }
 
 // PackageVariables returns the name, value, and type of all package variables in the application.
@@ -798,6 +826,15 @@ func (scope *EvalScope) extractVarInfoFromEntry(varEntry *dwarf.Entry) (*Variabl
 	if err != nil {
 		v.Unreadable = err
 	}
+
+	// Check if this variable is a function return value.
+	if varEntry.Tag == dwarf.TagFormalParameter {
+		attrVarParam, ok := entry.Val(dwarf.AttrVarParam).(bool)
+		if ok {
+			v.functionReturn = attrVarParam
+		}
+	}
+
 	return v, nil
 }
 

--- a/pkg/terminal/command.go
+++ b/pkg/terminal/command.go
@@ -1428,13 +1428,23 @@ func printcontextThread(t *Term, th *api.Thread) {
 		}
 		args = strings.Join(arg, ", ")
 	}
+	retVals := ""
+	if th.BreakpointInfo != nil && th.Breakpoint.LoadReturnVals != nil && *th.Breakpoint.LoadReturnVals == ShortLoadConfig {
+		var retValVars []string
+		for _, ar := range th.BreakpointInfo.Returns {
+			retValVars = append(retValVars, ar.SinglelineString())
+		}
+		retVals = strings.Join(retValVars, ", ")
+	}
 
 	bpname := ""
 	if th.Breakpoint.Name != "" {
 		bpname = fmt.Sprintf("[%s] ", th.Breakpoint.Name)
 	}
 
-	if hitCount, ok := th.Breakpoint.HitCount[strconv.Itoa(th.GoroutineID)]; ok {
+	if len(retVals) > 0 {
+		fmt.Printf("==> (%s)\n", retVals)
+	} else if hitCount, ok := th.Breakpoint.HitCount[strconv.Itoa(th.GoroutineID)]; ok {
 		fmt.Printf("> %s%s(%s) %s:%d (hits goroutine(%d):%d total:%d) (PC: %#v)\n",
 			bpname,
 			fn.Name,

--- a/service/api/conversions.go
+++ b/service/api/conversions.go
@@ -16,19 +16,21 @@ import (
 // an api.Breakpoint.
 func ConvertBreakpoint(bp *proc.Breakpoint) *Breakpoint {
 	b := &Breakpoint{
-		Name:          bp.Name,
-		ID:            bp.ID,
-		FunctionName:  bp.FunctionName,
-		File:          bp.File,
-		Line:          bp.Line,
-		Addr:          bp.Addr,
-		Tracepoint:    bp.Tracepoint,
-		Stacktrace:    bp.Stacktrace,
-		Goroutine:     bp.Goroutine,
-		Variables:     bp.Variables,
-		LoadArgs:      LoadConfigFromProc(bp.LoadArgs),
-		LoadLocals:    LoadConfigFromProc(bp.LoadLocals),
-		TotalHitCount: bp.TotalHitCount,
+		Name:           bp.Name,
+		ID:             bp.ID,
+		FunctionName:   bp.FunctionName,
+		File:           bp.File,
+		Line:           bp.Line,
+		AtReturn:       bp.AtReturn,
+		Addr:           bp.Addr,
+		Tracepoint:     bp.Tracepoint,
+		Stacktrace:     bp.Stacktrace,
+		Goroutine:      bp.Goroutine,
+		Variables:      bp.Variables,
+		LoadArgs:       LoadConfigFromProc(bp.LoadArgs),
+		LoadReturnVals: LoadConfigFromProc(bp.LoadReturnVals),
+		LoadLocals:     LoadConfigFromProc(bp.LoadLocals),
+		TotalHitCount:  bp.TotalHitCount,
 	}
 
 	b.HitCount = map[string]uint64{}

--- a/service/api/types.go
+++ b/service/api/types.go
@@ -48,6 +48,8 @@ type Breakpoint struct {
 	File string `json:"file"`
 	// Line is a line in File for the breakpoint.
 	Line int `json:"line"`
+	// AtReturn tells whether to set the breakpoint at the funcion return address.
+	AtReturn bool `json:"atReturn"`
 	// FunctionName is the name of the function at the current breakpoint, and
 	// may not always be available.
 	FunctionName string `json:"functionName,omitempty"`
@@ -65,6 +67,8 @@ type Breakpoint struct {
 	Variables []string `json:"variables,omitempty"`
 	// LoadArgs requests loading function arguments when the breakpoint is hit
 	LoadArgs *LoadConfig
+	// LoadReturnVals requests loading function return values when the breakpoint is hit
+	LoadReturnVals *LoadConfig
 	// LoadLocals requests loading function locals when the breakpoint is hit
 	LoadLocals *LoadConfig
 	// number of times a breakpoint has been reached in a certain goroutine
@@ -265,6 +269,7 @@ type BreakpointInfo struct {
 	Goroutine  *Goroutine   `json:"goroutine,omitempty"`
 	Variables  []Variable   `json:"variables,omitempty"`
 	Arguments  []Variable   `json:"arguments,omitempty"`
+	Returns    []Variable   `json:"returns,omitempty"`
 	Locals     []Variable   `json:"locals,omitempty"`
 }
 

--- a/service/config.go
+++ b/service/config.go
@@ -34,4 +34,7 @@ type Config struct {
 
 	// DisconnectChan will be closed by the server when the client disconnects
 	DisconnectChan chan<- struct{}
+
+	// TraceMode tells the debugger whether to discard target stdout / stderr.
+	TraceMode bool
 }

--- a/service/debugger/locations.go
+++ b/service/debugger/locations.go
@@ -249,7 +249,7 @@ func (loc *RegexLocationSpec) Find(d *Debugger, scope *proc.EvalScope, locStr st
 	}
 	r := make([]api.Location, 0, len(matches))
 	for i := range matches {
-		addr, err := proc.FindFunctionLocation(d.target, matches[i], true, 0)
+		addr, err := proc.FindFunctionLocation(d.target, matches[i], true, false, 0)
 		if err == nil {
 			r = append(r, api.Location{PC: addr})
 		}
@@ -381,9 +381,9 @@ func (loc *NormalLocationSpec) Find(d *Debugger, scope *proc.EvalScope, locStr s
 		addr, err = proc.FindFileLocation(d.target, candidateFiles[0], loc.LineOffset)
 	} else { // len(candidateFUncs) == 1
 		if loc.LineOffset < 0 {
-			addr, err = proc.FindFunctionLocation(d.target, candidateFuncs[0], true, 0)
+			addr, err = proc.FindFunctionLocation(d.target, candidateFuncs[0], true, false, 0)
 		} else {
-			addr, err = proc.FindFunctionLocation(d.target, candidateFuncs[0], false, loc.LineOffset)
+			addr, err = proc.FindFunctionLocation(d.target, candidateFuncs[0], false, false, loc.LineOffset)
 		}
 	}
 

--- a/service/rpc2/server.go
+++ b/service/rpc2/server.go
@@ -395,11 +395,11 @@ type ListFunctionArgsOut struct {
 
 // ListFunctionArgs lists all arguments to the current function
 func (s *RPCServer) ListFunctionArgs(arg ListFunctionArgsIn, out *ListFunctionArgsOut) error {
-	vars, err := s.debugger.FunctionArguments(arg.Scope, *api.LoadConfigToProc(&arg.Cfg))
+	args, err := s.debugger.FunctionArguments(arg.Scope, *api.LoadConfigToProc(&arg.Cfg))
 	if err != nil {
 		return err
 	}
-	out.Args = vars
+	out.Args = args
 	return nil
 }
 

--- a/service/test/variables_test.go
+++ b/service/test/variables_test.go
@@ -978,7 +978,7 @@ func TestConstants(t *testing.T) {
 }
 
 func setFunctionBreakpoint(p proc.Process, fname string) (*proc.Breakpoint, error) {
-	addr, err := proc.FindFunctionLocation(p, fname, true, 0)
+	addr, err := proc.FindFunctionLocation(p, fname, true, false, 0)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
This patch aims to improve the `dlv trace` command by printing the
return values. This is still a work in progress at the moment.
Improvements to be made are:

1. Detect true function return. Just like there is a function prologue
there is code at the end of a function after the RET instruction. We do
not want to set the function end breakpoint there as it won't hit when
we expect it to (when the function returns and return args are set).
Possible solutions are to do instruction level comparisons like we do
currently for prologue detection, and in the long term improve the DWARF
information to tell the actual address of the RET instruction via
`epilogue_begin`.

2. Discard target stdout / stderr. This will clean up output and only
show trace output from the debugger, making it all easier to read and
consume for the user.