### PR TITLE
proc,terminal,service: let headless instances run without connected clients

### DIFF
--- a/Documentation/cli/README.md
+++ b/Documentation/cli/README.md
@@ -163,6 +163,10 @@ Move the current frame down by <m>. The second form runs the command on the give
 
 ## exit
 Exit the debugger.
+		
+	exit [-c]
+	
+When connected to a headless instance started with the --accept-multiclient, pass -c to resume the execution of the target process before disconnecting.
 
 Aliases: quit q
 

--- a/cmd/dlv/cmds/commands.go
+++ b/cmd/dlv/cmds/commands.go
@@ -488,9 +488,16 @@ func execute(attachPid int, processArgs []string, conf *config.Config, coreFile 
 		fmt.Fprint(os.Stderr, "Warning: init file ignored\n")
 	}
 
+	if !Headless && AcceptMulti {
+		fmt.Fprint(os.Stderr, "Warning accept-multi: ignored\n")
+		// AcceptMulti won't work in normal (non-headless) mode because we always
+		// call server.Stop after the terminal client exits.
+		AcceptMulti = false
+	}
+
 	var server interface {
 		Run() error
-		Stop(bool) error
+		Stop() error
 	}
 
 	disconnectChan := make(chan struct{})
@@ -541,7 +548,7 @@ func execute(attachPid int, processArgs []string, conf *config.Config, coreFile 
 		case <-ch:
 		case <-disconnectChan:
 		}
