### PR TITLE
proc,service: export declaration line of variables

### DIFF
--- a/pkg/proc/variables.go
+++ b/pkg/proc/variables.go
@@ -103,6 +103,7 @@ type Variable struct {
 	Unreadable error
 
 	LocationExpr string // location expression
+	DeclLine     int64  // line number of this variable's declaration
 }
 
 type LoadConfig struct {
@@ -836,6 +837,7 @@ func (scope *EvalScope) extractVarInfoFromEntry(varEntry *dwarf.Entry) (*Variabl
 
 	v := scope.newVariable(n, uintptr(addr), t, mem)
 	v.LocationExpr = descr
+	v.DeclLine, _ = entry.Val(dwarf.AttrDeclLine).(int64)
 	if err != nil {
 		v.Unreadable = err
 	}

--- a/service/api/conversions.go
+++ b/service/api/conversions.go
@@ -123,6 +123,7 @@ func ConvertVar(v *proc.Variable) *Variable {
 		Base:     v.Base,
 
 		LocationExpr: v.LocationExpr,
+		DeclLine:     v.DeclLine,
 	}
 
 	r.Type = prettyTypeName(v.DwarfType)

--- a/service/api/types.go
+++ b/service/api/types.go
@@ -227,6 +227,8 @@ type Variable struct {
 
 	// LocationExpr describes the location expression of this variable's address
 	LocationExpr string
+	// DeclLine is the line number of this variable's declaration
+	DeclLine int64
 }
 
 // LoadConfig describes how to load values from target's memory


### PR DESCRIPTION
```
proc,service: export declaration line of variables

Adds a field, DeclLine, to Variable containing the declaration line
number of the variable.

```
