### PR TITLE
Documentation: mention that interfaces can also not be loaded

### DIFF
--- a/Documentation/api/ClientHowto.md
+++ b/Documentation/api/ClientHowto.md
@@ -200,6 +200,7 @@ the user of this:
 
 * For strings, arrays, slices *and structs* the load is incomplete if: `Variable.Len > len(Variable.Children)`. This can happen to structs even if LoadConfig.MaxStructFields is -1 when MaxVariableRecurse is reached.
 * For maps the load is incomplete if: `Variable.Len > len(Variable.Children) / 2`
+* For interfaces the load is incomplete if the only children has the onlyAddr attribute set to true.
 
 ### Loading more of a Variable
 


### PR DESCRIPTION
```
Documentation: mention that interfaces can also not be loaded

An interface with a children that has onlyAddr set to true was not
loaded due to the depth limit having been reached.

```
