### PR TITLE
rpccommon: restore API port message

### DIFF
--- a/service/rpccommon/server.go
+++ b/service/rpccommon/server.go
@@ -78,7 +78,7 @@ func NewServer(config *service.Config) *ServerImpl {
 	}
 	if config.Foreground {
 		// Print listener address
-		logger.Infof("API server listening at: %s", config.Listener.Addr())
+		fmt.Printf("API server listening at: %s\n", config.Listener.Addr())
 	}
 	return &ServerImpl{
 		config:   config,


### PR DESCRIPTION
```
rpccommon: restore API port message

This message is used by clients to determine the port that a headless
instance is using, therefore the format can not change or move to a
different file handle.

Fixes #1245

```
