### PR TITLE
Fix scripts/make.go for darwin

### DIFF
--- a/scripts/make.go
+++ b/scripts/make.go
@@ -180,7 +180,7 @@ func installedExecutablePath() string {
 		return filepath.Join(gobin, "dlv")
 	}
 	gopath := strings.Split(getoutput("go", "env", "GOPATH"), ":")
-	return filepath.Join(gopath[0], "dlv")
+	return filepath.Join(strings.TrimSpace(gopath[0]), "bin", "dlv")
 }
 
 func buildFlags() []string {


### PR DESCRIPTION
Correctly locates the installed executable path for darwin when GOBIN is not set. The current logic ignores the `bin` component of the install dir as well as adds a superfluous newline character to the output of `go env GOPATH`

Before:
```bash
05:52:24[/delve (master=)]$ make install
Password:
go install "-ldflags=-s -X main.Build=50419b61da7ef7be972ca7a3199c1f8a10a75a93" github.com/derekparker/delve/cmd/dlv
codesign -s dlv-cert /Users/kevincantwell/go
/dlv
/Users/kevincantwell/go
/dlv: No such file or directory
exit status 1
make: *** [install] Error 1
```

After:

```bash
06:22:10[/delve (master *=)]$ make install
go install "-ldflags=-s -X main.Build=50419b61da7ef7be972ca7a3199c1f8a10a75a93" github.com/derekparker/delve/cmd/dlv
2018/09/26 06:22:34 /Users/kevincantwell/go/bin/dlv
codesign -s dlv-cert /Users/kevincantwell/go/bin/dlv
```