### PR TITLE
Use setValue in CallFunction

### DIFF
--- a/_fixtures/fncall.go
+++ b/_fixtures/fncall.go
@@ -3,6 +3,7 @@ package main
 import (
 	"fmt"
 	"runtime"
+	"strings"
 )
 
 func callstacktrace() (stacktrace string) {
@@ -27,11 +28,21 @@ func callpanic() {
 	panic("callpanic panicked")
 }
 
+func stringsJoin(v []string, sep string) string {
+	// This is needed because strings.Join is in an optimized package and
+	// because of a bug in the compiler arguments of optimized functions don't
+	// have a location.
+	return strings.Join(v, sep)
+}
+
 var zero = 0
 
 func main() {
 	one, two := 1, 2
+	intslice := []int{1, 2, 3}
+	stringslice := []string{"one", "two", "three"}
+	comma := ","
 	runtime.Breakpoint()
 	call1(one, two)
-	fmt.Println(one, two, zero, callpanic, callstacktrace)
+	fmt.Println(one, two, zero, callpanic, callstacktrace, stringsJoin, intslice, stringslice, comma)
 }

--- a/_fixtures/testvariables2.go
+++ b/_fixtures/testvariables2.go
@@ -246,6 +246,8 @@ func main() {
 
 	var nilstruct *astruct = nil
 
+	s4 := []int{1, 2, 3, 4, 5, 6, 7, 8, 9, 0}
+
 	var amb1 = 1
 	runtime.Breakpoint()
 	for amb1 := 0; amb1 < 10; amb1++ {
@@ -253,5 +255,5 @@ func main() {
 	}
 
 	runtime.Breakpoint()
-	fmt.Println(i1, i2, i3, p1, amb1, s1, s3, a1, p2, p3, s2, as1, str1, f1, fn1, fn2, nilslice, nilptr, ch1, chnil, m1, mnil, m2, m3, up1, i4, i5, i6, err1, err2, errnil, iface1, iface2, ifacenil, arr1, parr, cpx1, const1, iface3, iface4, recursive1, recursive1.x, iface5, iface2fn1, iface2fn2, bencharr, benchparr, mapinf, mainMenu, b, b2, sd, anonstruct1, anonstruct2, anoniface1, anonfunc, mapanonstruct1, ifacearr, efacearr, ni8, ni16, ni32, pinf, ninf, nan, zsvmap, zsslice, zsvar, tm, errtypednil, emptyslice, emptymap, byteslice, runeslice, longstr, nilstruct)
+	fmt.Println(i1, i2, i3, p1, amb1, s1, s3, a1, p2, p3, s2, as1, str1, f1, fn1, fn2, nilslice, nilptr, ch1, chnil, m1, mnil, m2, m3, up1, i4, i5, i6, err1, err2, errnil, iface1, iface2, ifacenil, arr1, parr, cpx1, const1, iface3, iface4, recursive1, recursive1.x, iface5, iface2fn1, iface2fn2, bencharr, benchparr, mapinf, mainMenu, b, b2, sd, anonstruct1, anonstruct2, anoniface1, anonfunc, mapanonstruct1, ifacearr, efacearr, ni8, ni16, ni32, pinf, ninf, nan, zsvmap, zsslice, zsvar, tm, errtypednil, emptyslice, emptymap, byteslice, runeslice, longstr, nilstruct, s4)
 }

--- a/pkg/dwarf/godwarf/type.go
+++ b/pkg/dwarf/godwarf/type.go
@@ -849,6 +849,9 @@ func readType(d *dwarf.Data, name string, r *dwarf.Reader, off dwarf.Offset, typ
 				b = t.Type.Size()
 			case *PtrType:
 				b = int64(addressSize)
+			case *FuncType:
+				// on Go < 1.10 function types do not have a DW_AT_byte_size attribute.
+				b = int64(addressSize)
 			}
 		}
 		typ.Common().ByteSize = b

--- a/pkg/proc/eval.go
+++ b/pkg/proc/eval.go
@@ -1160,10 +1160,18 @@ func (v *Variable) asUint() (uint64, error) {
 	return n, nil
 }
 
+type typeConvErr struct {
+	srcType, dstType godwarf.Type
+}
+
+func (err *typeConvErr) Error() string {
+	return fmt.Sprintf("can not convert value of type %s to %s", err.srcType.String(), err.dstType.String())
+}
+
 func (v *Variable) isType(typ godwarf.Type, kind reflect.Kind) error {
 	if v.DwarfType != nil {
 		if typ != nil && typ.String() != v.RealType.String() {
-			return fmt.Errorf("can not convert value of type %s to %s", v.DwarfType.String(), typ.String())
+			return &typeConvErr{v.DwarfType, typ}
 		}
 		return nil
 	}

--- a/pkg/proc/mem.go
+++ b/pkg/proc/mem.go
@@ -136,3 +136,18 @@ func DereferenceMemory(mem MemoryReadWriter) MemoryReadWriter {
 	}
 	return mem
 }
+
+// bufferMemoryReadWriter is dummy a MemoryReadWriter backed by a []byte.
+type bufferMemoryReadWriter struct {
+	buf []byte
+}
+
+func (mem *bufferMemoryReadWriter) ReadMemory(buf []byte, addr uintptr) (n int, err error) {
+	copy(buf, mem.buf[addr-fakeAddress:][:len(buf)])
+	return len(buf), nil
+}
+
+func (mem *bufferMemoryReadWriter) WriteMemory(addr uintptr, data []byte) (written int, err error) {
+	copy(mem.buf[addr-fakeAddress:], data)
+	return len(data), nil
+}

--- a/pkg/proc/test/support.go
+++ b/pkg/proc/test/support.go
@@ -243,3 +243,14 @@ func SafeRemoveAll(dir string) {
 	}
 	os.Remove(dir)
 }
