### PR TITLE
terminal: disable next/step/stepout if current frame isn't 0

### DIFF
--- a/pkg/terminal/command.go
+++ b/pkg/terminal/command.go
@@ -911,12 +911,16 @@ func (c *Commands) step(t *Term, ctx callContext, args string) error {
 	return continueUntilCompleteNext(t, state, "step")
 }
 
+var notOnFrameZeroErr = errors.New("not on topmost frame")
+
 func (c *Commands) stepInstruction(t *Term, ctx callContext, args string) error {
 	if err := scopePrefixSwitch(t, ctx); err != nil {
 		return err
 	}
+	if c.frame != 0 {
+		return notOnFrameZeroErr
+	}
 	state, err := exitedToError(t.client.StepInstruction())
-	c.frame = 0
 	if err != nil {
 		printfileNoState(t)
 		return err
@@ -930,8 +934,10 @@ func (c *Commands) next(t *Term, ctx callContext, args string) error {
 	if err := scopePrefixSwitch(t, ctx); err != nil {
 		return err
 	}
+	if c.frame != 0 {
+		return notOnFrameZeroErr
+	}
 	state, err := exitedToError(t.client.Next())
-	c.frame = 0
 	if err != nil {
 		printfileNoState(t)
 		return err
@@ -944,8 +950,10 @@ func (c *Commands) stepout(t *Term, ctx callContext, args string) error {
 	if err := scopePrefixSwitch(t, ctx); err != nil {
 		return err
 	}
+	if c.frame != 0 {
+		return notOnFrameZeroErr
+	}
 	state, err := exitedToError(t.client.StepOut())
-	c.frame = 0
 	if err != nil {
 		printfileNoState(t)
 		return err


### PR DESCRIPTION
```
terminal: disable next/step/stepout if current frame isn't 0

next/step/stepout should work even if the current frame isn't the
topmost stack frame, but their behavior should be different in that
case (they should continue inside the function of the selected frame).

Most of the logic of next/step/stepout would work correctly if we
simply replaced the call to proc.topframe with something that took a
frame index. However the breakpoint they set on the first deferred
function is wrong, and fixing it requires scanning the defer stack and
matching it to the call stack, something we can't do yet.

Given that enhancing next/step/stepout will take time and the current
behavior confuses users (see issue #1240) return an error if
next/step/stepout are called while the currently selected frame isn't
frame 0.

Updates #1240

```
