### PR TITLE
proc: make proc.(ThreadBlockedError).Error() return a non-empty string

### DIFF
--- a/pkg/proc/threads.go
+++ b/pkg/proc/threads.go
@@ -49,7 +49,7 @@ type Location struct {
 type ThreadBlockedError struct{}
 
 func (tbe ThreadBlockedError) Error() string {
-	return ""
+	return "thread blocked"
 }
 
 // CommonThread contains fields used by this package, common to all


### PR DESCRIPTION
The JSON-RPC layer doesn't like non-nil error that return an empty string
when the Error method is called and when this happens it shuts down the
connection to the server.
Since we can return a ThreadBlockedError to the client it can't have an
empty string as return value.

Fixes #1251