### PR TITLE
proc,command: fix optimized function warning in 1.9

### DIFF
--- a/pkg/proc/proc_test.go
+++ b/pkg/proc/proc_test.go
@@ -3844,3 +3844,21 @@ func TestStepOutReturn(t *testing.T) {
 		}
 	})
 }
+
+func TestOptimizationCheck(t *testing.T) {
+	withTestProcess("continuetestprog", t, func(p proc.Process, fixture protest.Fixture) {
+		fn := p.BinInfo().LookupFunc["main.main"]
+		if fn.Optimized() {
+			t.Fatalf("main.main is optimized")
+		}
+	})
+
+	if goversion.VersionAfterOrEqual(runtime.Version(), 1, 10) {
+		withTestProcessArgs("continuetestprog", t, ".", []string{}, protest.EnableOptimization|protest.EnableInlining, func(p proc.Process, fixture protest.Fixture) {
+			fn := p.BinInfo().LookupFunc["main.main"]
+			if !fn.Optimized() {
+				t.Fatalf("main.main is not optimized")
+			}
+		})
+	}
+}

--- a/pkg/proc/test/support.go
+++ b/pkg/proc/test/support.go
@@ -56,6 +56,7 @@ const (
 	LinkStrip BuildFlags = 1 << iota
 	EnableCGOOptimization
 	EnableInlining
+	EnableOptimization
 	EnableDWZCompression
 )
 
@@ -94,10 +95,14 @@ func BuildFixture(name string, flags BuildFlags) Fixture {
 	if flags&LinkStrip != 0 {
 		buildFlags = append(buildFlags, "-ldflags=-s")
 	}
-	gcflags := "-gcflags=-N -l"
-	if flags&EnableInlining != 0 {
-		gcflags = "-gcflags=-N"
+	gcflagsv := []string{}
+	if flags&EnableInlining == 0 {
+		gcflagsv = append(gcflagsv, "-l")
 	}
+	if flags&EnableOptimization == 0 {
+		gcflagsv = append(gcflagsv, "-N")
+	}
+	gcflags := "-gcflags=" + strings.Join(gcflagsv, " ")
 	buildFlags = append(buildFlags, gcflags, "-o", tmpfile)
 	if *EnableRace {
 		buildFlags = append(buildFlags, "-race")

--- a/pkg/proc/types.go
+++ b/pkg/proc/types.go
@@ -22,6 +22,7 @@ import (
 	"github.com/derekparker/delve/pkg/dwarf/line"
 	"github.com/derekparker/delve/pkg/dwarf/op"
 	"github.com/derekparker/delve/pkg/dwarf/reader"
+	"github.com/derekparker/delve/pkg/goversion"
 	"github.com/derekparker/delve/pkg/logflags"
 )
 
@@ -223,10 +224,10 @@ func (bi *BinaryInfo) loadDebugInfoMaps(debugLineBytes []byte, wg *sync.WaitGrou
 				cu.lineInfo.LogSuppressedErrors(logflags.DebugLineErrors())
 			}
 			cu.producer, _ = entry.Val(dwarf.AttrProducer).(string)
-			if cu.isgo {
+			if cu.isgo && cu.producer != "" {
 				semicolon := strings.Index(cu.producer, ";")
 				if semicolon < 0 {
-					cu.optimized = true
+					cu.optimized = goversion.ProducerAfterOrEqual(cu.producer, 1, 10)
 				} else {
 					cu.optimized = !strings.Contains(cu.producer[semicolon:], "-N") || !strings.Contains(cu.producer[semicolon:], "-l")
 					cu.producer = cu.producer[:semicolon]


### PR DESCRIPTION
```
proc,command: fix optimized function warning in 1.9

A user complained on the mailing list about having continuous
"optimized function warnings" on non-optimized functions when using 1.9.
This commit fixes the problem by disabling optimized function detection
on 1.9 and earlier (where it's impossible) and adds a test so we don't
break it again in the future.

```
