### PR TITLE
proc: add flag to disable escape checking in function calls

### DIFF
--- a/Documentation/cli/README.md
+++ b/Documentation/cli/README.md
@@ -73,6 +73,8 @@ Aliases: bp
 ## call
 Resumes process, injecting a function call (EXPERIMENTAL!!!)
 	
+	call [-unsafe] <function call expression>
+	
 Current limitations:
 - only pointers to stack-allocated objects can be passed as argument.
 - only some automatic type conversions are supported.
@@ -174,8 +176,8 @@ Aliases: disass
 ## down
 Move the current frame down.
 
-  down [<m>]
-  down [<m>] <command>
+	down [<m>]
+	down [<m>] <command>
 
 Move the current frame down by <m>. The second form runs the command on the given frame.
 
@@ -201,8 +203,8 @@ Aliases: quit q
 ## frame
 Set the current frame, or execute command on a different frame.
 
-  frame <m>
-  frame <m> <command>
+	frame <m>
+	frame <m> <command>
 
 The first form sets frame used by subsequent commands such as "print" or "set".
 The second form runs the command on the given frame.
@@ -394,8 +396,8 @@ If regex is specified only the types matching it will be returned.
 ## up
 Move the current frame up.
 
-  up [<m>]
-  up [<m>] <command>
+	up [<m>]
+	up [<m>] <command>
 
 Move the current frame up by <m>. The second form runs the command on the given frame.
 

--- a/_fixtures/fncall.go
+++ b/_fixtures/fncall.go
@@ -39,6 +39,10 @@ type astruct struct {
 	X int
 }
 
+type a2struct struct {
+	Y int
+}
+
 func (a astruct) VRcvr(x int) string {
 	return fmt.Sprintf("%d + %d = %d", x, a.X, x+a.X)
 }
@@ -66,6 +70,11 @@ func makeclos(pa *astruct) func(int) string {
 }
 
 var ga astruct
+var globalPA2 *a2struct
+
+func escapeArg(pa2 *a2struct) {
+	globalPA2 = pa2
+}
 
 func main() {
 	one, two := 1, 2
@@ -74,6 +83,7 @@ func main() {
 	comma := ","
 	a := astruct{X: 3}
 	pa := &astruct{X: 6}
+	a2 := a2struct{Y: 7}
 
 	var vable_a VRcvrable = a
 	var vable_pa VRcvrable = pa
@@ -88,5 +98,5 @@ func main() {
 	runtime.Breakpoint()
 	call1(one, two)
 	fn2clos(2)
-	fmt.Println(one, two, zero, callpanic, callstacktrace, stringsJoin, intslice, stringslice, comma, a.VRcvr, a.PRcvr, pa, vable_a, vable_pa, pable_pa, fn2clos, fn2glob, fn2valmeth, fn2ptrmeth, fn2nil, ga)
+	fmt.Println(one, two, zero, callpanic, callstacktrace, stringsJoin, intslice, stringslice, comma, a.VRcvr, a.PRcvr, pa, vable_a, vable_pa, pable_pa, fn2clos, fn2glob, fn2valmeth, fn2ptrmeth, fn2nil, ga, escapeArg, a2)
 }

--- a/pkg/dwarf/godwarf/type.go
+++ b/pkg/dwarf/godwarf/type.go
@@ -876,3 +876,13 @@ func zeroArray(t Type) {
 		t = at.Type
 	}
 }
+
+func resolveTypedef(typ Type) Type {
+	for {
+		if tt, ok := typ.(*TypedefType); ok {
+			typ = tt.Type
+		} else {
+			return typ
+		}
+	}
+}

--- a/pkg/terminal/command.go
+++ b/pkg/terminal/command.go
@@ -125,12 +125,12 @@ A tracepoint is a breakpoint that does not stop the execution of the program, in
 See also: "help on", "help cond" and "help clear"`},
 		{aliases: []string{"restart", "r"}, cmdFn: restart, helpMsg: `Restart process.
 
-  restart [checkpoint]
-  restart [-noargs] newargv...
+	restart [checkpoint]
+	restart [-noargs] newargv...
 
-  For recorded processes restarts from the start or from the specified
-  checkpoint.  For normal processes restarts the process, optionally changing
-  the arguments.  With -noargs, the process starts with an empty commandline.
+For recorded processes restarts from the start or from the specified
+checkpoint.  For normal processes restarts the process, optionally changing
+the arguments.  With -noargs, the process starts with an empty commandline.
 `},
 		{aliases: []string{"continue", "c"}, cmdFn: c.cont, helpMsg: "Run until breakpoint or program termination."},
 		{aliases: []string{"step", "s"}, cmdFn: c.step, helpMsg: "Single step through program."},
@@ -138,6 +138,8 @@ See also: "help on", "help cond" and "help clear"`},
 		{aliases: []string{"next", "n"}, cmdFn: c.next, helpMsg: "Step over to next source line."},
 		{aliases: []string{"stepout"}, cmdFn: c.stepout, helpMsg: "Step out of the current function."},
 		{aliases: []string{"call"}, cmdFn: c.call, helpMsg: `Resumes process, injecting a function call (EXPERIMENTAL!!!)
+	
+	call [-unsafe] <function call expression>
 	
 Current limitations:
 - only pointers to stack-allocated objects can be passed as argument.
@@ -259,8 +261,8 @@ Show source around current point or provided linespec.`},
 			},
 			helpMsg: `Set the current frame, or execute command on a different frame.
 
-  frame <m>
-  frame <m> <command>
+	frame <m>
+	frame <m> <command>
 
 The first form sets frame used by subsequent commands such as "print" or "set".
 The second form runs the command on the given frame.`},
