### PR TITLE
gdbserial,debugger: better error message when debugserver not installed

### DIFF
--- a/pkg/proc/gdbserial/rr.go
+++ b/pkg/proc/gdbserial/rr.go
@@ -15,6 +15,10 @@ import (
 // Record uses rr to record the execution of the specified program and
 // returns the trace directory's path.
 func Record(cmd []string, wd string, quiet bool) (tracedir string, err error) {
+	if _, err := exec.LookPath("rr"); err != nil {
+		return "", &ErrBackendUnavailable{}
+	}
+
 	rfd, wfd, err := os.Pipe()
 	if err != nil {
 		return "", err
@@ -49,6 +53,10 @@ func Record(cmd []string, wd string, quiet bool) (tracedir string, err error) {
 // Replay starts an instance of rr in replay mode, with the specified trace
 // directory, and connects to it.
 func Replay(tracedir string, quiet bool) (*Process, error) {
+	if _, err := exec.LookPath("rr"); err != nil {
+		return nil, &ErrBackendUnavailable{}
+	}
+
 	rrcmd := exec.Command("rr", "replay", "--dbgport=0", tracedir)
 	rrcmd.Stdout = os.Stdout
 	stderr, err := rrcmd.StderrPipe()


### PR DESCRIPTION
```
gdbserial,debugger: better error message when debugserver not installed

When gdbserial can not find debugserver or lldb-server the error
message is always the same and it complains about lldb-server not being
found.

This is fine on linux (where the backend is unnecessary) but incomplete
on macOS (where the backend is actually used).

Make the error message clearer so that users who do not bother reading
install instructions are not confused.

```
