### PR TITLE
proc: fix reading of empty strings in core files

### DIFF
--- a/_fixtures/coreemptystring.go
+++ b/_fixtures/coreemptystring.go
@@ -1,0 +1,8 @@
+package main
+
+func main() {
+	s := ""
+	t := "test"
+	panic("panic!!!")
+	println(s, t)
+}

--- a/pkg/proc/variables.go
+++ b/pkg/proc/variables.go
@@ -992,6 +992,10 @@ func readStringInfo(mem MemoryReadWriter, arch Arch, addr uintptr) (uintptr, int
 }
 
 func readStringValue(mem MemoryReadWriter, addr uintptr, strlen int64, cfg LoadConfig) (string, error) {
+	if strlen == 0 {
+		return "", nil
+	}
+
 	count := strlen
 	if count > int64(cfg.MaxStringLen) {
 		count = int64(cfg.MaxStringLen)


### PR DESCRIPTION
```
proc: fix reading of empty strings in core files

Every time we read an empty string we accidentally issue a read for 0
bytes at address 0, this is fine for real memory but the core file
reader doesn't like it.

Fixes an issue reported on the mailing list.

```
