### PR TITLE
pkg/proc: Fix reporting of 'go' statement

### DIFF
--- a/pkg/proc/variable_test.go
+++ b/pkg/proc/variable_test.go
@@ -1,0 +1,45 @@
+package proc_test
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/derekparker/delve/pkg/proc"
+	protest "github.com/derekparker/delve/pkg/proc/test"
+)
+
+func TestGoroutineCreationLocation(t *testing.T) {
+	protest.AllowRecording(t)
+	withTestProcess("goroutinestackprog", t, func(p proc.Process, fixture protest.Fixture) {
+		bp, err := setFunctionBreakpoint(p, "main.agoroutine")
+		assertNoError(err, t, "BreakByLocation()")
+		assertNoError(proc.Continue(p), t, "Continue()")
+
+		gs, err := proc.GoroutinesInfo(p)
+		assertNoError(err, t, "GoroutinesInfo")
+
+		for _, g := range gs {
+			currentLocation := g.UserCurrent()
+			currentFn := currentLocation.Fn
+			if currentFn != nil && currentFn.BaseName() == "agoroutine" {
+				createdLocation := g.Go()
+				if createdLocation.Fn == nil {
+					t.Fatalf("goroutine creation function is nil")
+				}
+				if createdLocation.Fn.BaseName() != "main" {
+					t.Fatalf("goroutine creation function has wrong name: %s", createdLocation.Fn.BaseName())
+				}
+				if filepath.Base(createdLocation.File) != "goroutinestackprog.go" {
+					t.Fatalf("goroutine creation file incorrect: %s", filepath.Base(createdLocation.File))
+				}
+				if createdLocation.Line != 20 {
+					t.Fatalf("goroutine creation line incorrect: %v", createdLocation.Line)
+				}
+			}
+
+		}
+
+		p.ClearBreakpoint(bp.Addr)
+		proc.Continue(p)
+	})
+}

--- a/pkg/proc/variables.go
+++ b/pkg/proc/variables.go
@@ -526,7 +526,14 @@ func (g *G) UserCurrent() Location {
 // Go returns the location of the 'go' statement
 // that spawned this goroutine.
 func (g *G) Go() Location {
-	f, l, fn := g.variable.bi.PCToLine(g.GoPC)
+	pc := g.GoPC
+	fn := g.variable.bi.PCToFunc(pc)
+	// Backup to CALL instruction.
+	// Mimics runtime/traceback.go:677.
+	if g.GoPC > fn.Entry {
+		pc -= 1
+	}
+	f, l, fn := g.variable.bi.PCToLine(pc)
 	return Location{PC: g.GoPC, File: f, Line: l, Fn: fn}
 }
 


### PR DESCRIPTION
Fixes a bug where the 'go' statement that created a goroutine was
incorrectly reported.

Fixes #1135