### PR TITLE
Documentation update for install version

### DIFF
--- a/Documentation/installation/README.md
+++ b/Documentation/installation/README.md
@@ -1,6 +1,8 @@
 # Installation
 
-Directions for installing Delve on all supported platforms is provided here. Please note you *must* have Go 1.7 or higher installed.
+Directions for installing Delve on all supported platforms is provided here.
+
+Please note you *must* have **Go 1.8** or higher installed in order to compile Delve.
 
 - [OSX](osx/install.md)
 - [Linux](linux/install.md)


### PR DESCRIPTION
This updates the documentation for the Go version needed to compile Delve.

Fixes #1291