### PR TITLE
*: Show return values of traced functions

### DIFF
--- a/_fixtures/integrationprog.go
+++ b/_fixtures/integrationprog.go
@@ -5,14 +5,15 @@ import (
 	"time"
 )
 
-func sayhi() {
-	fmt.Println("hi")
+func sayhi(i int) string {
+	return fmt.Sprintf("hi %d", i)
 }
 
 func main() {
 	time.Sleep(1 * time.Second)
 	for i := 0; i < 3; i++ {
-		sayhi()
+		ret := sayhi(i)
+		fmt.Println(ret)
 		time.Sleep(1 * time.Second)
 	}
 }

--- a/cmd/dlv/cmds/commands.go
+++ b/cmd/dlv/cmds/commands.go
@@ -376,7 +376,13 @@ func traceCmd(cmd *cobra.Command, args []string) {
 			return 1
 		}
 		for i := range funcs {
-			_, err = client.CreateBreakpoint(&api.Breakpoint{FunctionName: funcs[i], Tracepoint: true, Line: -1, Stacktrace: traceStackDepth, LoadArgs: &terminal.ShortLoadConfig})
+			_, err = client.CreateBreakpoint(&api.Breakpoint{
+				FunctionName: funcs[i],
+				Tracepoint:   true,
+				Line:         -1,
+				Stacktrace:   traceStackDepth,
+				LoadArgs:     &terminal.ShortLoadConfig,
+			})
 			if err != nil {
 				fmt.Fprintln(os.Stderr, err)
 				return 1

--- a/pkg/proc/breakpoints.go
+++ b/pkg/proc/breakpoints.go
@@ -79,6 +79,9 @@ const (
 	// Continue will set a new breakpoint (of NextBreakpoint kind) on the
 	// destination of CALL, delete this breakpoint and then continue again
 	StepBreakpoint
+	// TraceReturnBreakpoint is an internal breakpoint set to get the return
+	// values of a traced function.
+	TraceReturnBreakpoint
 )
 
 func (bp *Breakpoint) String() string {
@@ -372,6 +375,7 @@ func configureReturnBreakpoint(bi *BinaryInfo, bp *Breakpoint, topframe *Stackfr
 	if topframe.Current.Fn == nil {
 		return
 	}
+	bp.Name = fmt.Sprintf("[return values] %d", bp.ID)
 	bp.returnInfo = &returnBreakpointInfo{
 		retFrameCond: retFrameCond,
 		fn:           topframe.Current.Fn,

--- a/pkg/proc/variables.go
+++ b/pkg/proc/variables.go
@@ -645,7 +645,7 @@ func (scope *EvalScope) FunctionArguments(cfg LoadConfig) ([]*Variable, error) {
 		return nil, err
 	}
 	vars = filterVariables(vars, func(v *Variable) bool {
-		return (v.Flags & (VariableArgument | VariableReturnArgument)) != 0
+		return (v.Flags & VariableArgument) != 0
 	})
 	loadValues(vars, cfg)
 	return vars, nil

--- a/pkg/terminal/command.go
+++ b/pkg/terminal/command.go
@@ -1553,25 +1553,41 @@ func printcontextThread(t *Term, th *api.Thread) {
 	}
 
 	if hitCount, ok := th.Breakpoint.HitCount[strconv.Itoa(th.GoroutineID)]; ok {
-		fmt.Printf("> %s%s(%s) %s:%d (hits goroutine(%d):%d total:%d) (PC: %#v)\n",
-			bpname,
-			fn.Name,
-			args,
-			ShortenFilePath(th.File),
-			th.Line,
-			th.GoroutineID,
-			hitCount,
-			th.Breakpoint.TotalHitCount,
-			th.PC)
+		shouldprint := true
+		if th.Breakpoint.Tracepoint {
+			if th.ReturnValues != nil {
+				shouldprint = false
+			}
+		}
+		if shouldprint {
+			fmt.Printf("> %s%s(%s) %s:%d (hits goroutine(%d):%d total:%d) (PC: %#v)\n",
+				bpname,
+				fn.Name,
+				args,
+				ShortenFilePath(th.File),
+				th.Line,
+				th.GoroutineID,
+				hitCount,
+				th.Breakpoint.TotalHitCount,
+				th.PC)
+		}
 	} else {
-		fmt.Printf("> %s%s(%s) %s:%d (hits total:%d) (PC: %#v)\n",
-			bpname,
-			fn.Name,
-			args,
-			ShortenFilePath(th.File),
-			th.Line,
-			th.Breakpoint.TotalHitCount,
-			th.PC)
+		shouldprint := true
+		if th.Breakpoint.Tracepoint {
+			if th.ReturnValues != nil {
+				shouldprint = false
+			}
+		}
+		if shouldprint {
+			fmt.Printf("> %s%s(%s) %s:%d (hits total:%d) (PC: %#v)\n",
+				bpname,
+				fn.Name,
+				args,
+				ShortenFilePath(th.File),
+				th.Line,
+				th.Breakpoint.TotalHitCount,
+				th.PC)
+		}
 	}
 	if th.Function != nil && th.Function.Optimized {
 		fmt.Println(optimizedFunctionWarning)


### PR DESCRIPTION
This patch enables the trace command to take advantage of the return
value distinction present in the debug info of binaries produced with a
sufficiently new Go compiler.