### PR TITLE
proc: support interface type resolution for packages containing a dot

### DIFF
--- a/_fixtures/dotpackagesiface.go
+++ b/_fixtures/dotpackagesiface.go
@@ -1,0 +1,15 @@
+package main
+
+import (
+	"dir.io"
+	"dir.io/io.io"
+	"fmt"
+	"runtime"
+)
+
+func main() {
+	var iface interface{} = &dirio.SomeType{}
+	var iface2 interface{} = &ioio.SomeOtherType{}
+	runtime.Breakpoint()
+	fmt.Println(iface, iface2)
+}

--- a/_fixtures/vendor/dir.io/dir.go
+++ b/_fixtures/vendor/dir.io/dir.go
@@ -1,0 +1,5 @@
+package dirio
+
+type SomeType struct {
+	X int
+}

--- a/_fixtures/vendor/dir.io/io.io/io.go
+++ b/_fixtures/vendor/dir.io/io.io/io.go
@@ -1,0 +1,5 @@
+package ioio
+
+type SomeOtherType struct {
+	Y int
+}

--- a/pkg/proc/proc_test.go
+++ b/pkg/proc/proc_test.go
@@ -3400,3 +3400,13 @@ func TestDeclLine(t *testing.T) {
 		}
 	})
 }
+
+func TestIssue1137(t *testing.T) {
+	withTestProcess("dotpackagesiface", t, func(p proc.Process, fixture protest.Fixture) {
+		assertNoError(proc.Continue(p), t, "Continue()")
+		v := evalVariable(p, t, "iface")
+		assertNoError(v.Unreadable, t, "iface unreadable")
+		v2 := evalVariable(p, t, "iface2")
+		assertNoError(v2.Unreadable, t, "iface2 unreadable")
+	})
+}

--- a/pkg/proc/types.go
+++ b/pkg/proc/types.go
@@ -435,6 +435,12 @@ func nameOfNamedRuntimeType(_type *Variable, kind, tflag int64) (typename string
 			if err != nil {
 				return "", err
 			}
+			if slash := strings.LastIndex(pkgPath, "/"); slash >= 0 {
+				fixedName := strings.Replace(pkgPath[slash+1:], ".", "%2e", -1)
+				if fixedName != pkgPath[slash+1:] {
+					pkgPath = pkgPath[:slash+1] + fixedName
+				}
+			}
 			typename = pkgPath + "." + typename
 		}
 	}


### PR DESCRIPTION
```
proc: support interface type resolution for packages containing a dot

If the last entry of the package path contains a '.' the corresponding
DIEs for its types will replace the '.' character with '%2e'. We must
do the same when resolving the package path of the concrete type of an
interface variable.

Fixes #1137

```
