### PR TITLE
pkg/proc: respect specified load configuration after reslicing a map

### DIFF
--- a/pkg/proc/eval.go
+++ b/pkg/proc/eval.go
@@ -726,9 +726,9 @@ func (scope *EvalScope) evalReslice(node *ast.SliceExpr) (*Variable, error) {
 			return nil, fmt.Errorf("second slice argument must be empty for maps")
 		}
 		xev.mapSkip += int(low)
-		xev.loadValue(loadFullValue)
-		if xev.Unreadable != nil {
-			return nil, xev.Unreadable
+		xev.mapIterator() // reads map length
+		if int64(xev.mapSkip) >= xev.Len {
+			return nil, fmt.Errorf("map index out of bounds")
 		}
 		return xev, nil
 	default:


### PR DESCRIPTION
```
pkg/proc: respect specified load configuration after reslicing a map

Maps were always loaded with using the default configuration during a
reslice. This is probably a remnant from when we didn't let clients
configure the load parameters.

```
