### PR TITLE
terminal: make printcontext use SelectedGoroutine

### DIFF
--- a/pkg/proc/proc.go
+++ b/pkg/proc/proc.go
@@ -128,6 +128,9 @@ func Continue(dbp Process) error {
 					}
 					loc, err := curthread.Location()
 					if err != nil || loc.Fn == nil || (loc.Fn.Name != "runtime.breakpoint" && loc.Fn.Name != "runtime.Breakpoint") {
+						if g := dbp.SelectedGoroutine(); g != nil {
+							g.CurrentLoc = *loc
+						}
 						break
 					}
 				}


### PR DESCRIPTION
```
terminal: make printcontext use SelectedGoroutine

printcontext should use SelectedGoroutine instead of trusting that the
goroutine running on current thread matches the SelectedGoroutine.

When the user switches to a parked goroutine CurrentThread and
SelectedGoroutine will diverge.

Almost all calls to printcontext are safe, they happen after a continue
command returns when SelectedGoroutine and CurrentThread always agree,
but the calls in frameCommand and listCommand are wrong.

Additionally we should stop reporting an error when the debugger is
stopped on an unknown PC address.

```
