### PR TITLE
proc/native,proc/gdbserial: ignore SIGTTIN, SIGTTOU when fg'ing target

### DIFF
--- a/pkg/proc/gdbserial/gdbserver_unix.go
+++ b/pkg/proc/gdbserial/gdbserver_unix.go
@@ -3,14 +3,14 @@
 package gdbserial
 
 import (
+	"os/signal"
 	"syscall"
-	"unsafe"
 )
 
-func backgroundSysProcAttr() *syscall.SysProcAttr {
-	return &syscall.SysProcAttr{Setpgid: true, Pgid: 0, Foreground: false}
+func sysProcAttr(foreground bool) *syscall.SysProcAttr {
+	return &syscall.SysProcAttr{Setpgid: true, Pgid: 0, Foreground: foreground}
 }
 
-func moveToForeground(pid int) {
-	syscall.Syscall(syscall.SYS_IOCTL, uintptr(0), uintptr(syscall.TIOCSPGRP), uintptr(unsafe.Pointer(&pid)))
+func foregroundSignalsIgnore() {
+	signal.Ignore(syscall.SIGTTOU, syscall.SIGTTIN)
 }

--- a/pkg/proc/gdbserial/gdbserver_windows.go
+++ b/pkg/proc/gdbserial/gdbserver_windows.go
@@ -2,10 +2,9 @@ package gdbserial
 
 import "syscall"
 
-func backgroundSysProcAttr() *syscall.SysProcAttr {
+func sysProcAttr(foreground bool) *syscall.SysProcAttr {
 	return nil
 }
 
-func moveToForeground(pid int) {
-	panic("lldb backend not supported on windows")
+func foregroundSignalsIgnore() {
 }

--- a/pkg/proc/gdbserial/rr.go
+++ b/pkg/proc/gdbserial/rr.go
@@ -64,7 +64,7 @@ func Replay(tracedir string, quiet bool) (*Process, error) {
 	if err != nil {
 		return nil, err
 	}
-	rrcmd.SysProcAttr = backgroundSysProcAttr()
+	rrcmd.SysProcAttr = sysProcAttr(false)
 
 	initch := make(chan rrInit)
 	go rrStderrParser(stderr, initch, quiet)


### PR DESCRIPTION
```
proc/native,proc/gdbserial: ignore SIGTTIN, SIGTTOU when fg'ing target

If we send a process to foreground while the headless instance may get
a SIGTTOU/SIGTTIN, if not ignored this signal will stop the headless.
It's not clear why this only happens the second time we do this but
that's how it is.

Also removes the direct syscall to TIOCSPGRP and lets the go runtime do
it instead.

Fixes #1279

```
