### PR TITLE
tests: call RunTestsWithFixtures everywhere we use BuildFixture

### DIFF
--- a/pkg/proc/core/core_test.go
+++ b/pkg/proc/core/core_test.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"go/constant"
 	"io/ioutil"
+	"os"
 	"os/exec"
 	"path"
 	"path/filepath"
@@ -17,6 +18,10 @@ import (
 	"github.com/derekparker/delve/pkg/proc"
 	"github.com/derekparker/delve/pkg/proc/test"
 )
+
+func TestMain(m *testing.M) {
+	os.Exit(test.RunTestsWithFixtures(m))
+}
 
 func assertNoError(err error, t testing.TB, s string) {
 	if err != nil {

--- a/pkg/proc/gdbserial/rr_test.go
+++ b/pkg/proc/gdbserial/rr_test.go
@@ -2,6 +2,7 @@ package gdbserial_test
 
 import (
 	"fmt"
+	"os"
 	"os/exec"
 	"path/filepath"
 	"runtime"
@@ -11,6 +12,10 @@ import (
 	"github.com/derekparker/delve/pkg/proc/gdbserial"
 	protest "github.com/derekparker/delve/pkg/proc/test"
 )
+
+func TestMain(m *testing.M) {
+	os.Exit(protest.RunTestsWithFixtures(m))
+}
 
 func withTestRecording(name string, t testing.TB, fn func(p *gdbserial.Process, fixture protest.Fixture)) {
 	fixture := protest.BuildFixture(name, 0)

--- a/pkg/proc/test/support.go
+++ b/pkg/proc/test/support.go
@@ -18,6 +18,8 @@ import (
 
 var EnableRace = flag.Bool("racetarget", false, "Enables race detector on inferior process")
 
+var runningWithFixtures bool
+
 // Fixture is a test binary.
 type Fixture struct {
 	// Name is the short name of the fixture.
@@ -58,6 +60,9 @@ const (
 )
 
 func BuildFixture(name string, flags BuildFlags) Fixture {
+	if !runningWithFixtures {
+		panic("RunTestsWithFixtures not called")
+	}
 	fk := FixtureKey{name, flags}
 	if f, ok := Fixtures[fk]; ok {
 		return f
@@ -132,6 +137,10 @@ func BuildFixture(name string, flags BuildFlags) Fixture {
 // RunTestsWithFixtures will pre-compile test fixtures before running test
 // methods. Test binaries are deleted before exiting.
 func RunTestsWithFixtures(m *testing.M) int {
+	runningWithFixtures = true
+	defer func() {
+		runningWithFixtures = false
+	}()
 	status := m.Run()
 
 	// Remove the fixtures.

--- a/pkg/terminal/command_test.go
+++ b/pkg/terminal/command_test.go
@@ -33,7 +33,7 @@ func TestMain(m *testing.M) {
 			testBackend = "native"
 		}
 	}
-	os.Exit(m.Run())
+	os.Exit(test.RunTestsWithFixtures(m))
 }
 
 type FakeTerminal struct {


### PR DESCRIPTION
```
tests: call RunTestsWithFixtures everywhere we use BuildFixture

If we don't build artifacts aren't removed after the tests run. Also
add a check to prevent this mistake from reoccuring.

```
