### PR TITLE
Documentation: remove homebrew as an install method

### DIFF
--- a/Documentation/installation/osx/install.md
+++ b/Documentation/installation/osx/install.md
@@ -2,14 +2,6 @@
 
 Please use the following steps to build and install Delve on OSX.
 
-## Via Homebrew
-
-If you have [HomeBrew](http://brew.sh/) installed, simply run:
-
-```
-$ brew install go-delve/delve/delve
-```
-
 ## Manual install
 
 Ensure you have a proper compilation toolchain.


### PR DESCRIPTION
```
Documentation: remove homebrew as an install method

The formula is broken and produces an endless stream of duplicate bug
reports yet nobody steps up to fix it. Using the formula isn't
necessary and hasn't been in almost a year, the maintainers of delve
aren't using it and the original maintainer of the formula vacated.

```
