### PR TITLE
Keep searching for file:line until found

### DIFF
--- a/pkg/proc/bininfo.go
+++ b/pkg/proc/bininfo.go
@@ -286,10 +286,9 @@ func (bi *BinaryInfo) LineToPC(filename string, lineno int) (pc uint64, fn *Func
 		if cu.lineInfo.Lookup[filename] != nil {
 			pc = cu.lineInfo.LineToPC(filename, lineno)
 			fn = bi.PCToFunc(pc)
-			if fn == nil {
-				err = fmt.Errorf("no code at %s:%d", filename, lineno)
+			if fn != nil {
+				return
 			}
-			return
 		}
 	}
 	err = fmt.Errorf("could not find %s:%d", filename, lineno)


### PR DESCRIPTION
Go seems to be generating multiple compilation units that have
the same file. I think this happens for functions that get inlined.
Without this patch, those inlined functions break the ability to set
a breakpoint at other lines in the file. I was able to load the same
binary in gdb and set a breakpoints throughout the file without issue.

Inlined functions are still a little weird. setting a breakpoint on
a function that gets inlined picks the first occurence. That being
said, I think delve should still do something reasonable for the rest
of the lines in the file.

Some potential debugging info:
```
➜ objdump --dwarf=decodedline automate-gateway | grep handler/users.go
.../handler/users.go:[++]
s/.../handler/users.go           20            0xb6dd88
.../handler/users.go:[++]
s/.../handler/users.go           20            0xb6e50f
.../handler/users.go:[++]
s/automate-gateway/handler/users.go           32            0xb66640
...
```

```
➜ go version
go version go1.10.1 linux/amd64
```

```
➜ dlv version
Delve Debugger
Version: 1.0.0
Build: $Id: c98a142125d0b17bb11ec0513bde346229b5f533 $
```
