### PR TITLE
proc: be more lenient with errors in GoroutinesInfo

### DIFF
--- a/pkg/proc/variables.go
+++ b/pkg/proc/variables.go
@@ -165,6 +165,8 @@ type G struct {
 	Thread Thread
 
 	variable *Variable
+
+	Unreadable error // could not read the G struct
 }
 
 // EvalScope is the scope for variable evaluation. Contains the thread,

--- a/pkg/terminal/command.go
+++ b/pkg/terminal/command.go
@@ -751,6 +751,9 @@ func formatGoroutine(g *api.Goroutine, fgl formatGoroutineLoc) string {
 	if g == nil {
 		return "<nil>"
 	}
+	if g.Unreadable != "" {
+		return fmt.Sprintf("(unreadable %s)", g.Unreadable)
+	}
 	var locname string
 	var loc api.Location
 	switch fgl {

--- a/service/api/conversions.go
+++ b/service/api/conversions.go
@@ -230,7 +230,7 @@ func ConvertGoroutine(g *proc.G) *Goroutine {
 	if th != nil {
 		tid = th.ThreadID()
 	}
-	return &Goroutine{
+	r := &Goroutine{
 		ID:             g.ID,
 		CurrentLoc:     ConvertLocation(g.CurrentLoc),
 		UserCurrentLoc: ConvertLocation(g.UserCurrent()),
@@ -238,6 +238,10 @@ func ConvertGoroutine(g *proc.G) *Goroutine {
 		StartLoc:       ConvertLocation(g.StartLoc()),
 		ThreadID:       tid,
 	}
+	if g.Unreadable != nil {
+		r.Unreadable = g.Unreadable.Error()
+	}
+	return r
 }
 
 // ConvertLocation converts from proc.Location to api.Location.

--- a/service/api/types.go
+++ b/service/api/types.go
@@ -289,7 +289,8 @@ type Goroutine struct {
 	// Location of the starting function
 	StartLoc Location `json:"startLoc"`
 	// ID of the associated thread for running goroutines
-	ThreadID int `json:"threadID"`
+	ThreadID   int    `json:"threadID"`
+	Unreadable string `json:"unreadable"`
 }
 
 // DebuggerCommand is a command which changes the debugger's execution state.


### PR DESCRIPTION
```
proc: be more lenient with errors in GoroutinesInfo

Instead of failing on the first goroutine we can't read save the error
message and keep going.

Fixes a bug reported on the mailing list:
https://groups.google.com/d/msgid/delve-dev/3b3bfaa3-83d5-4676-b974-1fec40e5bf53%40googlegroups.com?utm_medium=email&utm_source=footer

```
