### PR TITLE
proc,service: display return values when stepping out of a function

### DIFF
--- a/_fixtures/stepoutret.go
+++ b/_fixtures/stepoutret.go
@@ -1,0 +1,11 @@
+package main
+
+import "fmt"
+
+func stepout(n int) (str string, num int) {
+	return fmt.Sprintf("return %d", n), n + 1
+}
+
+func main() {
+	stepout(47)
+}

--- a/pkg/proc/core/core.go
+++ b/pkg/proc/core/core.go
@@ -154,6 +154,7 @@ type Thread struct {
 	th     *LinuxPrStatus
 	fpregs []proc.Register
 	p      *Process
+	common proc.CommonThread
 }
 
 var ErrWriteCore = errors.New("can not to core process")
@@ -256,6 +257,10 @@ func (t *Thread) Blocked() bool {
 
 func (t *Thread) SetCurrentBreakpoint() error {
 	return nil
+}
+
+func (t *Thread) Common() *proc.CommonThread {
+	return &t.common
 }
 
 func (p *Process) Breakpoints() *proc.BreakpointMap {

--- a/pkg/proc/core/core.go
+++ b/pkg/proc/core/core.go
@@ -147,7 +147,7 @@ type Process struct {
 	breakpoints       proc.BreakpointMap
 	currentThread     *Thread
 	selectedGoroutine *proc.G
-	allGCache         []*proc.G
+	common            proc.CommonProcess
 }
 
 type Thread struct {
@@ -298,8 +298,8 @@ func (p *Process) Exited() bool {
 	return false
 }
 
-func (p *Process) AllGCache() *[]*proc.G {
-	return &p.allGCache
+func (p *Process) Common() *proc.CommonProcess {
+	return &p.common
 }
 
 func (p *Process) Pid() int {

--- a/pkg/proc/core/linux_amd64_core.go
+++ b/pkg/proc/core/linux_amd64_core.go
@@ -277,7 +277,7 @@ func readCore(corePath, exePath string) (*Core, error) {
 		switch note.Type {
 		case elf.NT_PRSTATUS:
 			t := note.Desc.(*LinuxPrStatus)
-			lastThread = &Thread{t, nil, nil}
+			lastThread = &Thread{t, nil, nil, proc.CommonThread{}}
 			core.Threads[int(t.Pid)] = lastThread
 		case NT_X86_XSTATE:
 			if lastThread != nil {

--- a/pkg/proc/gdbserial/gdbserver.go
+++ b/pkg/proc/gdbserial/gdbserver.go
@@ -121,7 +121,7 @@ type Process struct {
 	process  *os.Process
 	waitChan chan *os.ProcessState
 
-	allGCache []*proc.G
+	common proc.CommonProcess
 }
 
 // Thread is a thread.
@@ -584,8 +584,8 @@ func (p *Process) CurrentThread() proc.Thread {
 	return p.currentThread
 }
 
-func (p *Process) AllGCache() *[]*proc.G {
-	return &p.allGCache
+func (p *Process) Common() *proc.CommonProcess {
+	return &p.common
 }
 
 func (p *Process) SelectedGoroutine() *proc.G {
@@ -615,7 +615,7 @@ func (p *Process) ContinueOnce() (proc.Thread, error) {
 		}
 	}
 
-	p.allGCache = nil
+	p.common.ClearAllGCache()
 	for _, th := range p.threads {
 		th.clearBreakpointState()
 	}
@@ -710,7 +710,7 @@ func (p *Process) StepInstruction() error {
 		}
 		thread = p.selectedGoroutine.Thread.(*Thread)
 	}
-	p.allGCache = nil
+	p.common.ClearAllGCache()
 	if p.exited {
 		return &proc.ProcessExitedError{Pid: p.conn.pid}
 	}
@@ -819,7 +819,7 @@ func (p *Process) Restart(pos string) error {
 
 	p.exited = false
 
-	p.allGCache = nil
+	p.common.ClearAllGCache()
 	for _, th := range p.threads {
 		th.clearBreakpointState()
 	}

--- a/pkg/proc/gdbserial/gdbserver.go
+++ b/pkg/proc/gdbserial/gdbserver.go
@@ -132,6 +132,7 @@ type Thread struct {
 	CurrentBreakpoint proc.BreakpointState
 	p                 *Process
 	setbp             bool // thread was stopped because of a breakpoint
+	common            proc.CommonThread
 }
 
 // ErrBackendUnavailable is returned when the stub program can not be found.
@@ -1187,6 +1188,10 @@ func (t *Thread) Arch() proc.Arch {
 
 func (t *Thread) BinInfo() *proc.BinaryInfo {
 	return &t.p.bi
+}
+
+func (t *Thread) Common() *proc.CommonThread {
+	return &t.common
 }
 
 func (t *Thread) stepInstruction(tu *threadUpdater) error {

--- a/pkg/proc/interface.go
+++ b/pkg/proc/interface.go
@@ -103,10 +103,13 @@ type BreakpointManipulation interface {
 	ClearInternalBreakpoints() error
 }
 
+// CommonProcess contains fields used by this package, common to all
+// implementations of the Process interface.
 type CommonProcess struct {
 	allGCache []*G
 }
 
+// ClearAllGCache clears the cached contents of the cache for runtime.allgs.
 func (p *CommonProcess) ClearAllGCache() {
 	p.allGCache = nil
 }

--- a/pkg/proc/interface.go
+++ b/pkg/proc/interface.go
@@ -62,6 +62,8 @@ type Info interface {
 	ResumeNotify(chan<- struct{})
 	Exited() bool
 	BinInfo() *BinaryInfo
+	// Common returns a struct with fields common to all backends
+	Common() *CommonProcess
 
 	ThreadInfo
 	GoroutineInfo
@@ -99,4 +101,12 @@ type BreakpointManipulation interface {
 	SetBreakpoint(addr uint64, kind BreakpointKind, cond ast.Expr) (*Breakpoint, error)
 	ClearBreakpoint(addr uint64) (*Breakpoint, error)
 	ClearInternalBreakpoints() error
+}
+
+type CommonProcess struct {
+	allGCache []*G
+}
+
+func (p *CommonProcess) ClearAllGCache() {
+	p.allGCache = nil
 }

--- a/pkg/proc/native/proc.go
+++ b/pkg/proc/native/proc.go
@@ -29,7 +29,7 @@ type Process struct {
 	// Normally selectedGoroutine is currentThread.GetG, it will not be only if SwitchGoroutine is called with a goroutine that isn't attached to a thread
 	selectedGoroutine *proc.G
 
-	allGCache           []*proc.G
+	common              proc.CommonProcess
 	os                  *OSProcessDetails
 	firstStart          bool
 	stopMu              sync.Mutex
@@ -230,7 +230,7 @@ func (dbp *Process) ContinueOnce() (proc.Thread, error) {
 		return nil, err
 	}
 
-	dbp.allGCache = nil
+	dbp.common.ClearAllGCache()
 	for _, th := range dbp.threads {
 		th.CurrentBreakpoint.Clear()
 	}
@@ -266,7 +266,7 @@ func (dbp *Process) StepInstruction() (err error) {
 		}
 		thread = dbp.selectedGoroutine.Thread.(*Thread)
 	}
-	dbp.allGCache = nil
+	dbp.common.ClearAllGCache()
 	if dbp.exited {
 		return &proc.ProcessExitedError{Pid: dbp.Pid()}
 	}
@@ -397,6 +397,6 @@ func (dbp *Process) writeSoftwareBreakpoint(thread *Thread, addr uint64) error {
 	return err
 }
 
-func (dbp *Process) AllGCache() *[]*proc.G {
-	return &dbp.allGCache
+func (dbp *Process) Common() *proc.CommonProcess {
+	return &dbp.common
 }

--- a/pkg/proc/native/proc_darwin.go
+++ b/pkg/proc/native/proc_darwin.go
@@ -103,7 +103,7 @@ func Launch(cmd []string, wd string, foreground bool) (*Process, error) {
 		return nil, err
 	}
 
-	dbp.allGCache = nil
+	dbp.common.ClearAllGCache()
 	for _, th := range dbp.threads {
 		th.CurrentBreakpoint.Clear()
 	}

--- a/pkg/proc/native/threads.go
+++ b/pkg/proc/native/threads.go
@@ -19,6 +19,7 @@ type Thread struct {
 	dbp            *Process
 	singleStepping bool
 	os             *OSSpecificDetails
+	common         proc.CommonThread
 }
 
 // Continue the execution of this thread.
@@ -99,6 +100,10 @@ func (thread *Thread) Arch() proc.Arch {
 
 func (thread *Thread) BinInfo() *proc.BinaryInfo {
 	return &thread.dbp.bi
+}
+
+func (thread *Thread) Common() *proc.CommonThread {
+	return &thread.common
 }
 
 // SetPC sets the PC for this thread.

--- a/pkg/proc/proc_test.go
+++ b/pkg/proc/proc_test.go
@@ -1515,10 +1515,7 @@ func BenchmarkGoroutinesInfo(b *testing.B) {
 	withTestProcess("testvariables2", b, func(p proc.Process, fixture protest.Fixture) {
 		assertNoError(proc.Continue(p), b, "Continue()")
 		for i := 0; i < b.N; i++ {
-			if p, ok := p.(proc.AllGCache); ok {
-				allgcache := p.AllGCache()
-				*allgcache = nil
-			}
+			p.Common().ClearAllGCache()
 			_, err := proc.GoroutinesInfo(p)
 			assertNoError(err, b, "GoroutinesInfo")
 		}

--- a/pkg/terminal/command.go
+++ b/pkg/terminal/command.go
@@ -1518,11 +1518,23 @@ func printcontextLocation(loc api.Location) {
 	return
 }
 
+func printReturnValues(th *api.Thread) {
+	if th.ReturnValues == nil {
+		return
+	}
+	fmt.Println("Values returned:")
+	for _, v := range th.ReturnValues {
+		fmt.Printf("\t%s: %s\n", v.Name, v.MultilineString("\t"))
+	}
+	fmt.Println()
+}
+
 func printcontextThread(t *Term, th *api.Thread) {
 	fn := th.Function
 
 	if th.Breakpoint == nil {
 		printcontextLocation(api.Location{PC: th.PC, File: th.File, Line: th.Line, Function: th.Function})
+		printReturnValues(th)
 		return
 	}
 
@@ -1564,6 +1576,8 @@ func printcontextThread(t *Term, th *api.Thread) {
 	if th.Function != nil && th.Function.Optimized {
 		fmt.Println(optimizedFunctionWarning)
 	}
+
+	printReturnValues(th)
 
 	if th.BreakpointInfo != nil {
 		bp := th.Breakpoint

--- a/pkg/terminal/terminal.go
+++ b/pkg/terminal/terminal.go
@@ -55,6 +55,10 @@ func New(client service.Client, conf *config.Config) *Term {
 		w = getColorableWriter()
 	}
 
+	if client != nil {
+		client.SetReturnValuesLoadConfig(&LongLoadConfig)
+	}
+
 	return &Term{
 		client: client,
 		conf:   conf,

--- a/service/api/types.go
+++ b/service/api/types.go
@@ -107,6 +107,9 @@ type Thread struct {
 	Breakpoint *Breakpoint `json:"breakPoint,omitempty"`
 	// Informations requested by the current breakpoint
 	BreakpointInfo *BreakpointInfo `json:"breakPointInfo,omitempty"`
+
+	// ReturnValues contains the return values of the function we just stepped out of
+	ReturnValues []Variable
 }
 
 type Location struct {
@@ -263,6 +266,9 @@ type DebuggerCommand struct {
 	// GoroutineID is used to specify which thread to use with the SwitchGoroutine
 	// command.
 	GoroutineID int `json:"goroutineID,omitempty"`
+	// When ReturnInfoLoadConfig is not nil it will be used to load the value
+	// of any return variables.
+	ReturnInfoLoadConfig *LoadConfig
 }
 
 // Informations about the current breakpoint

--- a/service/client.go
+++ b/service/client.go
@@ -127,4 +127,7 @@ type Client interface {
 	ListCheckpoints() ([]api.Checkpoint, error)
 	// ClearCheckpoint removes a checkpoint
 	ClearCheckpoint(id int) error
+
+	// SetReturnValuesLoadConfig sets the load configuration for return values.
+	SetReturnValuesLoadConfig(*api.LoadConfig)
 }

--- a/service/rpc2/client.go
+++ b/service/rpc2/client.go
@@ -15,6 +15,8 @@ import (
 type RPCClient struct {
 	addr   string
 	client *rpc.Client
+
+	retValLoadCfg *api.LoadConfig
 }
 
 // Ensure the implementation satisfies the interface.
@@ -80,7 +82,7 @@ func (c *RPCClient) continueDir(cmd string) <-chan *api.DebuggerState {
 	go func() {
 		for {
 			out := new(CommandOut)
-			err := c.call("Command", &api.DebuggerCommand{Name: cmd}, &out)
+			err := c.call("Command", &api.DebuggerCommand{Name: cmd, ReturnInfoLoadConfig: c.retValLoadCfg}, &out)
 			state := out.State
 			if err != nil {
 				state.Err = err
@@ -115,19 +117,19 @@ func (c *RPCClient) continueDir(cmd string) <-chan *api.DebuggerState {
 
 func (c *RPCClient) Next() (*api.DebuggerState, error) {
 	var out CommandOut
-	err := c.call("Command", api.DebuggerCommand{Name: api.Next}, &out)
+	err := c.call("Command", api.DebuggerCommand{Name: api.Next, ReturnInfoLoadConfig: c.retValLoadCfg}, &out)
 	return &out.State, err
 }
 
 func (c *RPCClient) Step() (*api.DebuggerState, error) {
 	var out CommandOut
-	err := c.call("Command", api.DebuggerCommand{Name: api.Step}, &out)
+	err := c.call("Command", api.DebuggerCommand{Name: api.Step, ReturnInfoLoadConfig: c.retValLoadCfg}, &out)
 	return &out.State, err
 }
 
 func (c *RPCClient) StepOut() (*api.DebuggerState, error) {
 	var out CommandOut
-	err := c.call("Command", &api.DebuggerCommand{Name: api.StepOut}, &out)
+	err := c.call("Command", &api.DebuggerCommand{Name: api.StepOut, ReturnInfoLoadConfig: c.retValLoadCfg}, &out)
 	return &out.State, err
 }
 
@@ -346,6 +348,10 @@ func (c *RPCClient) ClearCheckpoint(id int) error {
 	var out ClearCheckpointOut
 	err := c.call("ClearCheckpoint", ClearCheckpointIn{id}, &out)
 	return err
+}
+
+func (c *RPCClient) SetReturnValuesLoadConfig(cfg *api.LoadConfig) {
+	c.retValLoadCfg = cfg
 }
 
 func (c *RPCClient) call(method string, args, reply interface{}) error {


### PR DESCRIPTION
```
proc,service: display return values when stepping out of a function

Displays the return values of the current function when we step out of
it after executing a step, next or stepout command.

Implementation of this feature is tricky: when the function has
returned the return variables are not in scope anymore. Implementing
this feature requires evaluating variables that are out of scope, using
a stack frame that doesn't exist anymore.

We can't calculate the address of these variables when the
next/step/stepout command is initiated either, because between that
point and the time where the stepout breakpoint is actually hit the
goroutine stack could grow and be moved to a different memory address.
```
```
proc: move AllGCache to a common struct

Add a new method "Common" to proc.Process that returns a pointer to a
struct that pkg/proc can use to store its things, independently of the
backend.

This is used here to replace the AllGCache typecasts, it will also be
used to store the return values of the stepout breakpoint and the state
for injected function calls.

```
