### PR TITLE
proc: allow evaluating constants specified with a partial package path

### DIFF
--- a/_fixtures/consts.go
+++ b/_fixtures/consts.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"dir0/pkg"
 	"fmt"
 	"runtime"
 )
@@ -32,5 +33,6 @@ func main() {
 	e := ConstType(10)
 	f := BitFieldType(0)
 	runtime.Breakpoint()
-	fmt.Println(a, b, c, d, e, f)
+	pkg.SomeVar.AnotherMethod(2)
+	fmt.Println(a, b, c, d, e, f, pkg.SomeConst)
 }

--- a/_fixtures/vendor/dir0/pkg/main.go
+++ b/_fixtures/vendor/dir0/pkg/main.go
@@ -13,3 +13,7 @@ func (s *SomeType) AnotherMethod(x int) int {
 }
 
 var SomeVar SomeType
+
+const (
+	SomeConst int = 2
+)

--- a/pkg/proc/variables.go
+++ b/pkg/proc/variables.go
@@ -666,7 +666,7 @@ func (scope *EvalScope) findGlobal(name string) (*Variable, error) {
 	}
 	for offset, ctyp := range scope.BinInfo.consts {
 		for _, cval := range ctyp.values {
-			if cval.fullName == name {
+			if cval.fullName == name || strings.HasSuffix(cval.fullName, "/"+name) {
 				t, err := scope.Type(offset)
 				if err != nil {
 					return nil, err

--- a/service/test/variables_test.go
+++ b/service/test/variables_test.go
@@ -960,6 +960,7 @@ func TestConstants(t *testing.T) {
 		{"bitZero", true, "1", "", "main.BitFieldType", nil},
 		{"bitOne", true, "2", "", "main.BitFieldType", nil},
 		{"constTwo", true, "2", "", "main.ConstType", nil},
+		{"pkg.SomeConst", true, "2", "", "int", nil},
 	}
 	ver, _ := goversion.Parse(runtime.Version())
 	if ver.Major > 0 && !ver.AfterOrEqual(goversion.GoVersion{1, 10, -1, 0, 0, ""}) {


### PR DESCRIPTION
```
proc: allow evaluating constants specified with a partial package path

Fixes #1151

```
