### PR TITLE
proc: replace SavedRegisters interface with a Copy method

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,9 +7,9 @@ os:
 
 go:
   - tip
+  - 1.11.x
   - 1.10.x
   - 1.9.x
-  - 1.8.x
 
 matrix:
   allow_failures:

--- a/pkg/proc/core/core.go
+++ b/pkg/proc/core/core.go
@@ -239,7 +239,7 @@ func (t *Thread) Registers(floatingPoint bool) (proc.Registers, error) {
 	return r, nil
 }
 
-func (t *Thread) RestoreRegisters(proc.SavedRegisters) error {
+func (t *Thread) RestoreRegisters(proc.Registers) error {
 	return errors.New("not supported")
 }
 
@@ -426,6 +426,6 @@ func (r *Registers) Slice() []proc.Register {
 	return out
 }
 
-func (r *Registers) Save() proc.SavedRegisters {
+func (r *Registers) Copy() proc.Registers {
 	return r
 }

--- a/pkg/proc/gdbserial/gdbserver.go
+++ b/pkg/proc/gdbserial/gdbserver.go
@@ -187,6 +187,7 @@ func New(process *os.Process) *Process {
 		gcmdok:         true,
 		threadStopInfo: true,
 		process:        process,
+		common:         proc.NewCommonProcess(true),
 	}
 
 	if process != nil {
@@ -1188,9 +1189,8 @@ func (t *Thread) Registers(floatingPoint bool) (proc.Registers, error) {
 	return &t.regs, nil
 }
 
-func (t *Thread) RestoreRegisters(regs proc.SavedRegisters) error {
-	gdbregs := regs.(*gdbRegisters)
-	t.regs = *gdbregs
+func (t *Thread) RestoreRegisters(savedRegs proc.Registers) error {
+	copy(t.regs.buf, savedRegs.(*gdbRegisters).buf)
 	return t.writeRegisters()
 }
 
@@ -1804,7 +1804,7 @@ func (regs *gdbRegisters) Slice() []proc.Register {
 	return r
 }
 
-func (regs *gdbRegisters) Save() proc.SavedRegisters {
+func (regs *gdbRegisters) Copy() proc.Registers {
 	savedRegs := &gdbRegisters{}
 	savedRegs.init(regs.regsInfo)
 	copy(savedRegs.buf, regs.buf)

--- a/pkg/proc/gdbserial/gdbserver_conn.go
+++ b/pkg/proc/gdbserial/gdbserver_conn.go
@@ -866,6 +866,10 @@ func writeAsciiBytes(w io.Writer, data []byte) {
 
 // executes 'M' (write memory) command
 func (conn *gdbConn) writeMemory(addr uintptr, data []byte) (written int, err error) {
+	if len(data) == 0 {
+		// LLDB can't parse requests for 0-length writes and hangs if we emit them
+		return 0, nil
+	}
 	conn.outbuf.Reset()
 	//TODO(aarzilli): do not send packets larger than conn.PacketSize
 	fmt.Fprintf(&conn.outbuf, "$M%x,%x:", addr, len(data))

--- a/pkg/proc/native/proc_windows.go
+++ b/pkg/proc/native/proc_windows.go
@@ -57,6 +57,7 @@ func Launch(cmd []string, wd string, foreground bool) (*Process, error) {
 
 	var p *os.Process
 	dbp := New(0)
+	dbp.common = proc.NewCommonProcess(true)
 	dbp.execPtraceFunc(func() {
 		attr := &os.ProcAttr{
 			Dir:   wd,

--- a/pkg/proc/native/registers_darwin_amd64.go
+++ b/pkg/proc/native/registers_darwin_amd64.go
@@ -367,10 +367,7 @@ func registers(thread *Thread, floatingPoint bool) (proc.Registers, error) {
 	return regs, nil
 }
 
-type savedRegisters struct {
-}
-
-func (r *Regs) Save() proc.SavedRegisters {
+func (r *Regs) Copy() proc.Registers {
 	//TODO(aarzilli): implement this to support function calls
 	return nil
 }

--- a/pkg/proc/native/registers_linux_amd64.go
+++ b/pkg/proc/native/registers_linux_amd64.go
@@ -324,14 +324,6 @@ func (thread *Thread) fpRegisters() (regs []proc.Register, fpregs proc.LinuxX86X
 	return
 }
 
-type savedRegisters struct {
-	regs   sys.PtraceRegs
-	fpregs proc.LinuxX86Xstate
-}
-
-func (r *Regs) Save() proc.SavedRegisters {
-	savedRegs := &savedRegisters{}
-	savedRegs.regs = *r.regs
-	savedRegs.fpregs = *r.fpregset
-	return savedRegs
+func (r *Regs) Copy() proc.Registers {
+	return r
 }

--- a/pkg/proc/native/registers_linux_amd64.go
+++ b/pkg/proc/native/registers_linux_amd64.go
@@ -325,5 +325,16 @@ func (thread *Thread) fpRegisters() (regs []proc.Register, fpregs proc.LinuxX86X
 }
 
 func (r *Regs) Copy() proc.Registers {
-	return r
+	var rr Regs
+	rr.regs = &sys.PtraceRegs{}
+	rr.fpregset = &proc.LinuxX86Xstate{}
+	*(rr.regs) = *(r.regs)
+	if r.fpregset != nil {
+		*(rr.fpregset) = *(r.fpregset)
+	}
+	if r.fpregs != nil {
+		rr.fpregs = make([]proc.Register, len(r.fpregs))
+		copy(rr.fpregs, r.fpregs)
+	}
+	return &rr
 }

--- a/pkg/proc/native/registers_windows_amd64.go
+++ b/pkg/proc/native/registers_windows_amd64.go
@@ -378,10 +378,7 @@ func registers(thread *Thread, floatingPoint bool) (proc.Registers, error) {
 	return regs, nil
 }
 
-type savedRegisters struct {
-}
-
-func (r *Regs) Save() proc.SavedRegisters {
+func (r *Regs) Copy() proc.Registers {
 	//TODO(aarzilli): implement this to support function calls
 	return nil
 }

--- a/pkg/proc/native/registers_windows_amd64.go
+++ b/pkg/proc/native/registers_windows_amd64.go
@@ -33,6 +33,7 @@ type Regs struct {
 	fs      uint64
 	gs      uint64
 	tls     uint64
+	context *_CONTEXT
 	fltSave *_XMM_SAVE_AREA32
 }
 
@@ -374,11 +375,16 @@ func registers(thread *Thread, floatingPoint bool) (proc.Registers, error) {
 	if floatingPoint {
 		regs.fltSave = &context.FltSave
 	}
+	regs.context = context
 
 	return regs, nil
 }
 
 func (r *Regs) Copy() proc.Registers {
-	//TODO(aarzilli): implement this to support function calls
-	return nil
+	var rr Regs
+	rr = *r
+	rr.context = newCONTEXT()
+	*(rr.context) = *(r.context)
+	rr.fltSave = &rr.context.FltSave
+	return &rr
 }

--- a/pkg/proc/native/threads.go
+++ b/pkg/proc/native/threads.go
@@ -1,7 +1,6 @@
 package native
 
 import (
-	"errors"
 	"fmt"
 
 	"github.com/derekparker/delve/pkg/proc"
@@ -151,12 +150,8 @@ func (t *Thread) Registers(floatingPoint bool) (proc.Registers, error) {
 	return registers(t, floatingPoint)
 }
 
-func (t *Thread) RestoreRegisters(savedRegs proc.SavedRegisters) error {
-	sr, ok := savedRegs.(*savedRegisters)
-	if !ok {
-		return errors.New("unknown saved register set")
-	}
-	return t.restoreRegisters(sr)
+func (t *Thread) RestoreRegisters(savedRegs proc.Registers) error {
+	return t.restoreRegisters(savedRegs)
 }
 
 func (t *Thread) PC() (uint64, error) {

--- a/pkg/proc/native/threads_darwin.go
+++ b/pkg/proc/native/threads_darwin.go
@@ -146,6 +146,6 @@ func (t *Thread) ReadMemory(buf []byte, addr uintptr) (int, error) {
 	return len(buf), nil
 }
 
-func (t *Thread) restoreRegisters(sr *savedRegisters) error {
+func (t *Thread) restoreRegisters(sr proc.Registers) error {
 	return errors.New("not implemented")
 }

--- a/pkg/proc/native/threads_windows.go
+++ b/pkg/proc/native/threads_windows.go
@@ -150,6 +150,6 @@ func (t *Thread) ReadMemory(buf []byte, addr uintptr) (int, error) {
 	return int(count), err
 }
 
-func (t *Thread) restoreRegisters(sr *savedRegisters) error {
+func (t *Thread) restoreRegisters(savedRegs proc.Registers) error {
 	return errors.New("not implemented")
 }

--- a/pkg/proc/native/threads_windows.go
+++ b/pkg/proc/native/threads_windows.go
@@ -125,6 +125,9 @@ func (t *Thread) WriteMemory(addr uintptr, data []byte) (int, error) {
 	if t.dbp.exited {
 		return 0, proc.ProcessExitedError{Pid: t.dbp.pid}
 	}
+	if len(data) == 0 {
+		return 0, nil
+	}
 	var count uintptr
 	err := _WriteProcessMemory(t.dbp.os.hProcess, addr, &data[0], uintptr(len(data)), &count)
 	if err != nil {
@@ -151,5 +154,5 @@ func (t *Thread) ReadMemory(buf []byte, addr uintptr) (int, error) {
 }
 
 func (t *Thread) restoreRegisters(savedRegs proc.Registers) error {
-	return errors.New("not implemented")
+	return _SetThreadContext(t.os.hThread, savedRegs.(*Regs).context)
 }

--- a/pkg/proc/registers.go
+++ b/pkg/proc/registers.go
@@ -24,7 +24,7 @@ type Registers interface {
 	GAddr() (uint64, bool)
 	Get(int) (uint64, error)
 	Slice() []Register
-	// Copy returns a copy of this registers that is guaranteed not to change
+	// Copy returns a copy of the registers that is guaranteed not to change
 	// when the registers of the associated thread change.
 	Copy() Registers
 }

--- a/pkg/proc/registers.go
+++ b/pkg/proc/registers.go
@@ -24,17 +24,15 @@ type Registers interface {
 	GAddr() (uint64, bool)
 	Get(int) (uint64, error)
 	Slice() []Register
-	// Save saves a copy of this object that will survive restarts
-	Save() SavedRegisters
+	// Copy returns a copy of this registers that is guaranteed not to change
+	// when the registers of the associated thread change.
+	Copy() Registers
 }
 
 type Register struct {
 	Name  string
 	Bytes []byte
 	Value string
-}
-
-type SavedRegisters interface {
 }
 
 // AppendWordReg appends a word (16 bit) register to regs.

--- a/pkg/proc/test/support.go
+++ b/pkg/proc/test/support.go
@@ -250,7 +250,7 @@ func MustSupportFunctionCalls(t *testing.T, testBackend string) {
 	if !goversion.VersionAfterOrEqual(runtime.Version(), 1, 11) {
 		t.Skip("this version of Go does not support function calls")
 	}
-	if runtime.GOOS != "linux" || testBackend != "native" {
+	if runtime.GOOS == "windows" {
 		t.Skip("this backend does not support function calls")
 	}
 }

--- a/pkg/proc/test/support.go
+++ b/pkg/proc/test/support.go
@@ -251,18 +251,7 @@ func MustSupportFunctionCalls(t *testing.T, testBackend string) {
 		t.Skip("this version of Go does not support function calls")
 	}
 
-	const unsupported = "this backend does not support function calls"
-
-	if testBackend == "rr" {
-		t.Skip(unsupported)
-	}
-
-	switch runtime.GOOS {
-	case "darwin":
-		if testBackend == "native" {
-			t.Skip(unsupported)
-		}
-	case "windows":
-		t.Skip(unsupported)
+	if testBackend == "rr" || (runtime.GOOS == "darwin" && testBackend == "native") {
+		t.Skip("this backend does not support function calls")
 	}
 }

--- a/pkg/proc/test/support.go
+++ b/pkg/proc/test/support.go
@@ -250,7 +250,19 @@ func MustSupportFunctionCalls(t *testing.T, testBackend string) {
 	if !goversion.VersionAfterOrEqual(runtime.Version(), 1, 11) {
 		t.Skip("this version of Go does not support function calls")
 	}
-	if runtime.GOOS == "windows" {
-		t.Skip("this backend does not support function calls")
+
+	const unsupported = "this backend does not support function calls"
+
+	if testBackend == "rr" {
+		t.Skip(unsupported)
+	}
+
+	switch runtime.GOOS {
+	case "darwin":
+		if testBackend == "native" {
+			t.Skip(unsupported)
+		}
+	case "windows":
+		t.Skip(unsupported)
 	}
 }

--- a/pkg/proc/threads.go
+++ b/pkg/proc/threads.go
@@ -22,9 +22,17 @@ type Thread interface {
 	// nil if the thread is not stopped at any breakpoint.
 	Breakpoint() BreakpointState
 	ThreadID() int
+
+	// Registers returns the CPU registers of this thread. The contents of the
+	// variable returned may or may not change to reflect the new CPU status
+	// when the thread is resumed or the registers are changed by calling
+	// SetPC/SetSP/etc.
+	// To insure that the the returned variable won't change call the Copy
+	// method of Registers.
 	Registers(floatingPoint bool) (Registers, error)
+
 	// RestoreRegisters restores saved registers
-	RestoreRegisters(SavedRegisters) error
+	RestoreRegisters(Registers) error
 	Arch() Arch
 	BinInfo() *BinaryInfo
 	StepInstruction() error


### PR DESCRIPTION
```
proc: replace SavedRegisters interface with a Copy method

Fncall.go was written with the assumption that the object returned by
proc.Thread.Registers does not change after we call
proc.Thread.SetPC/etc.

This is true for the native backend but not for gdbserial. I had
anticipated this problem and introduced the Save/SavedRegisters
mechanism during the first implementation of fncall.go but that's
insufficient.

Instead:

1. clarify that the object returned by proc.Thread.Registers could
change when the CPU registers are modified.
2. add a Copy method to Registers that returns a copy of the registers
that are guaranteed not to change when the CPU registers change.
3. remove the Save/SavedRegisters mechanism.

This solution leaves us the option, in the future, to cache the output
of proc.(Thread).Registers, avoiding a system call every time it's
called.

[WIP] Add function call support for OSX

Implements missing functionality in gdbserial to enable function calls
on OSX.

```
