### PR TITLE
Add a note about headless and init

### DIFF
--- a/cmd/dlv/cmds/commands.go
+++ b/cmd/dlv/cmds/commands.go
@@ -89,7 +89,7 @@ func New(docCall bool) *cobra.Command {
 	RootCommand.PersistentFlags().BoolVarP(&Headless, "headless", "", false, "Run debug server only, in headless mode.")
 	RootCommand.PersistentFlags().BoolVarP(&AcceptMulti, "accept-multiclient", "", false, "Allows a headless server to accept multiple client connections. Note that the server API is not reentrant and clients will have to coordinate.")
 	RootCommand.PersistentFlags().IntVar(&APIVersion, "api-version", 1, "Selects API version when headless.")
-	RootCommand.PersistentFlags().StringVar(&InitFile, "init", "", "Init file, executed by the terminal client.")
+	RootCommand.PersistentFlags().StringVar(&InitFile, "init", "", "Init file, executed by the terminal client. (this feature doesn't work in headless mode).")
 	RootCommand.PersistentFlags().StringVar(&BuildFlags, "build-flags", buildFlagsDefault, "Build flags, to be passed to the compiler.")
 	RootCommand.PersistentFlags().StringVar(&WorkingDir, "wd", ".", "Working directory for running the program.")
 	RootCommand.PersistentFlags().StringVar(&Backend, "backend", "default", `Backend selection:


### PR DESCRIPTION
I spent some time trying to run an init file in headless mode and I just
discover that this feature is not implemented yet.

So I think it is reasonable to add this note to make it more clear for
other people that are trying to do the same.

In second, I would like to have this feature even in headless mode so, I
will open an issue to track it down.

Signed-off-by: Gianluca Arbezzano <gianarb92@gmail.com>