### PR TITLE
proc/native,proc/gdbserial: let target access terminal

### DIFF
--- a/cmd/dlv/cmds/commands.go
+++ b/cmd/dlv/cmds/commands.go
@@ -505,6 +505,7 @@ func execute(attachPid int, processArgs []string, conf *config.Config, coreFile 
 			WorkingDir:  WorkingDir,
 			Backend:     Backend,
 			CoreFile:    coreFile,
+			Foreground:  Headless,
 
 			DisconnectChan: disconnectChan,
 		}, logflags.Debugger())

--- a/pkg/proc/gdbserial/gdbserver_unix.go
+++ b/pkg/proc/gdbserial/gdbserver_unix.go
@@ -2,8 +2,15 @@
 
 package gdbserial
 
-import "syscall"
+import (
+	"syscall"
+	"unsafe"
+)
 
 func backgroundSysProcAttr() *syscall.SysProcAttr {
 	return &syscall.SysProcAttr{Setpgid: true, Pgid: 0, Foreground: false}
+}
+
+func moveToForeground(pid int) {
+	syscall.Syscall(syscall.SYS_IOCTL, uintptr(0), uintptr(syscall.TIOCSPGRP), uintptr(unsafe.Pointer(&pid)))
 }

--- a/pkg/proc/gdbserial/gdbserver_windows.go
+++ b/pkg/proc/gdbserial/gdbserver_windows.go
@@ -5,3 +5,7 @@ import "syscall"
 func backgroundSysProcAttr() *syscall.SysProcAttr {
 	return nil
 }
+
+func moveToForeground(pid int) {
+	panic("lldb backend not supported on windows")
+}

--- a/pkg/proc/native/proc_darwin.go
+++ b/pkg/proc/native/proc_darwin.go
@@ -36,7 +36,7 @@ type OSProcessDetails struct {
 // custom fork/exec process in order to take advantage of
 // PT_SIGEXC on Darwin which will turn Unix signals into
 // Mach exceptions.
-func Launch(cmd []string, wd string) (*Process, error) {
+func Launch(cmd []string, wd string, foreground bool) (*Process, error) {
 	// check that the argument to Launch is an executable file
 	if fi, staterr := os.Stat(cmd[0]); staterr == nil && (fi.Mode()&0111) == 0 {
 		return nil, proc.NotExecutableErr

--- a/pkg/proc/native/proc_windows.go
+++ b/pkg/proc/native/proc_windows.go
@@ -36,7 +36,7 @@ func openExecutablePathPE(path string) (*pe.File, io.Closer, error) {
 }
 
 // Launch creates and begins debugging a new process.
-func Launch(cmd []string, wd string) (*Process, error) {
+func Launch(cmd []string, wd string, foreground bool) (*Process, error) {
 	argv0Go, err := filepath.Abs(cmd[0])
 	if err != nil {
 		return nil, err

--- a/pkg/proc/proc_test.go
+++ b/pkg/proc/proc_test.go
@@ -59,9 +59,9 @@ func withTestProcessArgs(name string, t testing.TB, wd string, args []string, bu
 
 	switch testBackend {
 	case "native":
-		p, err = native.Launch(append([]string{fixture.Path}, args...), wd)
+		p, err = native.Launch(append([]string{fixture.Path}, args...), wd, false)
 	case "lldb":
-		p, err = gdbserial.LLDBLaunch(append([]string{fixture.Path}, args...), wd)
+		p, err = gdbserial.LLDBLaunch(append([]string{fixture.Path}, args...), wd, false)
 	case "rr":
 		protest.MustHaveRecordingAllowed(t)
 		t.Log("recording")
@@ -2036,7 +2036,7 @@ func TestIssue509(t *testing.T) {
 	cmd.Dir = nomaindir
 	assertNoError(cmd.Run(), t, "go build")
 	exepath := filepath.Join(nomaindir, "debug")
-	_, err := native.Launch([]string{exepath}, ".")
+	_, err := native.Launch([]string{exepath}, ".", false)
 	if err == nil {
 		t.Fatalf("expected error but none was generated")
 	}
@@ -2070,7 +2070,7 @@ func TestUnsupportedArch(t *testing.T) {
 	}
 	defer os.Remove(outfile)
 
-	p, err := native.Launch([]string{outfile}, ".")
+	p, err := native.Launch([]string{outfile}, ".", false)
 	switch err {
 	case proc.UnsupportedLinuxArchErr, proc.UnsupportedWindowsArchErr, proc.UnsupportedDarwinArchErr:
 		// all good

--- a/service/config.go
+++ b/service/config.go
@@ -32,6 +32,9 @@ type Config struct {
 	// Selects server backend.
 	Backend string
 
+	// Foreground lets target process access stdin.
+	Foreground bool
+
 	// DisconnectChan will be closed by the server when the client disconnects
 	DisconnectChan chan<- struct{}
 }

--- a/service/rpccommon/server.go
+++ b/service/rpccommon/server.go
@@ -115,6 +115,7 @@ func (s *ServerImpl) Run() error {
 		WorkingDir: s.config.WorkingDir,
 		CoreFile:   s.config.CoreFile,
 		Backend:    s.config.Backend,
+		Foreground: s.config.Foreground,
 	},
 		s.config.ProcessArgs); err != nil {
 		return err

--- a/service/test/variables_test.go
+++ b/service/test/variables_test.go
@@ -112,9 +112,9 @@ func withTestProcess(name string, t *testing.T, fn func(p proc.Process, fixture 
 	var tracedir string
 	switch testBackend {
 	case "native":
-		p, err = native.Launch([]string{fixture.Path}, ".")
+		p, err = native.Launch([]string{fixture.Path}, ".", false)
 	case "lldb":
-		p, err = gdbserial.LLDBLaunch([]string{fixture.Path}, ".")
+		p, err = gdbserial.LLDBLaunch([]string{fixture.Path}, ".", false)
 	case "rr":
 		protest.MustHaveRecordingAllowed(t)
 		t.Log("recording")


### PR DESCRIPTION
```
proc/native,proc/gdbserial: let target access terminal

Change the linux verison of proc/native and proc/gdbserial (with
debugserver) so that they let the target process use the terminal when
delve is launched in headless mode.

Windows already worked, proc/gdbserial (with rr) already worked.
I couldn't find a way to make proc/gdbserial (with lldb-server) work.

No tests are added because I can't think of a way to test for
foregroundness of a process.

Fixes #65

```
