### PR TITLE
terminal: always initialize conf

### DIFF
--- a/pkg/terminal/terminal.go
+++ b/pkg/terminal/terminal.go
@@ -42,6 +42,10 @@ func New(client service.Client, conf *config.Config) *Term {
 		cmds.Merge(conf.Aliases)
 	}
 
+	if conf == nil {
+		conf = &config.Config{}
+	}
+
 	var w io.Writer
 
 	dumb := strings.ToLower(os.Getenv("TERM")) == "dumb"


### PR DESCRIPTION
```
terminal: always initialize conf

So we don't have to worry about having a nil conf field, even if there
is no configuration.

```
