### PR TITLE
proc,service,terminal: read defer list

### DIFF
--- a/_fixtures/deferstack.go
+++ b/_fixtures/deferstack.go
@@ -1,0 +1,32 @@
+package main
+
+import "runtime"
+
+func f1() {
+}
+
+func f2() {
+}
+
+func f3() {
+}
+
+func call1() {
+	defer f2()
+	defer f1()
+	call2()
+}
+
+func call2() {
+	defer f3()
+	defer f2()
+	call3()
+}
+
+func call3() {
+	runtime.Breakpoint()
+}
+
+func main() {
+	call1()
+}

--- a/pkg/proc/core/core_test.go
+++ b/pkg/proc/core/core_test.go
@@ -185,7 +185,7 @@ func TestCore(t *testing.T) {
 	var panickingStack []proc.Stackframe
 	for _, g := range gs {
 		t.Logf("Goroutine %d", g.ID)
-		stack, err := g.Stacktrace(10)
+		stack, err := g.Stacktrace(10, false)
 		if err != nil {
 			t.Errorf("Stacktrace() on goroutine %v = %v", g, err)
 		}
@@ -329,7 +329,7 @@ func TestCoreWithEmptyString(t *testing.T) {
 	var mainFrame *proc.Stackframe
 mainSearch:
 	for _, g := range gs {
-		stack, err := g.Stacktrace(10)
+		stack, err := g.Stacktrace(10, false)
 		assertNoError(err, t, "Stacktrace()")
 		for _, frame := range stack {
 			if frame.Current.Fn != nil && frame.Current.Fn.Name == "main.main" {

--- a/pkg/proc/proc.go
+++ b/pkg/proc/proc.go
@@ -380,14 +380,11 @@ func StepOut(dbp Process) error {
 
 	var deferpc uint64 = 0
 	if filepath.Ext(topframe.Current.File) == ".go" {
-		if selg != nil {
-			deferPCEntry := selg.DeferPC()
-			if deferPCEntry != 0 {
-				deferfn := dbp.BinInfo().PCToFunc(deferPCEntry)
-				deferpc, err = FirstPCAfterPrologue(dbp, deferfn, false)
-				if err != nil {
-					return err
-				}
+		if topframe.TopmostDefer != nil && topframe.TopmostDefer.DeferredPC != 0 {
+			deferfn := dbp.BinInfo().PCToFunc(topframe.TopmostDefer.DeferredPC)
+			deferpc, err = FirstPCAfterPrologue(dbp, deferfn, false)
+			if err != nil {
+				return err
 			}
 		}
 	}
@@ -554,7 +551,7 @@ func ConvertEvalScope(dbp Process, gid, frame int) (*EvalScope, error) {
 		thread = g.Thread
 	}
 
-	locs, err := g.Stacktrace(frame + 1)
+	locs, err := g.Stacktrace(frame+1, false)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/proc/stack.go
+++ b/pkg/proc/stack.go
@@ -4,6 +4,7 @@ import (
 	"debug/dwarf"
 	"errors"
 	"fmt"
+	"go/constant"
 	"strings"
 
 	"github.com/derekparker/delve/pkg/dwarf/frame"
@@ -57,6 +58,15 @@ type Stackframe struct {
 	// pkg/proc.
 	// Use this value to determine active lexical scopes for the stackframe.
 	lastpc uint64
+
+	// TopmostDefer is the defer that would be at the top of the stack when a
+	// panic unwind would get to this call frame, in other words it's the first
+	// deferred function that will  be called if the runtime unwinds past this
+	// call frame.
+	TopmostDefer *Defer
+
+	// Defers is the list of functions deferred by this stack frame (so far).
+	Defers []*Defer
 }
 
 // FrameOffset returns the address of the stack frame, absolute for system
@@ -91,7 +101,7 @@ func ThreadStacktrace(thread Thread, depth int) ([]Stackframe, error) {
 		it := newStackIterator(thread.BinInfo(), thread, thread.BinInfo().Arch.RegistersToDwarfRegisters(regs), 0, nil, -1, nil)
 		return it.stacktrace(depth)
 	}
-	return g.Stacktrace(depth)
+	return g.Stacktrace(depth, false)
 }
 
 func (g *G) stackIterator() (*stackIterator, error) {
@@ -112,12 +122,19 @@ func (g *G) stackIterator() (*stackIterator, error) {
 
 // Stacktrace returns the stack trace for a goroutine.
 // Note the locations in the array are return addresses not call addresses.
-func (g *G) Stacktrace(depth int) ([]Stackframe, error) {
+func (g *G) Stacktrace(depth int, readDefers bool) ([]Stackframe, error) {
 	it, err := g.stackIterator()
 	if err != nil {
 		return nil, err
 	}
-	return it.stacktrace(depth)
+	frames, err := it.stacktrace(depth)
+	if err != nil {
+		return nil, err
+	}
+	if readDefers {
+		g.readDefers(frames)
+	}
+	return frames, nil
 }
 
 // NullAddrError is an error for a null address.
@@ -567,4 +584,102 @@ func (it *stackIterator) readRegisterAt(regnum uint64, addr uint64) (*op.DwarfRe
 		return nil, err
 	}
 	return op.DwarfRegisterFromBytes(buf), nil
+}
+
+// Defer represents one deferred call
+type Defer struct {
+	DeferredPC uint64 // Value of field _defer.fn.fn, the deferred function
+	DeferPC    uint64 // PC address of instruction that added this defer
+	SP         uint64 // Value of SP register when this function was deferred (this field gets adjusted when the stack is moved to match the new stack space)
+	link       *Defer // Next deferred function
+
+	variable   *Variable
+	Unreadable error
+}
+
+// readDefers decorates the frames with the function deferred at each stack frame.
+func (g *G) readDefers(frames []Stackframe) {
+	curdefer := g.Defer()
+	i := 0
+
+	// scan simultaneously frames and the curdefer linked list, assigning
+	// defers to their associated frames.
+	for {
+		if curdefer == nil || i >= len(frames) {
+			return
+		}
+		if curdefer.Unreadable != nil {
+			// Current defer is unreadable, stick it into the first available frame
+			// (so that it can be reported to the user) and exit
+			frames[i].Defers = append(frames[i].Defers, curdefer)
+			return
+		}
+		if frames[i].Err != nil {
+			return
+		}
+
+		if frames[i].TopmostDefer == nil {
+			frames[i].TopmostDefer = curdefer
+		}
+
+		if frames[i].SystemStack || curdefer.SP >= uint64(frames[i].Regs.CFA) {
+			// frames[i].Regs.CFA is the value that SP had before the function of
+			// frames[i] was called.
+			// This means that when curdefer.SP == frames[i].Regs.CFA then curdefer
+			// was added by the previous frame.
+			//
+			// curdefer.SP < frames[i].Regs.CFA means curdefer was added by a
+			// function further down the stack.
+			//
+			// SystemStack frames live on a different physical stack and can't be
+			// compared with deferred frames.
+			i++
+		} else {
+			frames[i].Defers = append(frames[i].Defers, curdefer)
+			curdefer = curdefer.Next()
+		}
+	}
+}
+
+func (d *Defer) load() {
+	d.variable.loadValue(LoadConfig{false, 1, 0, 0, -1})
+	if d.variable.Unreadable != nil {
+		d.Unreadable = d.variable.Unreadable
+		return
+	}
+
+	fnvar := d.variable.fieldVariable("fn").maybeDereference()
+	if fnvar.Addr != 0 {
+		fnvar = fnvar.loadFieldNamed("fn")
+		if fnvar.Unreadable == nil {
+			d.DeferredPC, _ = constant.Uint64Val(fnvar.Value)
+		}
+	}
+
+	d.DeferPC, _ = constant.Uint64Val(d.variable.fieldVariable("pc").Value)
+	d.SP, _ = constant.Uint64Val(d.variable.fieldVariable("sp").Value)
+
+	linkvar := d.variable.fieldVariable("link").maybeDereference()
+	if linkvar.Addr != 0 {
+		d.link = &Defer{variable: linkvar}
+	}
+}
+
+// spDecreasedErr is used when (*Defer).Next detects a corrupted linked
+// list, specifically when after followin a link pointer the value of SP
+// decreases rather than increasing or staying the same (the defer list is a
+// FIFO list, nodes further down the list have been added by function calls
+// further down the call stack and therefore the SP should always increase).
+var spDecreasedErr = errors.New("corrupted defer list: SP decreased")
+
+// Next returns the next defer in the linked list
+func (d *Defer) Next() *Defer {
+	if d.link == nil {
+		return nil
+	}
+	d.link.load()
+	if d.link.SP < d.SP {
+		d.link.Unreadable = spDecreasedErr
+	}
+	return d.link
 }

--- a/pkg/terminal/command_test.go
+++ b/pkg/terminal/command_test.go
@@ -224,7 +224,7 @@ func TestExecuteFile(t *testing.T) {
 
 func TestIssue354(t *testing.T) {
 	printStack([]api.Stackframe{}, "", false)
-	printStack([]api.Stackframe{{api.Location{PC: 0, File: "irrelevant.go", Line: 10, Function: nil}, nil, nil, 0, 0, ""}}, "", false)
+	printStack([]api.Stackframe{{api.Location{PC: 0, File: "irrelevant.go", Line: 10, Function: nil}, nil, nil, 0, 0, nil, ""}}, "", false)
 }
 
 func TestIssue411(t *testing.T) {

--- a/pkg/terminal/disasmprint.go
+++ b/pkg/terminal/disasmprint.go
@@ -14,7 +14,7 @@ func DisasmPrint(dv api.AsmInstructions, out io.Writer) {
 	bw := bufio.NewWriter(out)
 	defer bw.Flush()
 	if len(dv) > 0 && dv[0].Loc.Function != nil {
-		fmt.Fprintf(bw, "TEXT %s(SB) %s\n", dv[0].Loc.Function.Name, dv[0].Loc.File)
+		fmt.Fprintf(bw, "TEXT %s(SB) %s\n", dv[0].Loc.Function.Name(), dv[0].Loc.File)
 	}
 	tw := tabwriter.NewWriter(bw, 1, 8, 1, '\t', 0)
 	defer tw.Flush()

--- a/service/api/conversions.go
+++ b/service/api/conversions.go
@@ -215,7 +215,7 @@ func ConvertFunction(fn *proc.Function) *Function {
 	// those fields is not documented their value was replaced with 0 when
 	// gosym.Func was replaced by debug_info entries.
 	return &Function{
-		Name:      fn.Name,
+		Name_:     fn.Name,
 		Type:      0,
 		Value:     fn.Entry,
 		GoType:    0,

--- a/service/api/types.go
+++ b/service/api/types.go
@@ -129,7 +129,16 @@ type Stackframe struct {
 	FrameOffset        int64
 	FramePointerOffset int64
 
+	Defers []Defer
+
 	Err string
+}
+
+type Defer struct {
+	DeferredLoc Location // deferred function
+	DeferLoc    Location // location of the defer statement
+	SP          uint64   // value of SP when the function was deferred
+	Unreadable  string
 }
 
 func (frame *Stackframe) Var(name string) *Variable {
@@ -149,12 +158,19 @@ func (frame *Stackframe) Var(name string) *Variable {
 // Function represents thread-scoped function information.
 type Function struct {
 	// Name is the function name.
-	Name   string `json:"name"`
+	Name_  string `json:"name"`
 	Value  uint64 `json:"value"`
 	Type   byte   `json:"type"`
 	GoType uint64 `json:"goType"`
 	// Optimized is true if the function was optimized
 	Optimized bool `json:"optimized"`
+}
+
+func (fn *Function) Name() string {
+	if fn == nil {
+		return "???"
+	}
+	return fn.Name_
 }
 
 // VariableFlags is the type of the Flags field of Variable.

--- a/service/client.go
+++ b/service/client.go
@@ -98,7 +98,7 @@ type Client interface {
 	ListGoroutines() ([]*api.Goroutine, error)
 
 	// Returns stacktrace
-	Stacktrace(int, int, *api.LoadConfig) ([]api.Stackframe, error)
+	Stacktrace(goroutineID int, depth int, readDefers bool, cfg *api.LoadConfig) ([]api.Stackframe, error)
 
 	// Returns whether we attached to a running process or not
 	AttachedToExistingProcess() bool

--- a/service/debugger/locations.go
+++ b/service/debugger/locations.go
@@ -316,7 +316,7 @@ func (ale AmbiguousLocationError) Error() string {
 	var candidates []string
 	if ale.CandidatesLocation != nil {
 		for i := range ale.CandidatesLocation {
-			candidates = append(candidates, ale.CandidatesLocation[i].Function.Name)
+			candidates = append(candidates, ale.CandidatesLocation[i].Function.Name())
 		}
 
 	} else {

--- a/service/rpc1/server.go
+++ b/service/rpc1/server.go
@@ -87,7 +87,7 @@ func (s *RPCServer) StacktraceGoroutine(args *StacktraceGoroutineArgs, locations
 	if args.Full {
 		loadcfg = &defaultLoadConfig
 	}
-	locs, err := s.debugger.Stacktrace(args.Id, args.Depth, loadcfg)
+	locs, err := s.debugger.Stacktrace(args.Id, args.Depth, false, loadcfg)
 	if err != nil {
 		return err
 	}

--- a/service/rpc2/client.go
+++ b/service/rpc2/client.go
@@ -295,9 +295,9 @@ func (c *RPCClient) ListGoroutines() ([]*api.Goroutine, error) {
 	return out.Goroutines, err
 }
 
-func (c *RPCClient) Stacktrace(goroutineId, depth int, cfg *api.LoadConfig) ([]api.Stackframe, error) {
+func (c *RPCClient) Stacktrace(goroutineId, depth int, readDefers bool, cfg *api.LoadConfig) ([]api.Stackframe, error) {
 	var out StacktraceOut
-	err := c.call("Stacktrace", StacktraceIn{goroutineId, depth, false, cfg}, &out)
+	err := c.call("Stacktrace", StacktraceIn{goroutineId, depth, false, readDefers, cfg}, &out)
 	return out.Locations, err
 }
 

--- a/service/rpc2/server.go
+++ b/service/rpc2/server.go
@@ -152,10 +152,11 @@ func (s *RPCServer) GetBreakpoint(arg GetBreakpointIn, out *GetBreakpointOut) er
 }
 
 type StacktraceIn struct {
-	Id    int
-	Depth int
-	Full  bool
-	Cfg   *api.LoadConfig
+	Id     int
+	Depth  int
+	Full   bool
+	Defers bool // read deferred functions
+	Cfg    *api.LoadConfig
 }
 
 type StacktraceOut struct {
@@ -171,7 +172,7 @@ func (s *RPCServer) Stacktrace(arg StacktraceIn, out *StacktraceOut) error {
 	if cfg == nil && arg.Full {
 		cfg = &api.LoadConfig{true, 1, 64, 64, -1}
 	}
-	locs, err := s.debugger.Stacktrace(arg.Id, arg.Depth, api.LoadConfigToProc(cfg))
+	locs, err := s.debugger.Stacktrace(arg.Id, arg.Depth, arg.Defers, api.LoadConfigToProc(cfg))
 	if err != nil {
 		return err
 	}

--- a/service/test/integration1_test.go
+++ b/service/test/integration1_test.go
@@ -732,7 +732,7 @@ func Test1ClientServer_FullStacktrace(t *testing.T) {
 				if frame.Function == nil {
 					continue
 				}
-				if frame.Function.Name != "main.agoroutine" {
+				if frame.Function.Name() != "main.agoroutine" {
 					continue
 				}
 				t.Logf("frame %d: %v", i, frame)
@@ -887,7 +887,7 @@ func Test1Disasm(t *testing.T) {
 		// look for static call to afunction() on line 29
 		found := false
 		for i := range d3 {
-			if d3[i].Loc.Line == 29 && strings.HasPrefix(d3[i].Text, "call") && d3[i].DestLoc != nil && d3[i].DestLoc.Function != nil && d3[i].DestLoc.Function.Name == "main.afunction" {
+			if d3[i].Loc.Line == 29 && strings.HasPrefix(d3[i].Text, "call") && d3[i].DestLoc != nil && d3[i].DestLoc.Function != nil && d3[i].DestLoc.Function.Name() == "main.afunction" {
 				found = true
 				break
 			}
@@ -937,7 +937,7 @@ func Test1Disasm(t *testing.T) {
 				if curinstr.DestLoc == nil || curinstr.DestLoc.Function == nil {
 					t.Fatalf("Call instruction does not have destination: %v", curinstr)
 				}
-				if curinstr.DestLoc.Function.Name != "main.afunction" {
+				if curinstr.DestLoc.Function.Name() != "main.afunction" {
 					t.Fatalf("Call instruction destination not main.afunction: %v", curinstr)
 				}
 				break


### PR DESCRIPTION
```
proc,service,terminal: read defer list

Adds -defer flag to the stack command that decorates the stack traces
by associating each stack frame with its deferred calls.

Reworks proc.next to use this feature instead of using proc.DeferPC,
laying the groundwork to implement #1240.

```
