### PR TITLE
proc,service,terminal: propagate g.startpc

### DIFF
--- a/Documentation/cli/README.md
+++ b/Documentation/cli/README.md
@@ -203,13 +203,14 @@ Called with more arguments it will execute a command on the specified goroutine.
 ## goroutines
 List program goroutines.
 
-	goroutines [-u (default: user location)|-r (runtime location)|-g (go statement location) ] [ -t (stack trace)]
+	goroutines [-u (default: user location)|-r (runtime location)|-g (go statement location)|-s (start location)] [ -t (stack trace)]
 
 Print out info for every goroutine. The flag controls what information is shown along with each goroutine:
 
 	-u	displays location of topmost stackframe in user code
 	-r	displays location of topmost stackframe (including frames inside private runtime functions)
 	-g	displays location of go instruction that created the goroutine
+	-s	displays location of the start function
 	-t	displays stack trace of goroutine
 
 If no flag is specified the default is -u.

--- a/service/api/conversions.go
+++ b/service/api/conversions.go
@@ -235,6 +235,7 @@ func ConvertGoroutine(g *proc.G) *Goroutine {
 		CurrentLoc:     ConvertLocation(g.CurrentLoc),
 		UserCurrentLoc: ConvertLocation(g.UserCurrent()),
 		GoStatementLoc: ConvertLocation(g.Go()),
+		StartLoc:       ConvertLocation(g.StartLoc()),
 		ThreadID:       tid,
 	}
 }

--- a/service/api/types.go
+++ b/service/api/types.go
@@ -256,6 +256,8 @@ type Goroutine struct {
 	UserCurrentLoc Location `json:"userCurrentLoc"`
 	// Location of the go instruction that started this goroutine
 	GoStatementLoc Location `json:"goStatementLoc"`
+	// Location of the starting function
+	StartLoc Location `json:"startLoc"`
 	// ID of the associated thread for running goroutines
 	ThreadID int `json:"threadID"`
 }


### PR DESCRIPTION
```
proc,service,terminal: propagate g.startpc

Adds StartPC to proc.G, StartLoc to api.Goroutine and show the start
location in the command line client when appropriate.

Updates #1104

```