@@ -270,8 +272,8 @@ The second form runs the command on the given frame.`},
 			},
 			helpMsg: `Move the current frame up.
 
-  up [<m>]
-  up [<m>] <command>
+	up [<m>]
+	up [<m>] <command>
 
 Move the current frame up by <m>. The second form runs the command on the given frame.`},
 		{aliases: []string{"down"},
@@ -280,8 +282,8 @@ Move the current frame up by <m>. The second form runs the command on the given 
 			},
 			helpMsg: `Move the current frame down.
 
-  down [<m>]
-  down [<m>] <command>
+	down [<m>]
+	down [<m>] <command>
 
 Move the current frame down by <m>. The second form runs the command on the given frame.`},
 		{aliases: []string{"source"}, cmdFn: c.sourceCommand, helpMsg: `Executes a file containing a list of delve commands
@@ -980,7 +982,13 @@ func (c *Commands) call(t *Term, ctx callContext, args string) error {
 	if err := scopePrefixSwitch(t, ctx); err != nil {
 		return err
 	}
-	state, err := exitedToError(t.client.Call(args))
+	const unsafePrefix = "-unsafe "
+	unsafe := false
+	if strings.HasPrefix(args, unsafePrefix) {
+		unsafe = true
+		args = args[len(unsafePrefix):]
+	}
+	state, err := exitedToError(t.client.Call(args, unsafe))
 	c.frame = 0
 	if err != nil {
 		printcontextNoState(t)

--- a/service/api/types.go
+++ b/service/api/types.go
@@ -308,6 +308,8 @@ type DebuggerCommand struct {
 	ReturnInfoLoadConfig *LoadConfig
 	// Expr is the expression argument for a Call command
 	Expr string `json:"expr,omitempty"`
+	// UnsafeCall disabled parameter escape checking for function calls
+	UnsafeCall bool `json:"unsafeCall,omitempty"`
 }
 
 // BreakpointInfo contains informations about the current breakpoint

--- a/service/client.go
+++ b/service/client.go
@@ -39,7 +39,7 @@ type Client interface {
 	// StepOut continues to the return address of the current function
 	StepOut() (*api.DebuggerState, error)
 	// Call resumes process execution while making a function call.
-	Call(expr string) (*api.DebuggerState, error)
+	Call(expr string, unsafe bool) (*api.DebuggerState, error)
 
 	// SingleStep will step a single cpu instruction.
 	StepInstruction() (*api.DebuggerState, error)

--- a/service/debugger/debugger.go
+++ b/service/debugger/debugger.go
@@ -565,7 +565,7 @@ func (d *Debugger) Command(command *api.DebuggerCommand) (*api.DebuggerState, er
 		err = proc.Continue(d.target)
 	case api.Call:
 		d.log.Debugf("function call %s", command.Expr)
-		err = proc.CallFunction(d.target, command.Expr, api.LoadConfigToProc(command.ReturnInfoLoadConfig))
+		err = proc.CallFunction(d.target, command.Expr, api.LoadConfigToProc(command.ReturnInfoLoadConfig), !command.UnsafeCall)
 	case api.Rewind:
 		d.log.Debug("rewinding")
 		if err := d.target.Direction(proc.Backward); err != nil {

--- a/service/rpc2/client.go
+++ b/service/rpc2/client.go
@@ -148,9 +148,9 @@ func (c *RPCClient) StepOut() (*api.DebuggerState, error) {
 	return &out.State, err
 }
 
-func (c *RPCClient) Call(expr string) (*api.DebuggerState, error) {
+func (c *RPCClient) Call(expr string, unsafe bool) (*api.DebuggerState, error) {
 	var out CommandOut
-	err := c.call("Command", &api.DebuggerCommand{Name: api.Call, ReturnInfoLoadConfig: c.retValLoadCfg, Expr: expr}, &out)
+	err := c.call("Command", &api.DebuggerCommand{Name: api.Call, ReturnInfoLoadConfig: c.retValLoadCfg, Expr: expr, UnsafeCall: unsafe}, &out)
 	return &out.State, err
 }
 

--- a/service/test/integration2_test.go
+++ b/service/test/integration2_test.go
@@ -1525,7 +1525,7 @@ func TestClientServerFunctionCall(t *testing.T) {
 		state := <-c.Continue()
 		assertNoError(state.Err, t, "Continue()")
 		beforeCallFn := state.CurrentThread.Function.Name()
-		state, err := c.Call("call1(one, two)")
+		state, err := c.Call("call1(one, two)", false)
 		assertNoError(err, t, "Call()")
 		t.Logf("returned to %q", state.CurrentThread.Function.Name())
 		if state.CurrentThread.Function.Name() != beforeCallFn {
@@ -1564,7 +1564,7 @@ func TestClientServerFunctionCallBadPos(t *testing.T) {
 		state = <-c.Continue()
 		assertNoError(state.Err, t, "Continue()")
 
-		state, err = c.Call("main.call1(main.zero, main.zero)")
+		state, err = c.Call("main.call1(main.zero, main.zero)", false)
 		if err == nil || err.Error() != "call not at safe point" {
 			t.Fatalf("wrong error or no error: %v", err)
 		}
@@ -1578,7 +1578,7 @@ func TestClientServerFunctionCallPanic(t *testing.T) {
 		c.SetReturnValuesLoadConfig(&normalLoadConfig)
 		state := <-c.Continue()
 		assertNoError(state.Err, t, "Continue()")
-		state, err := c.Call("callpanic()")
+		state, err := c.Call("callpanic()", false)
 		assertNoError(err, t, "Call()")
 		t.Logf("at: %s:%d", state.CurrentThread.File, state.CurrentThread.Line)
 		if state.CurrentThread.ReturnValues == nil {
@@ -1604,7 +1604,7 @@ func TestClientServerFunctionCallStacktrace(t *testing.T) {
 		c.SetReturnValuesLoadConfig(&api.LoadConfig{false, 0, 2048, 0, 0})
 		state := <-c.Continue()
 		assertNoError(state.Err, t, "Continue()")
-		state, err := c.Call("callstacktrace()")
+		state, err := c.Call("callstacktrace()", false)
 		assertNoError(err, t, "Call()")
 		t.Logf("at: %s:%d", state.CurrentThread.File, state.CurrentThread.Line)
 		if state.CurrentThread.ReturnValues == nil {


### PR DESCRIPTION
```
proc: add flag to disable escape checking in function calls

Fix escape checking in function calls  and add a flag to disable it.

```