-		err = server.Stop(true)
+		err = server.Stop()
 	} else {
 		// Create and start a terminal
 		client := rpc2.NewClient(listener.Addr().String())

--- a/pkg/proc/core/core.go
+++ b/pkg/proc/core/core.go
@@ -299,8 +299,8 @@ func (p *Process) Detach(bool) error {
 	return nil
 }
 
-func (p *Process) Exited() bool {
-	return false
+func (p *Process) Valid() (bool, error) {
+	return true, nil
 }
 
 func (p *Process) Common() *proc.CommonProcess {

--- a/pkg/proc/disasm.go
+++ b/pkg/proc/disasm.go
@@ -24,8 +24,8 @@ const (
 // If currentGoroutine is set and thread is stopped at a CALL instruction Disassemble will evaluate the argument of the CALL instruction using the thread's registers
 // Be aware that the Bytes field of each returned instruction is a slice of a larger array of size endPC - startPC
 func Disassemble(dbp Process, g *G, startPC, endPC uint64) ([]AsmInstruction, error) {
-	if dbp.Exited() {
-		return nil, &ProcessExitedError{Pid: dbp.Pid()}
+	if _, err := dbp.Valid(); err != nil {
+		return nil, err
 	}
 	if g == nil {
 		ct := dbp.CurrentThread()

--- a/pkg/proc/interface.go
+++ b/pkg/proc/interface.go
@@ -60,7 +60,10 @@ type Info interface {
 	// ResumeNotify specifies a channel that will be closed the next time
 	// ContinueOnce finishes resuming the target.
 	ResumeNotify(chan<- struct{})
-	Exited() bool
+	// Valid returns true if this Process can be used. When it returns false it
+	// also returns an error describing why the Process is invalid (either
+	// ProcessExitedError or ProcessDetachedError).
+	Valid() (bool, error)
 	BinInfo() *BinaryInfo
 	// Common returns a struct with fields common to all backends
 	Common() *CommonProcess

--- a/pkg/proc/proc_test.go
+++ b/pkg/proc/proc_test.go
@@ -974,7 +974,7 @@ func TestKill(t *testing.T) {
 		if err := p.Detach(true); err != nil {
 			t.Fatal(err)
 		}
-		if !p.Exited() {
+		if valid, _ := p.Valid(); valid {
 			t.Fatal("expected process to have exited")
 		}
 		if runtime.GOOS == "linux" {
@@ -1036,7 +1036,7 @@ func TestContinueMulti(t *testing.T) {
 		sayhiCount := 0
 		for {
 			err := proc.Continue(p)
-			if p.Exited() {
+			if valid, _ := p.Valid(); !valid {
 				break
 			}
 			assertNoError(err, t, "Continue()")

--- a/pkg/terminal/command.go
+++ b/pkg/terminal/command.go
@@ -212,7 +212,11 @@ If regex is specified only package variables with a name matching it will be ret
 	regs [-a]
 
 Argument -a shows more registers.`},
-		{aliases: []string{"exit", "quit", "q"}, cmdFn: exitCommand, helpMsg: "Exit the debugger."},
+		{aliases: []string{"exit", "quit", "q"}, cmdFn: exitCommand, helpMsg: `Exit the debugger.
+		
+	exit [-c]
+	
+When connected to a headless instance started with the --accept-multiclient, pass -c to resume the execution of the target process before disconnecting.`},
 		{aliases: []string{"list", "ls", "l"}, cmdFn: listCommand, helpMsg: `Show source code.
 
 	[goroutine <n>] [frame <m>] list [<linespec>]
@@ -1669,6 +1673,12 @@ func (ere ExitRequestError) Error() string {
 }
 
 func exitCommand(t *Term, ctx callContext, args string) error {
+	if args == "-c" {
+		if !t.client.IsMulticlient() {
+			return errors.New("not connected to an --accept-multiclient server")
+		}
+		t.quitContinue = true
+	}
 	return ExitRequestError{}
 }
 

--- a/service/api/types.go
+++ b/service/api/types.go
@@ -15,6 +15,8 @@ var NotExecutableErr = proc.NotExecutableErr
 
 // DebuggerState represents the current context of the debugger.
 type DebuggerState struct {
+	// Running is true if the process is running and no other information can be collected.
+	Running bool
 	// CurrentThread is the currently selected debugger thread.
 	CurrentThread *Thread `json:"currentThread,omitempty"`
 	// SelectedGoroutine is the currently selected goroutine

--- a/service/client.go
+++ b/service/client.go
@@ -25,6 +25,8 @@ type Client interface {
 
 	// GetState returns the current debugger state.
 	GetState() (*api.DebuggerState, error)
+	// GetStateNonBlocking returns the current debugger state, returning immediately if the target is already running.
+	GetStateNonBlocking() (*api.DebuggerState, error)
 
 	// Continue resumes process execution.
 	Continue() <-chan *api.DebuggerState
@@ -130,4 +132,11 @@ type Client interface {
 
 	// SetReturnValuesLoadConfig sets the load configuration for return values.
 	SetReturnValuesLoadConfig(*api.LoadConfig)
+
+	// IsMulticlien returns true if the headless instance is multiclient.
+	IsMulticlient() bool
+
+	// Disconnect closes the connection to the server without sending a Detach request first.
+	// If cont is true a continue command will be sent instead.
+	Disconnect(cont bool) error
 }

--- a/service/rpc1/server.go
+++ b/service/rpc1/server.go
@@ -29,7 +29,11 @@ func (s *RPCServer) ProcessPid(arg1 interface{}, pid *int) error {
 }
 
 func (s *RPCServer) Detach(kill bool, ret *int) error {
-	return s.debugger.Detach(kill)
+	err := s.debugger.Detach(kill)
+	if s.config.DisconnectChan != nil {
+		close(s.config.DisconnectChan)
+	}
+	return err
 }
 
 func (s *RPCServer) Restart(arg1 interface{}, arg2 *int) error {
@@ -41,7 +45,7 @@ func (s *RPCServer) Restart(arg1 interface{}, arg2 *int) error {
 }
 
 func (s *RPCServer) State(arg interface{}, state *api.DebuggerState) error {
-	st, err := s.debugger.State()
+	st, err := s.debugger.State(false)
 	if err != nil {
 		return err
 	}
@@ -154,7 +158,7 @@ func (s *RPCServer) GetThread(id int, thread *api.Thread) error {
 }
 
 func (s *RPCServer) ListPackageVars(filter string, variables *[]api.Variable) error {
-	state, err := s.debugger.State()
+	state, err := s.debugger.State(false)
 	if err != nil {
 		return err
 	}
@@ -195,7 +199,7 @@ func (s *RPCServer) ListThreadPackageVars(args *ThreadListArgs, variables *[]api
 }
 
 func (s *RPCServer) ListRegisters(arg interface{}, registers *string) error {
-	state, err := s.debugger.State()
+	state, err := s.debugger.State(false)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
```
proc,terminal,service: let headless instances run without connected clients

This pull request makes several changes to delve to allow headless
instancess that are started with the --accept-multiclient flag to
keep running even if there is no connected client. Specifically:

1. Makes a headless instance started with --accept-multiclient quit
after one of the clients sends a Detach request (previously they
would never ever quit, which was a bug).
2. Changes proc/gdbserial and proc/native so that they mark the
Process as exited after they detach, even if they did not kill the
process during detach. This prevents bugs such as #1231 where we
attempt to manipulate a target process after we detached from it.
3. On non --accept-multiclient instances do not kill the target
process unless we started it or the client specifically requests
it (previously if the client did not Detach before closing the
connection we would kill the target process unconditionally)
4. Add a -c option to the quit command that detaches from the
headless server after restarting the target.
5. Change terminal so that, when attached to --accept-multiclient,
pressing ^C will prompt the user to either disconnect from the
server or pause the target process. Also extend the exit prompt to
ask if the user wants to keep the headless server running.

Implements #245, #952, #1159, #1231

```
