### PR TITLE
*: Fix log level setting in logrus

### DIFF
--- a/pkg/proc/gdbserial/gdbserver.go
+++ b/pkg/proc/gdbserial/gdbserver.go
@@ -169,7 +169,7 @@ type gdbRegister struct {
 // Use Listen, Dial or Connect to complete connection.
 func New(process *os.Process) *Process {
 	logger := logrus.New().WithFields(logrus.Fields{"layer": "gdbconn"})
-	logger.Level = logrus.DebugLevel
+	logger.Logger.Level = logrus.DebugLevel
 	if !logflags.GdbWire() {
 		logger.Logger.Out = ioutil.Discard
 	}

--- a/pkg/proc/gdbserial/gdbserver_conn.go
+++ b/pkg/proc/gdbserial/gdbserver_conn.go
@@ -637,7 +637,7 @@ func (conn *gdbConn) parseStopPacket(resp []byte, threadID string, tu *threadUpd
 		sp.sig = uint8(sig)
 
 		if logflags.GdbWire() && gdbWireFullStopPacket {
-			conn.log.Debugf("full stop packet: %s\n", string(resp))
+			conn.log.Debugf("full stop packet: %s", string(resp))
 		}
 
 		buf := resp[3:]
@@ -995,9 +995,9 @@ func (conn *gdbConn) send(cmd []byte) error {
 	for {
 		if logflags.GdbWire() {
 			if len(cmd) > gdbWireMaxLen {
-				conn.log.Debugf("<- %s...\n", string(cmd[:gdbWireMaxLen]))
+				conn.log.Debugf("<- %s...", string(cmd[:gdbWireMaxLen]))
 			} else {
-				conn.log.Debugf("<- %s\n", string(cmd))
+				conn.log.Debugf("<- %s", string(cmd))
 			}
 		}
 		_, err := conn.conn.Write(cmd)
@@ -1046,9 +1046,9 @@ func (conn *gdbConn) recv(cmd []byte, context string, binary bool) (resp []byte,
 				partial = true
 			}
 			if !partial {
-				conn.log.Debugf("-> %s%s\n", string(resp), string(conn.inbuf[:2]))
+				conn.log.Debugf("-> %s%s", string(resp), string(conn.inbuf[:2]))
 			} else {
-				conn.log.Debugf("-> %s...\n", string(out))
+				conn.log.Debugf("-> %s...", string(out))
 			}
 		}
 
@@ -1099,7 +1099,7 @@ func (conn *gdbConn) readack() bool {
 	if err != nil {
 		return false
 	}
-	conn.log.Debugf("-> %s\n", string(b))
+	conn.log.Debugf("-> %s", string(b))
 	return b == '+'
 }
 
@@ -1109,7 +1109,7 @@ func (conn *gdbConn) sendack(c byte) {
 		panic(fmt.Errorf("sendack(%c)", c))
 	}
 	conn.conn.Write([]byte{c})
-	conn.log.Debugf("<- %s\n", string(c))
+	conn.log.Debugf("<- %s", string(c))
 }
 
 // escapeXor is the value mandated by the specification to escape characters

--- a/pkg/proc/types.go
+++ b/pkg/proc/types.go
@@ -224,7 +224,7 @@ func (bi *BinaryInfo) loadDebugInfoMaps(debugLineBytes []byte, wg *sync.WaitGrou
 				var logfn func(string, ...interface{})
 				if logflags.DebugLineErrors() {
 					logger := logrus.New().WithFields(logrus.Fields{"layer": "dwarf-line"})
-					logger.Level = logrus.DebugLevel
+					logger.Logger.Level = logrus.DebugLevel
 					logfn = func(fmt string, args ...interface{}) {
 						logger.Printf(fmt, args)
 					}

--- a/service/debugger/debugger.go
+++ b/service/debugger/debugger.go
@@ -69,7 +69,7 @@ type Config struct {
 // new process.
 func New(config *Config, processArgs []string) (*Debugger, error) {
 	logger := logrus.New().WithFields(logrus.Fields{"layer": "debugger"})
-	logger.Level = logrus.DebugLevel
+	logger.Logger.Level = logrus.DebugLevel
 	if !logflags.Debugger() {
 		logger.Logger.Out = ioutil.Discard
 	}

--- a/service/rpccommon/server.go
+++ b/service/rpccommon/server.go
@@ -69,7 +69,7 @@ type methodType struct {
 // NewServer creates a new RPCServer.
 func NewServer(config *service.Config) *ServerImpl {
 	logger := logrus.New().WithFields(logrus.Fields{"layer": "rpc"})
-	logger.Level = logrus.DebugLevel
+	logger.Logger.Level = logrus.DebugLevel
 	if !logflags.RPC() {
 		logger.Logger.Out = ioutil.Discard
 	}
@@ -305,7 +305,7 @@ func (s *ServerImpl) serveJSONCodec(conn io.ReadWriteCloser) {
 		if mtype.Synchronous {
 			if logflags.RPC() {
 				argvbytes, _ := json.Marshal(argv.Interface())
-				s.log.Debugf("-> %s(%T%s)\n", req.ServiceMethod, argv.Interface(), argvbytes)
+				s.log.Debugf("<- %s(%T%s)", req.ServiceMethod, argv.Interface(), argvbytes)
 			}
 			replyv = reflect.New(mtype.ReplyType.Elem())
 			function := mtype.method.Func
@@ -328,13 +328,13 @@ func (s *ServerImpl) serveJSONCodec(conn io.ReadWriteCloser) {
 			resp = rpc.Response{}
 			if logflags.RPC() {
 				replyvbytes, _ := json.Marshal(replyv.Interface())
-				s.log.Debugf("<- %T%s error: %q\n", replyv.Interface(), replyvbytes, errmsg)
+				s.log.Debugf("-> %T%s error: %q", replyv.Interface(), replyvbytes, errmsg)
 			}
 			s.sendResponse(sending, &req, &resp, replyv.Interface(), codec, errmsg)
 		} else {
 			if logflags.RPC() {
 				argvbytes, _ := json.Marshal(argv.Interface())
-				s.log.Debugf("(async %d) -> %s(%T%s)\n", req.Seq, req.ServiceMethod, argv.Interface(), argvbytes)
+				s.log.Debugf("(async %d) <- %s(%T%s)", req.Seq, req.ServiceMethod, argv.Interface(), argvbytes)
 			}
 			function := mtype.method.Func
 			ctl := &RPCCallback{s, sending, codec, req}
@@ -379,7 +379,7 @@ func (cb *RPCCallback) Return(out interface{}, err error) {
 	var resp rpc.Response
 	if logflags.RPC() {
 		outbytes, _ := json.Marshal(out)
-		cb.s.log.Debugf("(async %d) <- %T%s error: %q", cb.req.Seq, out, outbytes, errmsg)
+		cb.s.log.Debugf("(async %d) -> %T%s error: %q", cb.req.Seq, out, outbytes, errmsg)
 	}
 	cb.s.sendResponse(cb.sending, &cb.req, &resp, out, cb.codec, errmsg)
 }


### PR DESCRIPTION
```
*: Fix log level setting in logrus

Setting the Level field of a logrus logger doesn't actually do anything
since the Level field simply reports the log level of the last log
message emitted on the logger.
The right way to do that is to set logger.Logger.Level.
Also cleans up newline characters from log messages emitted through
logrus and fixes the direction of the arrows in the messages emitted by
rpccommon, which was inconsistent with the arrows of gdbserial.

```
