### PR TITLE
Support calls of methods and function variables

### DIFF
--- a/Documentation/cli/README.md
+++ b/Documentation/cli/README.md
@@ -74,12 +74,8 @@ Aliases: bp
 Resumes process, injecting a function call (EXPERIMENTAL!!!)
 	
 Current limitations:
-- can only call package-level functions, no function pointers nor methods.
-- only things that have an address can be used as arguments (no literal
-  constants or results of evaluating some expressions).
 - only pointers to stack-allocated objects can be passed as argument.
-- no automatic type conversions are supported, including automatically
-  converting to an interface type.
+- only some automatic type conversions are supported.
 - functions can only be called on running goroutines that are not
   executing the runtime.
 - the current goroutine needs to have at least 256 bytes of free space on

--- a/_fixtures/fncall.go
+++ b/_fixtures/fncall.go
@@ -57,6 +57,14 @@ type VRcvrable interface {
 
 var zero = 0
 
+func makeclos(pa *astruct) func(int) string {
+	i := 0
+	return func(x int) string {
+		i++
+		return fmt.Sprintf("%d + %d + %d = %d", i, pa.X, x, i+pa.X+x)
+	}
+}
+
 func main() {
 	one, two := 1, 2
 	intslice := []int{1, 2, 3}
@@ -69,7 +77,14 @@ func main() {
 	var vable_pa VRcvrable = pa
 	var pable_pa PRcvrable = pa
 
+	fn2clos := makeclos(pa)
+	fn2glob := call1
+	fn2valmeth := pa.VRcvr
+	fn2ptrmeth := pa.PRcvr
+	var fn2nil func()
+
 	runtime.Breakpoint()
 	call1(one, two)
-	fmt.Println(one, two, zero, callpanic, callstacktrace, stringsJoin, intslice, stringslice, comma, a.VRcvr, a.PRcvr, pa, vable_a, vable_pa, pable_pa)
+	fn2clos(2)
+	fmt.Println(one, two, zero, callpanic, callstacktrace, stringsJoin, intslice, stringslice, comma, a.VRcvr, a.PRcvr, pa, vable_a, vable_pa, pable_pa, fn2clos, fn2glob, fn2valmeth, fn2ptrmeth, fn2nil)
 }

--- a/_fixtures/fncall.go
+++ b/_fixtures/fncall.go
@@ -35,6 +35,26 @@ func stringsJoin(v []string, sep string) string {
 	return strings.Join(v, sep)
 }
 
+type astruct struct {
+	X int
+}
+
+func (a astruct) VRcvr(x int) string {
+	return fmt.Sprintf("%d + %d = %d", x, a.X, x+a.X)
+}
+
+func (pa *astruct) PRcvr(x int) string {
+	return fmt.Sprintf("%d - %d = %d", x, pa.X, x-pa.X)
+}
+
+type PRcvrable interface {
+	PRcvr(int) string
+}
+
+type VRcvrable interface {
+	VRcvr(int) string
+}
+
 var zero = 0
 
 func main() {
@@ -42,7 +62,14 @@ func main() {
 	intslice := []int{1, 2, 3}
 	stringslice := []string{"one", "two", "three"}
 	comma := ","
+	a := astruct{X: 3}
+	pa := &astruct{X: 6}
+
+	var vable_a VRcvrable = a
+	var vable_pa VRcvrable = pa
+	var pable_pa PRcvrable = pa
+
 	runtime.Breakpoint()
 	call1(one, two)
-	fmt.Println(one, two, zero, callpanic, callstacktrace, stringsJoin, intslice, stringslice, comma)
+	fmt.Println(one, two, zero, callpanic, callstacktrace, stringsJoin, intslice, stringslice, comma, a.VRcvr, a.PRcvr, pa, vable_a, vable_pa, pable_pa)
 }

--- a/_fixtures/testvariables2.go
+++ b/_fixtures/testvariables2.go
@@ -62,6 +62,10 @@ func (a *astruct) Error() string {
 	return "not an error"
 }
 
+func (a astruct) NonPointerRecieverMethod() {
+	return
+}
+
 func (b *bstruct) Error() string {
 	return "not an error"
 }
@@ -246,6 +250,8 @@ func main() {
 
 	var nilstruct *astruct = nil
 
+	var as2 astruct
+
 	s4 := []int{1, 2, 3, 4, 5, 6, 7, 8, 9, 0}
 
 	var amb1 = 1
@@ -255,5 +261,5 @@ func main() {
 	}
 
 	runtime.Breakpoint()
-	fmt.Println(i1, i2, i3, p1, amb1, s1, s3, a1, p2, p3, s2, as1, str1, f1, fn1, fn2, nilslice, nilptr, ch1, chnil, m1, mnil, m2, m3, up1, i4, i5, i6, err1, err2, errnil, iface1, iface2, ifacenil, arr1, parr, cpx1, const1, iface3, iface4, recursive1, recursive1.x, iface5, iface2fn1, iface2fn2, bencharr, benchparr, mapinf, mainMenu, b, b2, sd, anonstruct1, anonstruct2, anoniface1, anonfunc, mapanonstruct1, ifacearr, efacearr, ni8, ni16, ni32, pinf, ninf, nan, zsvmap, zsslice, zsvar, tm, errtypednil, emptyslice, emptymap, byteslice, runeslice, longstr, nilstruct, s4)
+	fmt.Println(i1, i2, i3, p1, amb1, s1, s3, a1, p2, p3, s2, as1, str1, f1, fn1, fn2, nilslice, nilptr, ch1, chnil, m1, mnil, m2, m3, up1, i4, i5, i6, err1, err2, errnil, iface1, iface2, ifacenil, arr1, parr, cpx1, const1, iface3, iface4, recursive1, recursive1.x, iface5, iface2fn1, iface2fn2, bencharr, benchparr, mapinf, mainMenu, b, b2, sd, anonstruct1, anonstruct2, anoniface1, anonfunc, mapanonstruct1, ifacearr, efacearr, ni8, ni16, ni32, pinf, ninf, nan, zsvmap, zsslice, zsvar, tm, errtypednil, emptyslice, emptymap, byteslice, runeslice, longstr, nilstruct, as2, as2.NonPointerRecieverMethod, s4)
 }

--- a/pkg/proc/core/core.go
+++ b/pkg/proc/core/core.go
@@ -275,6 +275,10 @@ func (t *Thread) SetSP(uint64) error {
 	return errors.New("not supported")
 }
 
+func (t *Thread) SetDX(uint64) error {
+	return errors.New("not supported")
+}
+
 func (p *Process) Breakpoints() *proc.BreakpointMap {
 	return &p.breakpoints
 }

--- a/pkg/proc/fncall.go
+++ b/pkg/proc/fncall.go
@@ -207,7 +207,6 @@ func funcCallEvalExpr(p Process, expr string) (fn *Function, argvars []*Variable
 		return nil, nil, ErrNotACallExpr
 	}
 
-	//TODO(aarzilli): must evaluate <var>.<method> and treat them appropriately
 	fnvar, err := scope.evalAST(callexpr.Fun)
 	if err != nil {
 		return nil, nil, err
@@ -223,13 +222,18 @@ func funcCallEvalExpr(p Process, expr string) (fn *Function, argvars []*Variable
 		return nil, nil, ErrNotAGoFunction
 	}
 
-	argvars = make([]*Variable, len(callexpr.Args))
+	argvars = make([]*Variable, 0, len(callexpr.Args)+1)
+	if len(fnvar.Children) > 0 {
+		// receiver argument
+		argvars = append(argvars, &fnvar.Children[0])
+	}
 	for i := range callexpr.Args {
-		argvars[i], err = scope.evalAST(callexpr.Args[i])
+		argvar, err := scope.evalAST(callexpr.Args[i])
 		if err != nil {
 			return nil, nil, err
 		}
-		argvars[i].Name = exprToString(callexpr.Args[i])
+		argvar.Name = exprToString(callexpr.Args[i])
+		argvars = append(argvars, argvar)
 	}
 
 	return fn, argvars, nil

--- a/pkg/proc/gdbserial/gdbserver.go
+++ b/pkg/proc/gdbserial/gdbserver.go
@@ -1533,6 +1533,10 @@ func (regs *gdbRegisters) setSP(value uint64) {
 	binary.LittleEndian.PutUint64(regs.regs[regnameSP].value, value)
 }
 
+func (regs *gdbRegisters) setDX(value uint64) {
+	binary.LittleEndian.PutUint64(regs.regs[regnameDX].value, value)
+}
+
 func (regs *gdbRegisters) BP() uint64 {
 	return binary.LittleEndian.Uint64(regs.regs[regnameBP].value)
 }
@@ -1733,6 +1737,15 @@ func (t *Thread) SetSP(sp uint64) error {
 		return t.p.conn.writeRegisters(t.strID, t.regs.buf)
 	}
 	reg := t.regs.regs[regnameSP]
+	return t.p.conn.writeRegister(t.strID, reg.regnum, reg.value)
+}
+
+func (t *Thread) SetDX(dx uint64) error {
+	t.regs.setDX(dx)
+	if t.p.gcmdok {
+		return t.p.conn.writeRegisters(t.strID, t.regs.buf)
+	}
+	reg := t.regs.regs[regnameDX]
 	return t.p.conn.writeRegister(t.strID, reg.regnum, reg.value)
 }
 

--- a/pkg/proc/gdbserial/gdbserver_conn.go
+++ b/pkg/proc/gdbserial/gdbserver_conn.go
@@ -52,6 +52,7 @@ const (
 	regnamePC     = "rip"
 	regnameCX     = "rcx"
 	regnameSP     = "rsp"
+	regnameDX     = "rdx"
 	regnameBP     = "rbp"
 	regnameFsBase = "fs_base"
 	regnameGsBase = "gs_base"

--- a/pkg/proc/native/registers_darwin_amd64.go
+++ b/pkg/proc/native/registers_darwin_amd64.go
@@ -126,6 +126,10 @@ func (thread *Thread) SetSP(sp uint64) error {
 	return errors.New("not implemented")
 }
 
+func (thread *Thread) SetDX(dx uint64) error {
+	return errors.New("not implemented")
+}
+
 func (r *Regs) Get(n int) (uint64, error) {
 	reg := x86asm.Reg(n)
 	const (

--- a/pkg/proc/native/registers_linux_amd64.go
+++ b/pkg/proc/native/registers_linux_amd64.go
@@ -115,6 +115,18 @@ func (thread *Thread) SetSP(sp uint64) (err error) {
 	return
 }
 
+func (thread *Thread) SetDX(dx uint64) (err error) {
+	var ir proc.Registers
+	ir, err = registers(thread, false)
+	if err != nil {
+		return err
+	}
+	r := ir.(*Regs)
+	r.regs.Rdx = dx
+	thread.dbp.execPtraceFunc(func() { err = sys.PtraceSetRegs(thread.ID, r.regs) })
+	return
+}
+
 func (r *Regs) Get(n int) (uint64, error) {
 	reg := x86asm.Reg(n)
 	const (

--- a/pkg/proc/native/registers_windows_amd64.go
+++ b/pkg/proc/native/registers_windows_amd64.go
@@ -160,6 +160,20 @@ func (thread *Thread) SetSP(sp uint64) error {
 	return _SetThreadContext(thread.os.hThread, context)
 }
 
+func (thread *Thread) SetDX(dx uint64) error {
+	context := newCONTEXT()
+	context.ContextFlags = _CONTEXT_ALL
+
+	err := _GetThreadContext(thread.os.hThread, context)
+	if err != nil {
+		return err
+	}
+
+	context.Rdx = dx
+
+	return _SetThreadContext(thread.os.hThread, context)
+}
+
 func (r *Regs) Get(n int) (uint64, error) {
 	reg := x86asm.Reg(n)
 	const (

--- a/pkg/proc/threads.go
+++ b/pkg/proc/threads.go
@@ -37,6 +37,7 @@ type Thread interface {
 
 	SetPC(uint64) error
 	SetSP(uint64) error
+	SetDX(uint64) error
 }
 
 // Location represents the location of a thread.

--- a/pkg/proc/variables.go
+++ b/pkg/proc/variables.go
@@ -733,6 +733,7 @@ func (v *Variable) structMember(memberName string) (*Variable, error) {
 	if v.Unreadable != nil {
 		return v.clone(), nil
 	}
+	vname := v.Name
 	switch v.Kind {
 	case reflect.Chan:
 		v = v.clone()
@@ -789,12 +790,12 @@ func (v *Variable) structMember(memberName string) (*Variable, error) {
 				return embeddedField, nil
 			}
 		}
-		return nil, fmt.Errorf("%s has no member %s", v.Name, memberName)
+		return nil, fmt.Errorf("%s has no member %s", vname, memberName)
 	default:
 		if v.Name == "" {
 			return nil, fmt.Errorf("type %s is not a struct", structVar.TypeString())
 		}
-		return nil, fmt.Errorf("%s (type %s) is not a struct", v.Name, structVar.TypeString())
+		return nil, fmt.Errorf("%s (type %s) is not a struct", vname, structVar.TypeString())
 	}
 }
 

--- a/pkg/terminal/command.go
+++ b/pkg/terminal/command.go
@@ -132,12 +132,8 @@ See also: "help on", "help cond" and "help clear"`},
 		{aliases: []string{"call"}, cmdFn: c.call, helpMsg: `Resumes process, injecting a function call (EXPERIMENTAL!!!)
 	
 Current limitations:
-- can only call package-level functions, no function pointers nor methods.
-- only things that have an address can be used as arguments (no literal
-  constants or results of evaluating some expressions).
 - only pointers to stack-allocated objects can be passed as argument.
-- no automatic type conversions are supported, including automatically
-  converting to an interface type.
+- only some automatic type conversions are supported.
 - functions can only be called on running goroutines that are not
   executing the runtime.
 - the current goroutine needs to have at least 256 bytes of free space on
@@ -1154,10 +1150,10 @@ func getLocation(t *Term, ctx callContext) (*api.Location, error) {
 			return &state.SelectedGoroutine.CurrentLoc, nil
 		} else {
 			thread := state.CurrentThread
-			loc := api.Location {
-				PC: thread.PC,
-				File: thread.File,
-				Line: thread.Line,
+			loc := api.Location{
+				PC:       thread.PC,
+				File:     thread.File,
+				Line:     thread.Line,
 				Function: thread.Function,
 			}
 			return &loc, nil
@@ -1167,7 +1163,9 @@ func getLocation(t *Term, ctx callContext) (*api.Location, error) {
 
 func edit(t *Term, ctx callContext, args string) error {
 	loc, err := getLocation(t, ctx)
-	if err != nil { return err }
+	if err != nil {
+		return err
+	}
 
 	var editor string
 	if editor = os.Getenv("DELVE_EDITOR"); editor == "" {

--- a/service/test/variables_test.go
+++ b/service/test/variables_test.go
@@ -791,6 +791,11 @@ func TestEvalExpression(t *testing.T) {
 
 		{"afunc", true, `main.afunc`, `main.afunc`, `func()`, nil},
 		{"main.afunc2", true, `main.afunc2`, `main.afunc2`, `func()`, nil},
+
+		{"s2[0].Error", false, "main.(*astruct).Error", "main.(*astruct).Error", "func() string", nil},
+		{"s2[0].NonPointerRecieverMethod", false, "main.astruct.NonPointerRecieverMethod", "main.astruct.NonPointerRecieverMethod", "func()", nil},
+		{"as2.Error", false, "main.(*astruct).Error", "main.(*astruct).Error", "func() string", nil},
+		{"as2.NonPointerRecieverMethod", false, "main.astruct.NonPointerRecieverMethod", "main.astruct.NonPointerRecieverMethod", "func()", nil},
 	}
 
 	ver, _ := goversion.Parse(runtime.Version())
@@ -808,6 +813,10 @@ func TestEvalExpression(t *testing.T) {
 		assertNoError(proc.Continue(p), t, "Continue() returned an error")
 		for _, tc := range testcases {
 			variable, err := evalVariable(p, tc.name, pnormalLoadConfig)
+			if err != nil && err.Error() == "evaluating methods not supported on this version of Go" {
+				// this type of eval is unsupported with the current version of Go.
+				continue
+			}
 			if tc.err == nil {
 				assertNoError(err, t, fmt.Sprintf("EvalExpression(%s) returned an error", tc.name))
 				assertVariable(t, variable, tc)

--- a/service/test/variables_test.go
+++ b/service/test/variables_test.go
@@ -1087,6 +1087,28 @@ func TestCallFunction(t *testing.T) {
 		{`stringsJoin(stringslice, comma)`, []string{`:string:"one,two,three"`}, nil},
 		{`stringsJoin(s1, comma)`, nil, errors.New("could not find symbol value for s1")},
 		{`stringsJoin(intslice, comma)`, nil, errors.New("can not convert value of type []int to []string")},
+
+		// The following set of calls was constructed using https://docs.google.com/document/d/1bMwCey-gmqZVTpRax-ESeVuZGmjwbocYs1iHplK-cjo/pub as a reference
+
+		{`a.VRcvr(1)`, []string{`:string:"1 + 3 = 4"`}, nil},   // direct call of a method with value receiver / on a value
+		{`a.PRcvr(2)`, []string{`:string:"2 - 3 = -1"`}, nil},  // direct call of a method with pointer receiver / on a value
+		{`pa.VRcvr(3)`, []string{`:string:"3 + 6 = 9"`}, nil},  // direct call of a method with value receiver / on a pointer
+		{`pa.PRcvr(4)`, []string{`:string:"4 - 6 = -2"`}, nil}, // direct call of a method with pointer receiver / on a pointer
+
+		{`vable_pa.VRcvr(6)`, []string{`:string:"6 + 6 = 12"`}, nil}, // indirect call of method on interface / containing value with value method
+		{`pable_pa.PRcvr(7)`, []string{`:string:"7 - 6 = 1"`}, nil},  // indirect call of method on interface / containing pointer with value method
+		{`vable_a.VRcvr(5)`, []string{`:string:"5 + 3 = 8"`}, nil},   // indirect call of method on interface / containing pointer with pointer method
+
+		{`pa.nonexistent()`, nil, errors.New("pa has no member nonexistent")},
+		{`a.nonexistent()`, nil, errors.New("a has no member nonexistent")},
+		{`vable_pa.nonexistent()`, nil, errors.New("vable_pa has no member nonexistent")},
+		{`vable_a.nonexistent()`, nil, errors.New("vable_a has no member nonexistent")},
+		{`pable_pa.nonexistent()`, nil, errors.New("pable_pa has no member nonexistent")},
+
+		//TODO(aarzilli): indirect call of func value / set to top-level func
+		//TODO(aarzilli): indirect call of func value / set to func literal
+		//TODO(aarzilli): indirect call of func value / set to value method
+		//TODO(aarzilli): indirect call of func value / set to pointer method
 	}
 
 	withTestProcess("fncall", t, func(p proc.Process, fixture protest.Fixture) {


### PR DESCRIPTION
```
terminal: updated call description

Updated call description to reflect current limitations.

proc: support calls through function pointers

proc: support calls to methods directly and through interface

proc: evaluate var.method expressions

Evaluates var.method expressions into a variable holding the
corresponding method with the receiver variable as a child, in
preparation for extending CallFunction so that it can call methods.

```
