### PR TITLE
proc/eval: strings of different length are never equal

### DIFF
--- a/_fixtures/testvariables2.go
+++ b/_fixtures/testvariables2.go
@@ -242,6 +242,8 @@ func main() {
 	byteslice := []byte{116, 195, 168, 115, 116}
 	runeslice := []rune{116, 232, 115, 116}
 
+	longstr := "very long string 0123456789a0123456789b0123456789c0123456789d0123456789e0123456789f0123456789g012345678h90123456789i0123456789j0123456789"
+
 	var amb1 = 1
 	runtime.Breakpoint()
 	for amb1 := 0; amb1 < 10; amb1++ {
@@ -249,5 +251,5 @@ func main() {
 	}
 
 	runtime.Breakpoint()
-	fmt.Println(i1, i2, i3, p1, amb1, s1, s3, a1, p2, p3, s2, as1, str1, f1, fn1, fn2, nilslice, nilptr, ch1, chnil, m1, mnil, m2, m3, up1, i4, i5, i6, err1, err2, errnil, iface1, iface2, ifacenil, arr1, parr, cpx1, const1, iface3, iface4, recursive1, recursive1.x, iface5, iface2fn1, iface2fn2, bencharr, benchparr, mapinf, mainMenu, b, b2, sd, anonstruct1, anonstruct2, anoniface1, anonfunc, mapanonstruct1, ifacearr, efacearr, ni8, ni16, ni32, pinf, ninf, nan, zsvmap, zsslice, zsvar, tm, errtypednil, emptyslice, emptymap, byteslice, runeslice)
+	fmt.Println(i1, i2, i3, p1, amb1, s1, s3, a1, p2, p3, s2, as1, str1, f1, fn1, fn2, nilslice, nilptr, ch1, chnil, m1, mnil, m2, m3, up1, i4, i5, i6, err1, err2, errnil, iface1, iface2, ifacenil, arr1, parr, cpx1, const1, iface3, iface4, recursive1, recursive1.x, iface5, iface2fn1, iface2fn2, bencharr, benchparr, mapinf, mainMenu, b, b2, sd, anonstruct1, anonstruct2, anoniface1, anonfunc, mapanonstruct1, ifacearr, efacearr, ni8, ni16, ni32, pinf, ninf, nan, zsvmap, zsslice, zsvar, tm, errtypednil, emptyslice, emptymap, byteslice, runeslice, longstr)
 }

--- a/pkg/proc/eval.go
+++ b/pkg/proc/eval.go
@@ -1015,6 +1015,14 @@ func compareOp(op token.Token, xv *Variable, yv *Variable) (bool, error) {
 	case reflect.Float32, reflect.Float64, reflect.Complex64, reflect.Complex128:
 		return constantCompare(op, xv.Value, yv.Value)
 	case reflect.String:
+		if xv.Len != yv.Len {
+			switch op {
+			case token.EQL:
+				return false, nil
+			case token.NEQ:
+				return true, nil
+			}
+		}
 		if int64(len(constant.StringVal(xv.Value))) != xv.Len || int64(len(constant.StringVal(yv.Value))) != yv.Len {
 			return false, fmt.Errorf("string too long for comparison")
 		}

--- a/service/test/variables_test.go
+++ b/service/test/variables_test.go
@@ -615,6 +615,7 @@ func TestEvalExpression(t *testing.T) {
 		{"c1.pb.a != *(c1.sa[0])", false, "false", "false", "", nil},
 		{"c1.pb.a == *(c1.sa[1])", false, "false", "false", "", nil},
 		{"c1.pb.a != *(c1.sa[1])", false, "true", "true", "", nil},
+		{`longstr == "not this"`, false, "false", "false", "", nil},
 
 		// builtins
 		{"cap(parr)", false, "4", "4", "", nil},


### PR DESCRIPTION
```
proc/eval: strings of different length are never equal

```
