### PR TITLE
proc: support inlining

### DIFF
--- a/_fixtures/testinline.go
+++ b/_fixtures/testinline.go
@@ -1,0 +1,21 @@
+package main
+
+import "fmt"
+
+func inlineThis(a int) int {
+	z := a * a
+	return z + a/a
+}
+
+func initialize(a, b *int) {
+	*a = 3
+	*b = 4
+}
+
+func main() {
+	var a, b int
+	initialize(&a, &b)
+	a = inlineThis(a)
+	b = inlineThis(b)
+	fmt.Printf("%d %d\n", a, b)
+}

--- a/pkg/dwarf/line/state_machine.go
+++ b/pkg/dwarf/line/state_machine.go
@@ -119,7 +119,6 @@ func (lineInfo *DebugLineInfo) AllPCsForFileLine(f string, l int) (pcs []uint64)
 			if sm.valid {
 				pcs = append(pcs, sm.address)
 			}
-			line := sm.line
 			// Keep going until we're on a different line. We only care about
 			// when a line comes back around (i.e. for loop) so get to next line,
 			// and try to find the line we care about again.
@@ -127,7 +126,7 @@ func (lineInfo *DebugLineInfo) AllPCsForFileLine(f string, l int) (pcs []uint64)
 				if err := sm.next(); err != nil {
 					break
 				}
-				if line < sm.line {
+				if l != sm.line {
 					break
 				}
 			}

--- a/pkg/dwarf/reader/variables.go
+++ b/pkg/dwarf/reader/variables.go
@@ -47,10 +47,10 @@ func (vrdr *VariableReader) Next() bool {
 				return false
 			}
 
-		case dwarf.TagLexDwarfBlock, dwarf.TagSubprogram:
+		case dwarf.TagLexDwarfBlock, dwarf.TagSubprogram, dwarf.TagInlinedSubroutine:
 			recur := true
 			if vrdr.onlyVisible {
-				recur, vrdr.err = vrdr.entryRangesContains()
+				recur, vrdr.err = entryRangesContains(vrdr.dwarf, vrdr.entry, vrdr.pc)
 				if vrdr.err != nil {
 					return false
 				}
@@ -77,13 +77,13 @@ func (vrdr *VariableReader) Next() bool {
 	}
 }
 
-func (vrdr *VariableReader) entryRangesContains() (bool, error) {
-	rngs, err := vrdr.dwarf.Ranges(vrdr.entry)
+func entryRangesContains(dwarf *dwarf.Data, entry *dwarf.Entry, pc uint64) (bool, error) {
+	rngs, err := dwarf.Ranges(entry)
 	if err != nil {
 		return false, err
 	}
 	for _, rng := range rngs {
-		if vrdr.pc >= rng[0] && vrdr.pc < rng[1] {
+		if pc >= rng[0] && pc < rng[1] {
 			return true, nil
 		}
 	}

--- a/pkg/proc/bininfo.go
+++ b/pkg/proc/bininfo.go
@@ -296,6 +296,17 @@ func (bi *BinaryInfo) LineToPC(filename string, lineno int) (pc uint64, fn *Func
 	return
 }
 
+// AllPCsForFileLine returns all PC addresses for the given filename:lineno.
+func (bi *BinaryInfo) AllPCsForFileLine(filename string, lineno int) []uint64 {
+	r := make([]uint64, 0, 1)
+	for _, cu := range bi.compileUnits {
+		if cu.lineInfo.Lookup[filename] != nil {
+			r = append(r, cu.lineInfo.AllPCsForFileLine(filename, lineno)...)
+		}
+	}
+	return r
+}
+
 // PCToFunc returns the function containing the given PC address
 func (bi *BinaryInfo) PCToFunc(pc uint64) *Function {
 	i := sort.Search(len(bi.Functions), func(i int) bool {

--- a/pkg/proc/eval.go
+++ b/pkg/proc/eval.go
@@ -584,9 +584,8 @@ func (scope *EvalScope) evalIdent(node *ast.Ident) (*Variable, error) {
 	}
 
 	// if it's not a local variable then it could be a package variable w/o explicit package name
-	_, _, fn := scope.BinInfo.PCToLine(scope.PC)
-	if fn != nil {
-		if v, err := scope.findGlobal(fn.PackageName() + "." + node.Name); err == nil {
+	if scope.Fn != nil {
+		if v, err := scope.findGlobal(scope.Fn.PackageName() + "." + node.Name); err == nil {
 			v.Name = node.Name
 			return v, nil
 		}

--- a/pkg/proc/test/support.go
+++ b/pkg/proc/test/support.go
@@ -48,6 +48,7 @@ type BuildFlags uint32
 const (
 	LinkStrip BuildFlags = 1 << iota
 	EnableCGOOptimization
+	EnableInlining
 )
 
 func BuildFixture(name string, flags BuildFlags) Fixture {
@@ -81,7 +82,11 @@ func BuildFixture(name string, flags BuildFlags) Fixture {
 	if flags&LinkStrip != 0 {
 		buildFlags = append(buildFlags, "-ldflags=-s")
 	}
-	buildFlags = append(buildFlags, "-gcflags=-N -l", "-o", tmpfile)
+	gcflags := "-gcflags=-N -l"
+	if flags&EnableInlining != 0 {
+		gcflags = "-gcflags=-N"
+	}
+	buildFlags = append(buildFlags, gcflags, "-o", tmpfile)
 	if *EnableRace {
 		buildFlags = append(buildFlags, "-race")
 	}


### PR DESCRIPTION
```
proc: support inlining

Go 1.10 added inlined calls to debug_info, this commit adds support
for DW_TAG_inlined_call to delve, both for stack traces (where
inlined calls will appear as normal stack frames) and to correct
the behavior of next, step and stepout.

# Changes to stack traces

The calls to Next and Frame of stackIterator continue to work
unchanged and only return real stack frames, after reading each line
appendInlinedCalls is called to unpacked all the inlined calls that
involve the current PC.

The fake stack frames produced by appendInlinedCalls are
distinguished from real stack frames by having the Inlined attribute
set to true. Also their Current and Call locations are treated
differently. The Call location will be changed to represent the
position inside the inlined call, while the Current location will
always reference the real stack frame. This is done because:

* next, step and stepout need to access the debug_info entry of
the real function they are stepping through
* we are already manipulating Call in different ways while Current
is just what we read from the call stack

# Changes to step, next

The strategy remains mostly the same, we disassemble the function
and we set a breakpoint on each instruction corresponding to a
different file:line. The function in question will be the one
corresponding to the first real (i.e. non-inlined) stack frame.

* If the current function contains inlined calls, 'next' will not
set any breakpoints on instructions that belong to inlined calls. We
do not do this for 'step'.

* If we are inside an inlined call that makes other inlined
functions, 'next' will not set any breakpoints that belong to
inlined calls that are children of the current inlined call.

* If the current function is inlined the breakpoint on the return
address won't be set, because inlined frames don't have a return
address.

* The code we use for stepout doesn't work at all if we are inside
an inlined call, instead we call 'next' but instruct it to remove
all PCs belonging to the current inlined call.

```
