### PR TITLE
proc: add support for dwz compressed DWARF

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,3 +14,6 @@ go:
 matrix:
   allow_failures:
     - go: tip
+
+before_install:
+  - if [ $TRAVIS_OS_NAME = "linux" ]; then sudo apt-get -qq update; sudo apt-get install -y dwz; fi

--- a/_fixtures/dwzcompression.go
+++ b/_fixtures/dwzcompression.go
@@ -1,0 +1,14 @@
+package main
+
+// #include <stdio.h>
+// void fortytwo()
+// {
+//      fprintf(stdin, "42");
+// }
+import "C"
+import "runtime"
+
+func main() {
+	C.fortytwo()
+	runtime.Breakpoint()
+}

--- a/pkg/proc/bininfo.go
+++ b/pkg/proc/bininfo.go
@@ -78,6 +78,20 @@ type compileUnit struct {
 	optimized     bool // this compile unit is optimized
 }
 
+type partialUnitConstant struct {
+	name  string
+	typ   dwarf.Offset
+	value int64
+}
+
+type partialUnit struct {
+	entry       *dwarf.Entry
+	types       map[string]dwarf.Offset
+	variables   []packageVar
+	constants   []partialUnitConstant
+	functions   []Function
+}
+
 // Function describes a function in the target program.
 type Function struct {
 	Name       string

--- a/pkg/proc/proc_test.go
+++ b/pkg/proc/proc_test.go
@@ -3697,3 +3697,20 @@ func TestIssue951(t *testing.T) {
 		}
 	})
 }
+	
+func TestDWZCompression(t *testing.T) {
+	// If dwz is not available in the system, skip this test
+	if _, err := exec.LookPath("dwz"); err != nil {
+		t.Skip("dwz not installed")
+	}
+
+	withTestProcessArgs("dwzcompression", t, ".", []string{}, protest.EnableDWZCompression, func(p proc.Process, fixture protest.Fixture) {
+		_, err := setFunctionBreakpoint(p, "C.fortytwo")
+		assertNoError(err, t, "setFunctionBreakpoint()")
+		assertNoError(proc.Continue(p), t, "first Continue()")
+		val := evalVariable(p, t, "stdin")
+		if val.RealType == nil {
+			t.Errorf("Can't find type for \"stdin\" global variable")
+		}
+	})
+}

--- a/pkg/proc/test/support.go
+++ b/pkg/proc/test/support.go
@@ -54,6 +54,7 @@ const (
 	LinkStrip BuildFlags = 1 << iota
 	EnableCGOOptimization
 	EnableInlining
+	EnableDWZCompression
 )
 
 func BuildFixture(name string, flags BuildFlags) Fixture {
@@ -108,6 +109,15 @@ func BuildFixture(name string, flags BuildFlags) Fixture {
 		fmt.Printf("Error compiling %s: %s\n", path, err)
 		fmt.Printf("%s\n", string(out))
 		os.Exit(1)
+	}
+
+	if flags&EnableDWZCompression != 0 {
+		cmd := exec.Command("dwz", tmpfile)
+		if out, err := cmd.CombinedOutput(); err != nil {
+			fmt.Printf("Error running dwz on %s: %s\n", tmpfile, err)
+			fmt.Printf("%s\n", string(out))
+			os.Exit(1)
+		}
 	}
 
 	source, _ := filepath.Abs(path)


### PR DESCRIPTION
'dwz' is a tool that reduces the size of DWARF sections by deduplicating
symbols. The deduplicated symbols are moved from their original 'compile
unit' to a 'partial unit', which is then referenced from its original
location with an 'imported unit' tag.

In the case of Go binaries, all symbols are located in a single 'compile
unit', and the name of each symbol contains a reference to its package,
so 'dwz' is not able to deduplicate them. But still, some C symbols
included in the binary are deduplicated, which also alters the structure
of the DWARF sections, making delve unable to parse them (crashing in
the attempt).

While it would've been possible to simply ignore the C symbols, or
blindly loading all then into BinaryInfo members (packageVars,
Functions...), for correctness sake this change tries to do the right
thing, staging symbols into temporary partialUnit objects, moving them
to BinaryInfo when they are actually requested  by a 'imported unit'
tag.