### PR TITLE
proc: Refactor proc.(*EvalScope).variablesByTag

### DIFF
--- a/_fixtures/issue951.go
+++ b/_fixtures/issue951.go
@@ -1,0 +1,21 @@
+package main
+
+import (
+	"fmt"
+	"runtime"
+)
+
+func main() {
+	shadow(42)
+}
+
+func shadow(i int) {
+	for i := 0; i < 5; i++ {
+		for i := 20; i < 25; i++ {
+			runtime.Breakpoint()
+			fmt.Println("another shadow", i)
+		}
+		fmt.Println("shadow", i)
+	}
+	fmt.Println("arg", i)
+}

--- a/pkg/proc/eval.go
+++ b/pkg/proc/eval.go
@@ -2,7 +2,6 @@ package proc
 
 import (
 	"bytes"
-	"debug/dwarf"
 	"encoding/binary"
 	"errors"
 	"fmt"
@@ -564,22 +563,13 @@ func (scope *EvalScope) evalIdent(node *ast.Ident) (*Variable, error) {
 		return nilVariable, nil
 	}
 
-	vars, err := scope.variablesByTag(dwarf.TagVariable, nil)
+	vars, err := scope.Locals()
 	if err != nil {
 		return nil, err
 	}
 	for i := range vars {
 		if vars[i].Name == node.Name && vars[i].Flags&VariableShadowed == 0 {
 			return vars[i], nil
-		}
-	}
-	args, err := scope.variablesByTag(dwarf.TagFormalParameter, nil)
-	if err != nil {
-		return nil, err
-	}
-	for i := range args {
-		if args[i].Name == node.Name {
-			return args[i], nil
 		}
 	}
 

--- a/pkg/proc/proc.go
+++ b/pkg/proc/proc.go
@@ -524,7 +524,7 @@ func FrameToScope(bi *BinaryInfo, thread MemoryReadWriter, g *G, frames ...Stack
 
 	// Creates a cacheMem that will preload the entire stack frame the first
 	// time any local variable is read.
-	// Remember that the stack grows from downward in memory.
+	// Remember that the stack grows downward in memory.
 	minaddr := frames[0].Regs.SP()
 	var maxaddr uint64
 	if len(frames) > 1 && frames[0].SystemStack == frames[1].SystemStack {

--- a/pkg/proc/proc.go
+++ b/pkg/proc/proc.go
@@ -511,7 +511,11 @@ func ConvertEvalScope(dbp Process, gid, frame int) (*EvalScope, error) {
 	return FrameToScope(dbp.BinInfo(), thread, g, locs[frame]), nil
 }
 
-// FrameToScope returns a new EvalScope for this frame
+// FrameToScope returns a new EvalScope for frames[0].
+// If frames has at least two elements all memory between
+// frames[0].Regs.SP() and frames[1].Regs.CFA will be cached.
+// Otherwise all memory between frames[0].Regs.SP() and frames[0].Regs.CFA
+// will be cached.
 func FrameToScope(bi *BinaryInfo, thread MemoryReadWriter, g *G, frame Stackframe) *EvalScope {
 	var gvar *Variable
 	if g != nil {

--- a/pkg/proc/proc_general_test.go
+++ b/pkg/proc/proc_general_test.go
@@ -7,7 +7,7 @@ import (
 func TestIssue554(t *testing.T) {
 	// unsigned integer overflow in proc.(*memCache).contains was
 	// causing it to always return true for address 0xffffffffffffffff
-	mem := memCache{0x20, make([]byte, 100), nil}
+	mem := memCache{true, 0x20, make([]byte, 100), nil}
 	if mem.contains(0xffffffffffffffff, 40) {
 		t.Fatalf("should be false")
 	}

--- a/pkg/proc/proc_test.go
+++ b/pkg/proc/proc_test.go
@@ -3333,7 +3333,7 @@ func TestIssue1034(t *testing.T) {
 		assertNoError(proc.Continue(p), t, "Continue()")
 		frames, err := p.SelectedGoroutine().Stacktrace(10)
 		assertNoError(err, t, "Stacktrace")
-		scope := proc.FrameToScope(p.BinInfo(), p.CurrentThread(), nil, frames[2])
+		scope := proc.FrameToScope(p.BinInfo(), p.CurrentThread(), nil, frames[2:]...)
 		args, _ := scope.FunctionArguments(normalLoadConfig)
 		assertNoError(err, t, "FunctionArguments()")
 		if len(args) > 0 {

--- a/pkg/proc/threads.go
+++ b/pkg/proc/threads.go
@@ -461,19 +461,19 @@ func GetG(thread Thread) (*G, error) {
 
 // ThreadScope returns an EvalScope for this thread.
 func ThreadScope(thread Thread) (*EvalScope, error) {
-	locations, err := ThreadStacktrace(thread, 0)
+	locations, err := ThreadStacktrace(thread, 1)
 	if err != nil {
 		return nil, err
 	}
 	if len(locations) < 1 {
 		return nil, errors.New("could not decode first frame")
 	}
-	return FrameToScope(thread.BinInfo(), thread, nil, locations[0]), nil
+	return FrameToScope(thread.BinInfo(), thread, nil, locations...), nil
 }
 
 // GoroutineScope returns an EvalScope for the goroutine running on this thread.
 func GoroutineScope(thread Thread) (*EvalScope, error) {
-	locations, err := ThreadStacktrace(thread, 0)
+	locations, err := ThreadStacktrace(thread, 1)
 	if err != nil {
 		return nil, err
 	}
@@ -484,7 +484,7 @@ func GoroutineScope(thread Thread) (*EvalScope, error) {
 	if err != nil {
 		return nil, err
 	}
-	return FrameToScope(thread.BinInfo(), thread, g, locations[0]), nil
+	return FrameToScope(thread.BinInfo(), thread, g, locations...), nil
 }
 
 func onRuntimeBreakpoint(thread Thread) bool {

--- a/service/api/types.go
+++ b/service/api/types.go
@@ -170,6 +170,12 @@ const (
 
 	// VariableConstant means this variable is a constant value
 	VariableConstant
+
+	// VariableArgument means this variable is a function argument
+	VariableArgument
+
+	// VariableReturnArgument means this variable is a function return value
+	VariableReturnArgument
 )
 
 // Variable describes a variable.

--- a/service/debugger/debugger.go
+++ b/service/debugger/debugger.go
@@ -881,7 +881,7 @@ func (d *Debugger) convertStacktrace(rawlocs []proc.Stackframe, cfg *proc.LoadCo
 		}
 		if cfg != nil && rawlocs[i].Current.Fn != nil {
 			var err error
-			scope := proc.FrameToScope(d.target.BinInfo(), d.target.CurrentThread(), nil, rawlocs[i])
+			scope := proc.FrameToScope(d.target.BinInfo(), d.target.CurrentThread(), nil, rawlocs[i:]...)
 			locals, err := scope.LocalVariables(*cfg)
 			if err != nil {
 				return nil, err


### PR DESCRIPTION
```
proc: Flag shadowed arguments as shadowed

Fixes #951

proc: cache entire frame in FrameToScope instead of variablesByTag

Caching the frame in variablesByTag is problematic:

1. accounting for variables that are (partially) stored in registers is
complicated (see issue #1106)
2. for some types (strings, interfaces...) simply creating the Variable
object reads memory, which therefore happens before we can do any
caching.

Instead cache the entire frame when the EvalScope object is created.
The cached range is between the SP value of the current frame and the
CFA of the preceeding frame, if available, or the CFA of the current
frame otherwise.

Fixes #1106

proc: change memCache to delay reading

Change memCache so that the preloaded memory is not read immediately
but only after the actual read to the preloaded range.

This allows us to request caching the entire stack frame every time we
create an eval scope and no unnecessary reads will be made even if the
user is just trying to evaluate a global variable.

```
