### PR TITLE
cmd,service: in non-headless mode use an in-memory connection

### DIFF
--- a/service/listenerpipe.go
+++ b/service/listenerpipe.go
@@ -1,0 +1,60 @@
+package service
+
+import (
+	"errors"
+	"net"
+	"sync"
+)
+
+// ListenerPipe returns a full-duplex in-memory connection, like net.Pipe.
+// Unlike net.Pipe one end of the connection is returned as an object
+// satisfying the net.Listener interface.
+// The first call to the Accept method of this object will return a net.Conn
+// connected to the other net.Conn returned by ListenerPipe.
+// Any subsequent calls to Accept will block until the listener is closed.
+func ListenerPipe() (net.Listener, net.Conn) {
+	conn0, conn1 := net.Pipe()
+	return &preconnectedListener{conn: conn0, closech: make(chan struct{})}, conn1
+}
+
+// preconnectedListener satisfies the net.Listener interface by accepting a
+// single pre-established connection.
+// The first call to Accept will return the conn field, any subsequent call
+// will block until the listener is closed.
+type preconnectedListener struct {
+	accepted bool
+	conn     net.Conn
+	closech  chan struct{}
+	closeMu  sync.Mutex
+	acceptMu sync.Mutex
+}
+
+// Accept returns the pre-established connection the first time it's called,
+// it blocks until the listener is closed on every subsequent call.
+func (l *preconnectedListener) Accept() (net.Conn, error) {
+	l.acceptMu.Lock()
+	defer l.acceptMu.Unlock()
+	if !l.accepted {
+		l.accepted = true
+		return l.conn, nil
+	}
+	<-l.closech
+	return nil, errors.New("accept failed: listener closed")
+}
+
+// Close closes the listener.
+func (l *preconnectedListener) Close() error {
+	l.closeMu.Lock()
+	defer l.closeMu.Unlock()
+	if l.closech == nil {
+		return nil
+	}
+	close(l.closech)
+	l.closech = nil
+	return nil
+}
+
+// Addr returns the listener's network address.
+func (l *preconnectedListener) Addr() net.Addr {
+	return l.conn.LocalAddr()
+}

--- a/service/rpc2/client.go
+++ b/service/rpc2/client.go
@@ -3,6 +3,7 @@ package rpc2
 import (
 	"fmt"
 	"log"
+	"net"
 	"net/rpc"
 	"net/rpc/jsonrpc"
 	"time"
@@ -13,7 +14,6 @@ import (
 
 // Client is a RPC service.Client.
 type RPCClient struct {
-	addr   string
 	client *rpc.Client
 
 	retValLoadCfg *api.LoadConfig
@@ -28,9 +28,18 @@ func NewClient(addr string) *RPCClient {
 	if err != nil {
 		log.Fatal("dialing:", err)
 	}
-	c := &RPCClient{addr: addr, client: client}
+	return newFromRPCClient(client)
+}
+
+func newFromRPCClient(client *rpc.Client) *RPCClient {
+	c := &RPCClient{client: client}
 	c.call("SetApiVersion", api.SetAPIVersionIn{2}, &api.SetAPIVersionOut{})
 	return c
+}
+
+// NewClientFromConn creates a new RPCClient from the given connection.
+func NewClientFromConn(conn net.Conn) *RPCClient {
+	return newFromRPCClient(jsonrpc.NewClient(conn))
 }
 
 func (c *RPCClient) ProcessPid() int {

--- a/service/test/integration2_test.go
+++ b/service/test/integration2_test.go
@@ -41,11 +41,7 @@ func withTestClient2(name string, t *testing.T, fn func(c service.Client)) {
 	if testBackend == "rr" {
 		protest.MustHaveRecordingAllowed(t)
 	}
-	listener, err := net.Listen("tcp", "localhost:0")
-	if err != nil {
-		t.Fatalf("couldn't start listener: %s\n", err)
-	}
-	defer listener.Close()
+	listener, clientConn := service.ListenerPipe()
 	server := rpccommon.NewServer(&service.Config{
 		Listener:    listener,
 		ProcessArgs: []string{protest.BuildFixture(name, 0).Path},
@@ -54,7 +50,7 @@ func withTestClient2(name string, t *testing.T, fn func(c service.Client)) {
 	if err := server.Run(); err != nil {
 		t.Fatal(err)
 	}
-	client := rpc2.NewClient(listener.Addr().String())
+	client := rpc2.NewClientFromConn(clientConn)
 	defer func() {
 		dir, _ := client.TraceDirectory()
 		client.Detach(true)


### PR DESCRIPTION
```
cmd,service: in non-headless mode use an in-memory connection

Replace the socket connection with an in-memory connection (created by net.Pipe) for non-headless uses of delve.
This is faster and more secure.

Fixes #1332

```
