### PR TITLE
proc/core: Make TestCoreFpTest less flaky

### DIFF
--- a/_fixtures/fputest/fputest_amd64.s
+++ b/_fixtures/fputest/fputest_amd64.s
@@ -52,5 +52,8 @@ TEXT ·fputestsetup(SB),$0-48
 	// XMM8 = XMM2 + XMM5 = { f32d+f32b, f32c+f32a, f32b+f32d, f32a+f32c } = { 3.4, 3.2, 3.4, 3.2 }
 	MOVAPS X2, X8
 	ADDPS X5, X8
-	
+
+	MOVAPS X1, X9
+	MOVAPS X2, X10
+
 	RET

--- a/pkg/proc/core/core_test.go
+++ b/pkg/proc/core/core_test.go
@@ -276,8 +276,8 @@ func TestCoreFpRegisters(t *testing.T) {
 		// Unlike TestClientServer_FpRegisters in service/test/integration2_test
 		// we can not test the value of XMM0, it probably has been reused by
 		// something between the panic and the time we get the core dump.
-		{"XMM1", "0x3ff66666666666663ff4cccccccccccd"},
-		{"XMM2", "0x3fe666663fd9999a3fcccccd3fc00000"},
+		{"XMM9", "0x3ff66666666666663ff4cccccccccccd"},
+		{"XMM10", "0x3fe666663fd9999a3fcccccd3fc00000"},
 		{"XMM3", "0x3ff199999999999a3ff3333333333333"},
 		{"XMM4", "0x3ff4cccccccccccd3ff6666666666666"},
 		{"XMM5", "0x3fcccccd3fc000003fe666663fd9999a"},


### PR DESCRIPTION
```
proc/core: Make TestCoreFpTest less flaky

Registers XMM1 and XMM2 get sometimes clobbered between the time we set
them and the panic. There is no guarantee that they won't in the go
spec so we shouldn't expect any register to keep its value. However
since this seems to only affect 1 and 2 let's try to use 9 and 10
instead.

```
