### PR TITLE
cmd/dlv: Revert 4e177b, use new flag name for debug logging options

### DIFF
--- a/Documentation/usage/dlv.md
+++ b/Documentation/usage/dlv.md
@@ -31,11 +31,12 @@ Pass flags to the program you are debugging using `--`, for example:
       --headless             Run debug server only, in headless mode.
       --init string          Init file, executed by the terminal client.
   -l, --listen string        Debugging server listen address. (default "localhost:0")
-      --log string           Comma separated list of components that should produce debug output, possible values:
+      --log                  Enable debugging server logging.
+      --log-output string    Comma separated list of components that should produce debug output, possible values:
 	debugger	Log debugger commands
 	gdbwire		Log connection to gdbserial backend
 	lldbout		Copy output from debugserver/lldb to standard output
- (default "false")
+Defaults to "debugger" when logging is enabled with --log.
       --wd string            Working directory for running the program. (default ".")
 ```
 

--- a/Documentation/usage/dlv_attach.md
+++ b/Documentation/usage/dlv_attach.md
@@ -31,11 +31,12 @@ dlv attach pid [executable]
       --headless             Run debug server only, in headless mode.
       --init string          Init file, executed by the terminal client.
   -l, --listen string        Debugging server listen address. (default "localhost:0")
-      --log string           Comma separated list of components that should produce debug output, possible values:
+      --log                  Enable debugging server logging.
+      --log-output string    Comma separated list of components that should produce debug output, possible values:
 	debugger	Log debugger commands
 	gdbwire		Log connection to gdbserial backend
 	lldbout		Copy output from debugserver/lldb to standard output
- (default "false")
+Defaults to "debugger" when logging is enabled with --log.
       --wd string            Working directory for running the program. (default ".")
 ```
 

--- a/Documentation/usage/dlv_connect.md
+++ b/Documentation/usage/dlv_connect.md
@@ -26,11 +26,12 @@ dlv connect addr
       --headless             Run debug server only, in headless mode.
       --init string          Init file, executed by the terminal client.
   -l, --listen string        Debugging server listen address. (default "localhost:0")
-      --log string           Comma separated list of components that should produce debug output, possible values:
+      --log                  Enable debugging server logging.
+      --log-output string    Comma separated list of components that should produce debug output, possible values:
 	debugger	Log debugger commands
 	gdbwire		Log connection to gdbserial backend
 	lldbout		Copy output from debugserver/lldb to standard output
- (default "false")
+Defaults to "debugger" when logging is enabled with --log.
       --wd string            Working directory for running the program. (default ".")
 ```
 

--- a/Documentation/usage/dlv_core.md
+++ b/Documentation/usage/dlv_core.md
@@ -30,11 +30,12 @@ dlv core <executable> <core>
       --headless             Run debug server only, in headless mode.
       --init string          Init file, executed by the terminal client.
   -l, --listen string        Debugging server listen address. (default "localhost:0")
-      --log string           Comma separated list of components that should produce debug output, possible values:
+      --log                  Enable debugging server logging.
+      --log-output string    Comma separated list of components that should produce debug output, possible values:
 	debugger	Log debugger commands
 	gdbwire		Log connection to gdbserial backend
 	lldbout		Copy output from debugserver/lldb to standard output
- (default "false")
+Defaults to "debugger" when logging is enabled with --log.
       --wd string            Working directory for running the program. (default ".")
 ```
 

--- a/Documentation/usage/dlv_debug.md
+++ b/Documentation/usage/dlv_debug.md
@@ -37,11 +37,12 @@ dlv debug [package]
       --headless             Run debug server only, in headless mode.
       --init string          Init file, executed by the terminal client.
   -l, --listen string        Debugging server listen address. (default "localhost:0")
-      --log string           Comma separated list of components that should produce debug output, possible values:
+      --log                  Enable debugging server logging.
+      --log-output string    Comma separated list of components that should produce debug output, possible values:
 	debugger	Log debugger commands
 	gdbwire		Log connection to gdbserial backend
 	lldbout		Copy output from debugserver/lldb to standard output
- (default "false")
+Defaults to "debugger" when logging is enabled with --log.
       --wd string            Working directory for running the program. (default ".")
 ```
 

--- a/Documentation/usage/dlv_exec.md
+++ b/Documentation/usage/dlv_exec.md
@@ -31,11 +31,12 @@ dlv exec <path/to/binary>
       --headless             Run debug server only, in headless mode.
       --init string          Init file, executed by the terminal client.
   -l, --listen string        Debugging server listen address. (default "localhost:0")
-      --log string           Comma separated list of components that should produce debug output, possible values:
+      --log                  Enable debugging server logging.
+      --log-output string    Comma separated list of components that should produce debug output, possible values:
 	debugger	Log debugger commands
 	gdbwire		Log connection to gdbserial backend
 	lldbout		Copy output from debugserver/lldb to standard output
- (default "false")
+Defaults to "debugger" when logging is enabled with --log.
       --wd string            Working directory for running the program. (default ".")
 ```
 

--- a/Documentation/usage/dlv_replay.md
+++ b/Documentation/usage/dlv_replay.md
@@ -30,11 +30,12 @@ dlv replay [trace directory]
       --headless             Run debug server only, in headless mode.
       --init string          Init file, executed by the terminal client.
   -l, --listen string        Debugging server listen address. (default "localhost:0")
-      --log string           Comma separated list of components that should produce debug output, possible values:
+      --log                  Enable debugging server logging.
+      --log-output string    Comma separated list of components that should produce debug output, possible values:
 	debugger	Log debugger commands
 	gdbwire		Log connection to gdbserial backend
 	lldbout		Copy output from debugserver/lldb to standard output
