### PR TITLE
proc: support GNU compressed debug sections (go1.11 support)

### DIFF
--- a/pkg/dwarf/godwarf/sections.go
+++ b/pkg/dwarf/godwarf/sections.go
@@ -1,0 +1,107 @@
+package godwarf
+
+import (
+	"bytes"
+	"compress/zlib"
+	"debug/elf"
+	"debug/macho"
+	"debug/pe"
+	"encoding/binary"
+	"fmt"
+	"io"
+)
+
+// GetDebugSectionElf returns the data contents of the specified debug
+// section, decompressing it if it is compressed.
+// For example GetDebugSectionElf("line") will return the contents of
+// .debug_line, if .debug_line doesn't exist it will try to return the
+// decompressed contents of .zdebug_line.
+func GetDebugSectionElf(f *elf.File, name string) ([]byte, error) {
+	sec := f.Section(".debug_" + name)
+	if sec != nil {
+		return sec.Data()
+	}
+	sec = f.Section(".zdebug_" + name)
+	if sec == nil {
+		return nil, fmt.Errorf("could not find .debug_%s section", name)
+	}
+	b, err := sec.Data()
+	if err != nil {
+		return nil, err
+	}
+	return decompressMaybe(b)
+}
+
+// GetDebugSectionPE returns the data contents of the specified debug
+// section, decompressing it if it is compressed.
+// For example GetDebugSectionPE("line") will return the contents of
+// .debug_line, if .debug_line doesn't exist it will try to return the
+// decompressed contents of .zdebug_line.
+func GetDebugSectionPE(f *pe.File, name string) ([]byte, error) {
+	sec := f.Section(".debug_" + name)
+	if sec != nil {
+		return peSectionData(sec)
+	}
+	sec = f.Section(".zdebug_" + name)
+	if sec == nil {
+		return nil, fmt.Errorf("could not find .debug_%s section", name)
+	}
+	b, err := peSectionData(sec)
+	if err != nil {
+		return nil, err
+	}
+	return decompressMaybe(b)
+}
+
+func peSectionData(sec *pe.Section) ([]byte, error) {
+	b, err := sec.Data()
+	if err != nil {
+		return nil, err
+	}
+	if 0 < sec.VirtualSize && sec.VirtualSize < sec.Size {
+		b = b[:sec.VirtualSize]
+	}
+	return b, nil
+}
+
+// GetDebugSectionMacho returns the data contents of the specified debug
+// section, decompressing it if it is compressed.
+// For example GetDebugSectionMacho("line") will return the contents of
+// __debug_line, if __debug_line doesn't exist it will try to return the
+// decompressed contents of __zdebug_line.
+func GetDebugSectionMacho(f *macho.File, name string) ([]byte, error) {
+	sec := f.Section("__debug_" + name)
+	if sec != nil {
+		return sec.Data()
+	}
+	sec = f.Section("__zdebug_" + name)
+	if sec == nil {
+		return nil, fmt.Errorf("could not find .debug_%s section", name)
+	}
+	b, err := sec.Data()
+	if err != nil {
+		return nil, err
+	}
+	return decompressMaybe(b)
+}
+
+func decompressMaybe(b []byte) ([]byte, error) {
+	if len(b) < 12 || string(b[:4]) != "ZLIB" {
+		// not compressed
+		return b, nil
+	}
+
+	dlen := binary.BigEndian.Uint64(b[4:12])
+	dbuf := make([]byte, dlen)
+	r, err := zlib.NewReader(bytes.NewBuffer(b[12:]))
+	if err != nil {
+		return nil, err
+	}
+	if _, err := io.ReadFull(r, dbuf); err != nil {
+		return nil, err
+	}
+	if err := r.Close(); err != nil {
+		return nil, err
+	}
+	return dbuf, nil
+}

--- a/pkg/dwarf/line/line_parser_test.go
+++ b/pkg/dwarf/line/line_parser_test.go
@@ -14,6 +14,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/derekparker/delve/pkg/dwarf/godwarf"
 	"github.com/pkg/profile"
 )
 
@@ -34,24 +35,23 @@ func grabDebugLineSection(p string, t *testing.T) []byte {
 
 	ef, err := elf.NewFile(f)
 	if err == nil {
-		data, _ := ef.Section(".debug_line").Data()
+		data, _ := godwarf.GetDebugSectionElf(ef, "line")
 		return data
 	}
 
 	pf, err := pe.NewFile(f)
 	if err == nil {
-		sec := pf.Section(".debug_line")
-		data, _ := sec.Data()
-		if 0 < sec.VirtualSize && sec.VirtualSize < sec.Size {
-			return data[:sec.VirtualSize]
-		}
+		data, _ := godwarf.GetDebugSectionPE(pf, "line")
 		return data
 	}
 
-	mf, _ := macho.NewFile(f)
-	data, _ := mf.Section("__debug_line").Data()
+	mf, err := macho.NewFile(f)
+	if err == nil {
+		data, _ := godwarf.GetDebugSectionMacho(mf, "line")
+		return data
+	}
 
-	return data
+	return nil
 }
 
 const (

--- a/pkg/proc/gdbserial/gdbserver_conn.go
+++ b/pkg/proc/gdbserial/gdbserver_conn.go
@@ -637,7 +637,7 @@ func (conn *gdbConn) parseStopPacket(resp []byte, threadID string, tu *threadUpd
 		sp.sig = uint8(sig)
 
 		if logflags.GdbWire() && gdbWireFullStopPacket {
-			conn.log.Debug("full stop packet: %s\n", string(resp))
+			conn.log.Debugf("full stop packet: %s\n", string(resp))
 		}
 
 		buf := resp[3:]


### PR DESCRIPTION
```
proc: support GNU compressed debug sections (go1.11 support)

Go1.11 switched to the zlib-gnu compression format for debug sections.
Change proc and and a test in dwarf/line to support this change.

Also deletes some dead code from pkg/proc/bininfo.go that hadn't been
used in a long time.

```
