### PR TITLE
proc/native/windows: when there is an error during Attach dbp might be nil

### DIFF
--- a/pkg/proc/native/proc_windows.go
+++ b/pkg/proc/native/proc_windows.go
@@ -163,7 +163,9 @@ func Attach(pid int) (*Process, error) {
 	}
 	dbp, err := newDebugProcess(New(pid), exepath)
 	if err != nil {
-		dbp.Detach(false)
+		if dbp != nil {
+			dbp.Detach(false)
+		}
 		return nil, err
 	}
 	return dbp, nil


### PR DESCRIPTION
```
proc/native/windows: when there is an error during Attach dbp might be nil

```