- (default "false")
+Defaults to "debugger" when logging is enabled with --log.
       --wd string            Working directory for running the program. (default ".")
 ```
 

--- a/Documentation/usage/dlv_run.md
+++ b/Documentation/usage/dlv_run.md
@@ -26,11 +26,12 @@ dlv run
       --headless             Run debug server only, in headless mode.
       --init string          Init file, executed by the terminal client.
   -l, --listen string        Debugging server listen address. (default "localhost:0")
-      --log string           Comma separated list of components that should produce debug output, possible values:
+      --log                  Enable debugging server logging.
+      --log-output string    Comma separated list of components that should produce debug output, possible values:
 	debugger	Log debugger commands
 	gdbwire		Log connection to gdbserial backend
 	lldbout		Copy output from debugserver/lldb to standard output
- (default "false")
+Defaults to "debugger" when logging is enabled with --log.
       --wd string            Working directory for running the program. (default ".")
 ```
 

--- a/Documentation/usage/dlv_test.md
+++ b/Documentation/usage/dlv_test.md
@@ -37,11 +37,12 @@ dlv test [package]
       --headless             Run debug server only, in headless mode.
       --init string          Init file, executed by the terminal client.
   -l, --listen string        Debugging server listen address. (default "localhost:0")
-      --log string           Comma separated list of components that should produce debug output, possible values:
+      --log                  Enable debugging server logging.
+      --log-output string    Comma separated list of components that should produce debug output, possible values:
 	debugger	Log debugger commands
 	gdbwire		Log connection to gdbserial backend
 	lldbout		Copy output from debugserver/lldb to standard output
- (default "false")
+Defaults to "debugger" when logging is enabled with --log.
       --wd string            Working directory for running the program. (default ".")
 ```
 

--- a/Documentation/usage/dlv_trace.md
+++ b/Documentation/usage/dlv_trace.md
@@ -39,11 +39,12 @@ dlv trace [package] regexp
       --headless             Run debug server only, in headless mode.
       --init string          Init file, executed by the terminal client.
   -l, --listen string        Debugging server listen address. (default "localhost:0")
-      --log string           Comma separated list of components that should produce debug output, possible values:
+      --log                  Enable debugging server logging.
+      --log-output string    Comma separated list of components that should produce debug output, possible values:
 	debugger	Log debugger commands
 	gdbwire		Log connection to gdbserial backend
 	lldbout		Copy output from debugserver/lldb to standard output
- (default "false")
+Defaults to "debugger" when logging is enabled with --log.
       --wd string            Working directory for running the program. (default ".")
 ```
 

--- a/Documentation/usage/dlv_version.md
+++ b/Documentation/usage/dlv_version.md
@@ -26,11 +26,12 @@ dlv version
       --headless             Run debug server only, in headless mode.
       --init string          Init file, executed by the terminal client.
   -l, --listen string        Debugging server listen address. (default "localhost:0")
-      --log string           Comma separated list of components that should produce debug output, possible values:
+      --log                  Enable debugging server logging.
+      --log-output string    Comma separated list of components that should produce debug output, possible values:
 	debugger	Log debugger commands
 	gdbwire		Log connection to gdbserial backend
 	lldbout		Copy output from debugserver/lldb to standard output
- (default "false")
+Defaults to "debugger" when logging is enabled with --log.
       --wd string            Working directory for running the program. (default ".")
 ```
 

--- a/cmd/dlv/dlv_test.go
+++ b/cmd/dlv/dlv_test.go
@@ -210,7 +210,7 @@ func checkAutogenDoc(t *testing.T, filename, gencommand string, generated []byte
 	saved := slurpFile(t, os.ExpandEnv(fmt.Sprintf("$GOPATH/src/github.com/derekparker/delve/%s", filename)))
 
 	if len(saved) != len(generated) {
-		t.Fatalf("%s: needs to be regenerated run scripts/gen-cli-docs.go", filename)
+		t.Fatalf("%s: needs to be regenerated; run %s", filename, gencommand)
 	}
 
 	for i := range saved {

--- a/pkg/logflags/logflags.go
+++ b/pkg/logflags/logflags.go
@@ -1,6 +1,9 @@
 package logflags
 
-import "strings"
+import (
+	"errors"
+	"strings"
+)
 
 var debugger = false
 var gdbWire = false
@@ -23,11 +26,18 @@ func LLDBServerOutput() bool {
 	return lldbServerOutput
 }
 
+var errLogstrWithoutLog = errors.New("--log-output specified without --log")
+
 // Setup sets debugger flags based on the contents of logstr.
-func Setup(logstr string) {
-	if logstr == "true" || logstr == "" {
-		debugger = true
-		return
+func Setup(log bool, logstr string) error {
+	if !log {
+		if logstr != "" {
+			return errLogstrWithoutLog
+		}
+		return nil
+	}
+	if logstr == "" {
+		logstr = "debugger"
 	}
 	v := strings.Split(logstr, ",")
 	for _, logcmd := range v {
@@ -40,4 +50,5 @@ func Setup(logstr string) {
 			lldbServerOutput = true
 		}
 	}
+	return nil
 }


### PR DESCRIPTION
```
cmd/dlv: Revert 4e177b, use new flag name for debug logging options

Previously to 4e177bb99acc511897f9cdbfc6cbc50d92ae4725 it was possible
to use --log without arguments to enable logging, this commit reenables
that use case.

The new functionality of the --log flag moved to a new flag name
--logx.

Fixes #1188

```
