### PR TITLE
proc/gdbserial: disable foreground if /dev/tty can't be opened

### DIFF
--- a/pkg/proc/gdbserial/gdbserver.go
+++ b/pkg/proc/gdbserial/gdbserver.go
@@ -399,6 +399,17 @@ func LLDBLaunch(cmd []string, wd string, foreground bool) (*Process, error) {
 		}
 	}
 
+	if foreground {
+		// Disable foregrounding if we can't open /dev/tty or debugserver will
+		// crash. See issue #1215.
+		tty, err := os.Open("/dev/tty")
+		if err != nil {
+			foreground = false
+		} else {
+			tty.Close()
+		}
+	}
+
 	isDebugserver := false
 
 	var listener net.Listener


### PR DESCRIPTION
```
proc/gdbserial: disable foreground if /dev/tty can't be opened

Passing --stdin-path /dev/tty will crash debugserver if /dev/tty can't
be open.

Fixes #1215

```
