### PR TITLE
proc: implement conversion of integers to string

### DIFF
--- a/service/test/variables_test.go
+++ b/service/test/variables_test.go
@@ -748,6 +748,8 @@ func TestEvalExpression(t *testing.T) {
 		{"uint8(i5)", false, "253", "253", "uint8", nil},
 		{"int8(i5)", false, "-3", "-3", "int8", nil},
 		{"int8(i6)", false, "12", "12", "int8", nil},
+		{"string(byteslice[0])", false, `"t"`, `"t"`, "string", nil},
+		{"string(runeslice[0])", false, `"t"`, `"t"`, "string", nil},
 
 		// misc
 		{"i1", true, "1", "1", "int", nil},


### PR DESCRIPTION
```
proc: implement conversion of integers to string

Go allows converting a single integer value to string, resulting in a
string containing a single unicode rune with the same code as the value
of the integer.
Allow the same conversion to happen.

Fixes #1322

```
