### PR TITLE
proc: fix type of some struct global variables

### DIFF
--- a/_fixtures/fncall.go
+++ b/_fixtures/fncall.go
@@ -65,6 +65,8 @@ func makeclos(pa *astruct) func(int) string {
 	}
 }
 
+var ga astruct
+
 func main() {
 	one, two := 1, 2
 	intslice := []int{1, 2, 3}
@@ -86,5 +88,5 @@ func main() {
 	runtime.Breakpoint()
 	call1(one, two)
 	fn2clos(2)
-	fmt.Println(one, two, zero, callpanic, callstacktrace, stringsJoin, intslice, stringslice, comma, a.VRcvr, a.PRcvr, pa, vable_a, vable_pa, pable_pa, fn2clos, fn2glob, fn2valmeth, fn2ptrmeth, fn2nil)
+	fmt.Println(one, two, zero, callpanic, callstacktrace, stringsJoin, intslice, stringslice, comma, a.VRcvr, a.PRcvr, pa, vable_a, vable_pa, pable_pa, fn2clos, fn2glob, fn2valmeth, fn2ptrmeth, fn2nil, ga)
 }

--- a/pkg/proc/bininfo.go
+++ b/pkg/proc/bininfo.go
@@ -88,6 +88,8 @@ type compileUnit struct {
 	concreteInlinedFns []inlinedFn         // list of concrete inlined functions within this compile unit
 	optimized          bool                // this compile unit is optimized
 	producer           string              // producer attribute
+
+	startOffset, endOffset dwarf.Offset // interval of offsets contained in this compile unit
 }
 
 type partialUnitConstant struct {
@@ -489,6 +491,15 @@ func (bi *BinaryInfo) loclistEntry(off int64, pc uint64) []byte {
 func (bi *BinaryInfo) findCompileUnit(pc uint64) *compileUnit {
 	for _, cu := range bi.compileUnits {
 		if pc >= cu.LowPC && pc < cu.HighPC {
+			return cu
+		}
+	}
+	return nil
+}
+
+func (bi *BinaryInfo) findCompileUnitForOffset(off dwarf.Offset) *compileUnit {
+	for _, cu := range bi.compileUnits {
+		if off >= cu.startOffset && off < cu.endOffset {
 			return cu
 		}
 	}

--- a/pkg/proc/eval.go
+++ b/pkg/proc/eval.go
@@ -1266,7 +1266,7 @@ func (v *Variable) mapAccess(idx *Variable) (*Variable, error) {
 		}
 		if first {
 			first = false
-			if err := idx.isType(key.DwarfType, key.Kind); err != nil {
+			if err := idx.isType(key.RealType, key.Kind); err != nil {
 				return nil, err
 			}
 		}

--- a/service/test/variables_test.go
+++ b/service/test/variables_test.go
@@ -1112,6 +1112,8 @@ func TestCallFunction(t *testing.T) {
 		{`fn2ptrmeth(14)`, []string{`:string:"14 - 6 = 8"`}, nil},  // indirect call of func value / set to pointer method
 
 		{"fn2nil()", nil, errors.New("nil pointer dereference")},
+
+		{"ga.PRcvr(2)", []string{`:string:"2 - 0 = 2"`}, nil},
 	}
 
 	withTestProcess("fncall", t, func(p proc.Process, fixture protest.Fixture) {


### PR DESCRIPTION
```
proc: fix type of some struct global variables

Normally variables that have a named struct as a type will get a
typedef entry as their type, sometimes however the Go linker will
decide to use the DW_TAG_structure_type entry instead.

For consistency always wrap a struct type into a typedef when we are
creating a new variables (see comment in newVariable for exceptions).

This fixes a bug where it would be impossible to call methods on a
global variable.

```