+
+// MustSupportFunctionCalls skips this test if function calls are
+// unsupported on this backend/architecture pair.
+func MustSupportFunctionCalls(t *testing.T, testBackend string) {
+	if !goversion.VersionAfterOrEqual(runtime.Version(), 1, 11) {
+		t.Skip("this version of Go does not support function calls")
+	}
+	if runtime.GOOS != "linux" || testBackend != "native" {
+		t.Skip("this backend does not support function calls")
+	}
+}

--- a/pkg/proc/variables.go
+++ b/pkg/proc/variables.go
@@ -1066,7 +1066,7 @@ func (dstv *Variable) setValue(srcv *Variable, srcExpr string) error {
 
 // convertToEface converts srcv into an "interface {}" and writes it to
 // dstv.
-// Dstv must be a variable of type "inteface {}" and srcv must either by an
+// Dstv must be a variable of type "inteface {}" and srcv must either be an
 // interface or a pointer shaped variable (map, channel, pointer or struct
 // containing a single pointer)
 func convertToEface(srcv, dstv *Variable) error {

--- a/service/test/integration2_test.go
+++ b/service/test/integration2_test.go
@@ -1508,9 +1508,7 @@ func mustHaveDebugCalls(t *testing.T, c service.Client) {
 }
 
 func TestClientServerFunctionCall(t *testing.T) {
-	if runtime.GOOS != "linux" || testBackend != "native" {
-		t.Skip("unsupported")
-	}
+	protest.MustSupportFunctionCalls(t, testBackend)
 	withTestClient2("fncall", t, func(c service.Client) {
 		mustHaveDebugCalls(t, c)
 		c.SetReturnValuesLoadConfig(&normalLoadConfig)
@@ -1541,9 +1539,7 @@ func TestClientServerFunctionCall(t *testing.T) {
 }
 
 func TestClientServerFunctionCallBadPos(t *testing.T) {
-	if runtime.GOOS != "linux" || testBackend != "native" {
-		t.Skip("unsupported")
-	}
+	protest.MustSupportFunctionCalls(t, testBackend)
 	withTestClient2("fncall", t, func(c service.Client) {
 		mustHaveDebugCalls(t, c)
 		loc, err := c.FindLocation(api.EvalScope{-1, 0}, "fmt/print.go:649")
@@ -1566,9 +1562,7 @@ func TestClientServerFunctionCallBadPos(t *testing.T) {
 }
 
 func TestClientServerFunctionCallPanic(t *testing.T) {
-	if runtime.GOOS != "linux" || testBackend != "native" {
-		t.Skip("unsupported")
-	}
+	protest.MustSupportFunctionCalls(t, testBackend)
 	withTestClient2("fncall", t, func(c service.Client) {
 		mustHaveDebugCalls(t, c)
 		c.SetReturnValuesLoadConfig(&normalLoadConfig)
@@ -1594,9 +1588,7 @@ func TestClientServerFunctionCallPanic(t *testing.T) {
 }
 
 func TestClientServerFunctionCallStacktrace(t *testing.T) {
-	if runtime.GOOS != "linux" || testBackend != "native" {
-		t.Skip("unsupported")
-	}
+	protest.MustSupportFunctionCalls(t, testBackend)
 	withTestClient2("fncall", t, func(c service.Client) {
 		mustHaveDebugCalls(t, c)
 		c.SetReturnValuesLoadConfig(&api.LoadConfig{false, 0, 2048, 0, 0})

--- a/service/test/variables_test.go
+++ b/service/test/variables_test.go
@@ -1,6 +1,7 @@
 package service_test
 
 import (
+	"errors"
 	"fmt"
 	"runtime"
 	"sort"
@@ -1056,6 +1057,73 @@ func TestIssue1075(t *testing.T) {
 			assertNoError(err, t, fmt.Sprintf("LocalVariables (%d)", i))
 			for _, v := range vars {
 				api.ConvertVar(v).SinglelineString()
+			}
+		}
+	})
+}
+
+func TestCallFunction(t *testing.T) {
+	protest.MustSupportFunctionCalls(t, testBackend)
+
+	var testcases = []struct {
+		expr string   // call expression to evaluate
+		outs []string // list of return parameters in this format: <param name>:<param type>:<param value>
+		err  error    // if not nil should return an error
+	}{
+		{"call1(one, two)", []string{":int:3"}, nil},
+		{"call1(one+two, 4)", []string{":int:7"}, nil},
+		{"callpanic()", []string{`~panic:interface {}:interface {}(string) "callpanic panicked"`}, nil},
+		{`stringsJoin(nil, "")`, []string{`:string:""`}, nil},
+		{`stringsJoin(stringslice, ",")`, nil, errors.New("can not set variables of type string (not implemented)")},
+		{`stringsJoin(stringslice, comma)`, []string{`:string:"one,two,three"`}, nil},
+		{`stringsJoin(s1, comma)`, nil, errors.New("could not find symbol value for s1")},
+		{`stringsJoin(intslice, comma)`, nil, errors.New("can not convert value of type []int to []string")},
+	}
+
+	withTestProcess("fncall", t, func(p proc.Process, fixture protest.Fixture) {
+		_, err := proc.FindFunctionLocation(p, "runtime.debugCallV1", true, 0)
+		if err != nil {
+			t.Skip("function calls not supported on this version of go")
+		}
+		assertNoError(proc.Continue(p), t, "Continue()")
+		for _, tc := range testcases {
+			err := proc.CallFunction(p, tc.expr, &pnormalLoadConfig)
+			if tc.err != nil {
+				if err == nil {
+					t.Fatalf("call %q: expected error %q, got no error", tc.expr, tc.err.Error())
+				}
+				if tc.err.Error() != err.Error() {
+					t.Fatalf("call %q: expected error %q, got %q", tc.expr, tc.err.Error(), err.Error())
+				}
+				continue
+			}
+
+			if err != nil {
+				t.Fatalf("call %q: error %q", tc.expr, err.Error())
+			}
+
+			retvals := p.CurrentThread().Common().ReturnValues(pnormalLoadConfig)
+
+			if len(retvals) != len(tc.outs) {
+				t.Fatalf("call %q: wrong number of return parameters", tc.expr)
+			}
+
+			for i := range retvals {
+				outfields := strings.SplitN(tc.outs[i], ":", 3)
+				tgtName, tgtType, tgtValue := outfields[0], outfields[1], outfields[2]
+
+				if tgtName != "" && tgtName != retvals[i].Name {
+					t.Fatalf("call %q output parameter %d: expected name %q, got %q", tc.expr, i, tgtName, retvals[i].Name)
+				}
+
+				cv := api.ConvertVar(retvals[i])
+
+				if cv.Type != tgtType {
+					t.Fatalf("call %q, output parameter %d: expected type %q, got %q", tc.expr, i, tgtType, cv.Type)
+				}
+				if cvs := cv.SinglelineString(); cvs != tgtValue {
+					t.Fatalf("call %q, output parameter %d: expected value %q, got %q", tc.expr, i, tgtValue, cvs)
+				}
 			}
 		}
 	})


### PR DESCRIPTION
```
proc: use (*Variable).setValue in fncall

proc: change (*Variable).setValue for use in CallFunction

Changes (*Variable).setValue so that it can be used in CallFunction to
set up the argument frame for the function call, adding the ability to:
- nil nillable types
- set strings to the empty string
- copy from one structure to another (including strings and slices)
- convert any interface type to interface{}
- convert pointer shaped types (map, chan, pointers, and structs
consisting of a single pointer field) to interface{}

This covers all cases where an assignment statement can be evaluated
without allocating memory or calling functions in the target process.

```
