### PR TITLE
terminal: refactor edit/list to share getLocation code

### DIFF
--- a/Documentation/cli/README.md
+++ b/Documentation/cli/README.md
@@ -183,6 +183,10 @@ Move the current frame down by <m>. The second form runs the command on the give
 ## edit
 Open where you are in $DELVE_EDITOR or $EDITOR
 
+	edit [locspec]
+	
+If locspec is omitted edit will open the current source file in the editor, otherwise it will open the specified location.
+
 Aliases: ed
 
 ## exit


### PR DESCRIPTION
```
terminal: refactor edit/list to share getLocation code

Refactors edit and list so that they use the same code to get the
current location and also both accept a locspec as an argument.

```
