### PR TITLE
proc: support position independent executables (PIE)

### DIFF
--- a/pkg/dwarf/frame/parser_test.go
+++ b/pkg/dwarf/frame/parser_test.go
@@ -25,6 +25,6 @@ func BenchmarkParse(b *testing.B) {
 
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		frame.Parse(data, binary.BigEndian)
+		frame.Parse(data, binary.BigEndian, 0)
 	}
 }

--- a/pkg/dwarf/frame/table.go
+++ b/pkg/dwarf/frame/table.go
@@ -277,7 +277,7 @@ func setloc(frame *FrameContext) {
 	var loc uint64
 	binary.Read(frame.buf, frame.order, &loc)
 
-	frame.loc = loc
+	frame.loc = loc + frame.cie.staticBase
 }
 
 func offsetextended(frame *FrameContext) {

--- a/pkg/dwarf/line/line_parser_test.go
+++ b/pkg/dwarf/line/line_parser_test.go
@@ -67,7 +67,7 @@ const (
 
 func testDebugLinePrologueParser(p string, t *testing.T) {
 	data := grabDebugLineSection(p, t)
-	debugLines := ParseAll(data, nil)
+	debugLines := ParseAll(data, nil, 0)
 
 	mainFileFound := false
 
@@ -164,7 +164,7 @@ func BenchmarkLineParser(b *testing.B) {
 
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		_ = ParseAll(data, nil)
+		_ = ParseAll(data, nil, 0)
 	}
 }
 
@@ -179,7 +179,7 @@ func loadBenchmarkData(tb testing.TB) DebugLines {
 		tb.Fatal("Could not read test data", err)
 	}
 
-	return ParseAll(data, nil)
+	return ParseAll(data, nil, 0)
 }
 
 func BenchmarkStateMachine(b *testing.B) {

--- a/pkg/dwarf/line/state_machine.go
+++ b/pkg/dwarf/line/state_machine.go
@@ -105,7 +105,7 @@ func newStateMachine(dbl *DebugLineInfo, instructions []byte) *StateMachine {
 	for op := range standardopcodes {
 		opcodes[op] = standardopcodes[op]
 	}
-	sm := &StateMachine{dbl: dbl, file: dbl.FileNames[0].Path, line: 1, buf: bytes.NewBuffer(instructions), opcodes: opcodes, isStmt: dbl.Prologue.InitialIsStmt == uint8(1)}
+	sm := &StateMachine{dbl: dbl, file: dbl.FileNames[0].Path, line: 1, buf: bytes.NewBuffer(instructions), opcodes: opcodes, isStmt: dbl.Prologue.InitialIsStmt == uint8(1), address: dbl.staticBase}
 	return sm
 }
 
@@ -433,7 +433,7 @@ func setaddress(sm *StateMachine, buf *bytes.Buffer) {
 
 	binary.Read(buf, binary.LittleEndian, &addr)
 
-	sm.address = addr
+	sm.address = addr + sm.dbl.staticBase
 }
 
 func definefile(sm *StateMachine, buf *bytes.Buffer) {

--- a/pkg/dwarf/line/state_machine_test.go
+++ b/pkg/dwarf/line/state_machine_test.go
@@ -77,7 +77,7 @@ func TestGrafana(t *testing.T) {
 		}
 		cuname, _ := e.Val(dwarf.AttrName).(string)
 
-		lineInfo := Parse(e.Val(dwarf.AttrCompDir).(string), debugLineBuffer, t.Logf)
+		lineInfo := Parse(e.Val(dwarf.AttrCompDir).(string), debugLineBuffer, t.Logf, 0)
 		sm := newStateMachine(lineInfo, lineInfo.Instructions)
 
 		lnrdr, err := data.LineReader(e)

--- a/pkg/dwarf/op/op.go
+++ b/pkg/dwarf/op/op.go
@@ -133,7 +133,7 @@ func callframecfa(opcode Opcode, ctxt *context) error {
 }
 
 func addr(opcode Opcode, ctxt *context) error {
-	ctxt.stack = append(ctxt.stack, int64(binary.LittleEndian.Uint64(ctxt.buf.Next(8))))
+	ctxt.stack = append(ctxt.stack, int64(binary.LittleEndian.Uint64(ctxt.buf.Next(8))+ctxt.StaticBase))
 	return nil
 }
 

--- a/pkg/dwarf/op/regs.go
+++ b/pkg/dwarf/op/regs.go
@@ -6,6 +6,8 @@ import (
 )
 
 type DwarfRegisters struct {
+	StaticBase uint64
+
 	CFA       int64
 	FrameBase int64
 	ObjBase   int64

--- a/pkg/dwarf/reader/variables.go
+++ b/pkg/dwarf/reader/variables.go
@@ -6,6 +6,14 @@ import (
 	"debug/dwarf"
 )
 
+// RelAddr is an address relative to the static base. For normal executables
+// this is just a normal memory address, for PIE it's a relative address.
+type RelAddr uint64
+
+func ToRelAddr(addr uint64, staticBase uint64) RelAddr {
+	return RelAddr(addr - staticBase)
+}
+
 // VariableReader provides a way of reading the local variables and formal
 // parameters of a function that are visible at the specified PC address.
 type VariableReader struct {
@@ -22,10 +30,10 @@ type VariableReader struct {
 // Variables returns a VariableReader for the function or lexical block at off.
 // If onlyVisible is true only variables visible at pc will be returned by
 // the VariableReader.
-func Variables(dwarf *dwarf.Data, off dwarf.Offset, pc uint64, line int, onlyVisible bool) *VariableReader {
+func Variables(dwarf *dwarf.Data, off dwarf.Offset, pc RelAddr, line int, onlyVisible bool) *VariableReader {
 	reader := dwarf.Reader()
 	reader.Seek(off)
-	return &VariableReader{dwarf: dwarf, reader: reader, entry: nil, depth: 0, onlyVisible: onlyVisible, pc: pc, line: line, err: nil}
+	return &VariableReader{dwarf: dwarf, reader: reader, entry: nil, depth: 0, onlyVisible: onlyVisible, pc: uint64(pc), line: line, err: nil}
 }
 
 // Next reads the next variable entry, returns false if there aren't any.

--- a/pkg/proc/arch.go
+++ b/pkg/proc/arch.go
@@ -17,7 +17,7 @@ type Arch interface {
 	DerefTLS() bool
 	FixFrameUnwindContext(fctxt *frame.FrameContext, pc uint64, bi *BinaryInfo) *frame.FrameContext
 	RegSize(uint64) int
-	RegistersToDwarfRegisters(Registers) op.DwarfRegisters
+	RegistersToDwarfRegisters(regs Registers, staticBase uint64) op.DwarfRegisters
 	GoroutineToDwarfRegisters(*G) op.DwarfRegisters
 }
 
@@ -270,7 +270,7 @@ func maxAmd64DwarfRegister() int {
 
 // RegistersToDwarfRegisters converts hardware registers to the format used
 // by the DWARF expression interpreter.
-func (a *AMD64) RegistersToDwarfRegisters(regs Registers) op.DwarfRegisters {
+func (a *AMD64) RegistersToDwarfRegisters(regs Registers, staticBase uint64) op.DwarfRegisters {
 	dregs := make([]*op.DwarfRegister, maxAmd64DwarfRegister()+1)
 
 	dregs[amd64DwarfIPRegNum] = op.DwarfRegisterFromUint64(regs.PC())
@@ -292,7 +292,7 @@ func (a *AMD64) RegistersToDwarfRegisters(regs Registers) op.DwarfRegisters {
 		}
 	}
 
-	return op.DwarfRegisters{Regs: dregs, ByteOrder: binary.LittleEndian, PCRegNum: amd64DwarfIPRegNum, SPRegNum: amd64DwarfSPRegNum, BPRegNum: amd64DwarfBPRegNum}
+	return op.DwarfRegisters{StaticBase: staticBase, Regs: dregs, ByteOrder: binary.LittleEndian, PCRegNum: amd64DwarfIPRegNum, SPRegNum: amd64DwarfSPRegNum, BPRegNum: amd64DwarfBPRegNum}
 }
 
 // GoroutineToDwarfRegisters extract the saved DWARF registers from a parked
@@ -302,5 +302,5 @@ func (a *AMD64) GoroutineToDwarfRegisters(g *G) op.DwarfRegisters {
 	dregs[amd64DwarfIPRegNum] = op.DwarfRegisterFromUint64(g.PC)
 	dregs[amd64DwarfSPRegNum] = op.DwarfRegisterFromUint64(g.SP)
 	dregs[amd64DwarfBPRegNum] = op.DwarfRegisterFromUint64(g.BP)
-	return op.DwarfRegisters{Regs: dregs, ByteOrder: binary.LittleEndian, PCRegNum: amd64DwarfIPRegNum, SPRegNum: amd64DwarfSPRegNum, BPRegNum: amd64DwarfBPRegNum}
+	return op.DwarfRegisters{StaticBase: g.variable.bi.staticBase, Regs: dregs, ByteOrder: binary.LittleEndian, PCRegNum: amd64DwarfIPRegNum, SPRegNum: amd64DwarfSPRegNum, BPRegNum: amd64DwarfBPRegNum}
 }

--- a/pkg/proc/core/core.go
+++ b/pkg/proc/core/core.go
@@ -191,7 +191,7 @@ func OpenCore(corePath, exePath string) (*Process, error) {
 	}
 
 	var wg sync.WaitGroup
-	err = p.bi.LoadBinaryInfo(exePath, &wg)
+	err = p.bi.LoadBinaryInfo(exePath, core.entryPoint, &wg)
 	wg.Wait()
 	if err == nil {
 		err = p.bi.LoadError()

--- a/pkg/proc/dwarf_expr_test.go
+++ b/pkg/proc/dwarf_expr_test.go
@@ -90,7 +90,7 @@ func dwarfExprCheck(t *testing.T, mem proc.MemoryReadWriter, regs op.DwarfRegist
 
 func dwarfRegisters(regs *core.Registers) op.DwarfRegisters {
 	a := proc.AMD64Arch("linux")
-	dwarfRegs := a.RegistersToDwarfRegisters(regs)
+	dwarfRegs := a.RegistersToDwarfRegisters(regs, 0)
 	dwarfRegs.CFA = defaultCFA
 	dwarfRegs.FrameBase = defaultCFA
 	return dwarfRegs

--- a/pkg/proc/fncall.go
+++ b/pkg/proc/fncall.go
@@ -297,7 +297,7 @@ func funcCallArgFrame(fn *Function, actualArgs []*Variable, g *G, bi *BinaryInfo
 
 func funcCallArgs(fn *Function, bi *BinaryInfo, includeRet bool) (argFrameSize int64, formalArgs []funcCallArg, err error) {
 	const CFA = 0x1000
-	vrdr := reader.Variables(bi.dwarf, fn.offset, fn.Entry, int(^uint(0)>>1), false)
+	vrdr := reader.Variables(bi.dwarf, fn.offset, reader.ToRelAddr(fn.Entry, bi.staticBase), int(^uint(0)>>1), false)
 
 	// typechecks arguments, calculates argument frame size
 	for vrdr.Next() {

--- a/pkg/proc/linutil/auxv.go
+++ b/pkg/proc/linutil/auxv.go
@@ -1,0 +1,39 @@
+package linutil
+
+import (
+	"bytes"
+	"encoding/binary"
+)
+
+const (
+	_AT_NULL_AMD64  = 0
+	_AT_ENTRY_AMD64 = 9
+)
+
+// EntryPointFromAuxv searches the elf auxiliary vector for the entry point
+// address.
+// For a description of the auxiliary vector (auxv) format see:
+// System V Application Binary Interface, AMD64 Architecture Processor
+// Supplement, section 3.4.3
+func EntryPointFromAuxvAMD64(auxv []byte) uint64 {
+	rd := bytes.NewBuffer(auxv)
+
+	for {
+		var tag, val uint64
+		err := binary.Read(rd, binary.LittleEndian, &tag)
+		if err != nil {
+			return 0
+		}
+		err = binary.Read(rd, binary.LittleEndian, &val)
+		if err != nil {
+			return 0
+		}
+
+		switch tag {
+		case _AT_NULL_AMD64:
+			return 0
+		case _AT_ENTRY_AMD64:
+			return val
+		}
+	}
+}

--- a/pkg/proc/linutil/doc.go
+++ b/pkg/proc/linutil/doc.go
@@ -1,0 +1,4 @@
+// This package contains functions and data structures used by both the
+// linux implementation of the native backend and the core backend to deal
+// with structures used by the linux kernel.
+package linutil

--- a/pkg/proc/native/nonative_darwin.go
+++ b/pkg/proc/native/nonative_darwin.go
@@ -75,6 +75,10 @@ func (dbp *Process) detach(kill bool) error {
 	panic(ErrNativeBackendDisabled)
 }
 
+func (dbp *Process) entryPoint() (uint64, error) {
+	panic(ErrNativeBackendDisabled)
+}
+
 // Blocked returns true if the thread is blocked
 func (t *Thread) Blocked() bool {
 	panic(ErrNativeBackendDisabled)

--- a/pkg/proc/native/proc.go
+++ b/pkg/proc/native/proc.go
@@ -194,9 +194,14 @@ func (dbp *Process) LoadInformation(path string) error {
 
 	path = findExecutable(path, dbp.pid)
 
+	entryPoint, err := dbp.entryPoint()
+	if err != nil {
+		return err
+	}
+
 	wg.Add(1)
 	go dbp.loadProcessInformation(&wg)
-	err := dbp.bi.LoadBinaryInfo(path, &wg)
+	err = dbp.bi.LoadBinaryInfo(path, entryPoint, &wg)
 	wg.Wait()
 	if err == nil {
 		err = dbp.bi.LoadError()

--- a/pkg/proc/native/proc_darwin.go
+++ b/pkg/proc/native/proc_darwin.go
@@ -463,3 +463,8 @@ func (dbp *Process) stop(trapthread *Thread) (err error) {
 func (dbp *Process) detach(kill bool) error {
 	return PtraceDetach(dbp.pid, 0)
 }
+
+func (dbp *Process) entryPoint() (uint64, error) {
+	//TODO(aarzilli): implement this
+	return 0, nil
+}

--- a/pkg/proc/native/proc_linux.go
+++ b/pkg/proc/native/proc_linux.go
@@ -19,6 +19,7 @@ import (
 	sys "golang.org/x/sys/unix"
 
 	"github.com/derekparker/delve/pkg/proc"
+	"github.com/derekparker/delve/pkg/proc/linutil"
 	"github.com/mattn/go-isatty"
 )
 
@@ -476,6 +477,15 @@ func (dbp *Process) detach(kill bool) error {
 		sys.Kill(dbp.pid, sys.SIGCONT)
 	}
 	return nil
+}
+
+func (dbp *Process) entryPoint() (uint64, error) {
+	auxvbuf, err := ioutil.ReadFile(fmt.Sprintf("/proc/%d/auxv", dbp.pid))
+	if err != nil {
+		return 0, fmt.Errorf("could not read auxiliary vector: %v", err)
+	}
+
+	return linutil.EntryPointFromAuxvAMD64(auxvbuf), nil
 }
 
 func killProcess(pid int) error {

--- a/pkg/proc/native/proc_windows.go
+++ b/pkg/proc/native/proc_windows.go
@@ -20,6 +20,7 @@ import (
 type OSProcessDetails struct {
 	hProcess    syscall.Handle
 	breakThread int
+	entryPoint  uint64
 }
 
 func openExecutablePathPE(path string) (*pe.File, io.Closer, error) {
@@ -271,6 +272,7 @@ func (dbp *Process) waitForDebugEvent(flags waitForDebugEventFlags) (threadID, e
 					return 0, 0, err
 				}
 			}
+			dbp.os.entryPoint = uint64(debugInfo.BaseOfImage)
 			dbp.os.hProcess = debugInfo.Process
 			_, err = dbp.addThread(debugInfo.Thread, int(debugEvent.ThreadId), false, flags&waitSuspendNewThreads != 0)
 			if err != nil {
@@ -478,6 +480,10 @@ func (dbp *Process) detach(kill bool) error {
 		}
 	}
 	return _DebugActiveProcessStop(uint32(dbp.pid))
+}
+
+func (dbp *Process) entryPoint() (uint64, error) {
+	return dbp.os.entryPoint, nil
 }
 
 func killProcess(pid int) error {

--- a/pkg/proc/proc.go
+++ b/pkg/proc/proc.go
@@ -463,7 +463,7 @@ func GoroutinesInfo(dbp Process) ([]*G, error) {
 		}
 	}
 
-	addr, err := rdr.AddrFor("runtime.allglen")
+	addr, err := rdr.AddrFor("runtime.allglen", dbp.BinInfo().staticBase)
 	if err != nil {
 		return nil, err
 	}
@@ -475,10 +475,10 @@ func GoroutinesInfo(dbp Process) ([]*G, error) {
 	allglen := binary.LittleEndian.Uint64(allglenBytes)
 
 	rdr.Seek(0)
-	allgentryaddr, err := rdr.AddrFor("runtime.allgs")
+	allgentryaddr, err := rdr.AddrFor("runtime.allgs", dbp.BinInfo().staticBase)
 	if err != nil {
 		// try old name (pre Go 1.6)
-		allgentryaddr, err = rdr.AddrFor("runtime.allg")
+		allgentryaddr, err = rdr.AddrFor("runtime.allg", dbp.BinInfo().staticBase)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/proc/threads.go
+++ b/pkg/proc/threads.go
@@ -349,17 +349,17 @@ func removeInlinedCalls(dbp Process, pcs []uint64, topframe Stackframe) ([]uint6
 			return pcs, err
 		}
 		for _, rng := range ranges {
-			pcs = removePCsBetween(pcs, rng[0], rng[1])
+			pcs = removePCsBetween(pcs, rng[0], rng[1], bi.staticBase)
 		}
 		irdr.SkipChildren()
 	}
 	return pcs, irdr.Err()
 }
 
-func removePCsBetween(pcs []uint64, start, end uint64) []uint64 {
+func removePCsBetween(pcs []uint64, start, end, staticBase uint64) []uint64 {
 	out := pcs[:0]
 	for _, pc := range pcs {
-		if pc < start || pc >= end {
+		if pc < start+staticBase || pc >= end+staticBase {
 			out = append(out, pc)
 		}
 	}

--- a/pkg/proc/variables.go
+++ b/pkg/proc/variables.go
@@ -193,7 +193,7 @@ func (err *IsNilErr) Error() string {
 }
 
 func globalScope(bi *BinaryInfo, mem MemoryReadWriter) *EvalScope {
-	return &EvalScope{Location: Location{}, Regs: op.DwarfRegisters{}, Mem: mem, Gvar: nil, BinInfo: bi, frameOffset: 0}
+	return &EvalScope{Location: Location{}, Regs: op.DwarfRegisters{StaticBase: bi.staticBase}, Mem: mem, Gvar: nil, BinInfo: bi, frameOffset: 0}
 }
 
 func (scope *EvalScope) newVariable(name string, addr uintptr, dwarfType godwarf.Type, mem MemoryReadWriter) *Variable {
@@ -319,9 +319,12 @@ func newVariable(name string, addr uintptr, dwarfType godwarf.Type, bi *BinaryIn
 
 func resolveTypedef(typ godwarf.Type) godwarf.Type {
 	for {
-		if tt, ok := typ.(*godwarf.TypedefType); ok {
+		switch tt := typ.(type) {
+		case *godwarf.TypedefType:
 			typ = tt.Type
-		} else {
+		case *godwarf.QualType:
+			typ = tt.Type
+		default:
 			return typ
 		}
 	}
@@ -2046,7 +2049,7 @@ func (scope *EvalScope) Locals() ([]*Variable, error) {
 
 	var vars []*Variable
 	var depths []int
-	varReader := reader.Variables(scope.BinInfo.dwarf, scope.Fn.offset, scope.PC, scope.Line, true)
+	varReader := reader.Variables(scope.BinInfo.dwarf, scope.Fn.offset, reader.ToRelAddr(scope.PC, scope.BinInfo.staticBase), scope.Line, true)
 	hasScopes := false
 	for varReader.Next() {
 		entry := varReader.Entry()

--- a/service/test/integration1_test.go
+++ b/service/test/integration1_test.go
@@ -21,6 +21,12 @@ import (
 )
 
 func withTestClient1(name string, t *testing.T, fn func(c *rpc1.RPCClient)) {
+	withTestClient1Extended(name, t, func(c *rpc1.RPCClient, fixture protest.Fixture) {
+		fn(c)
+	})
+}
+
+func withTestClient1Extended(name string, t *testing.T, fn func(c *rpc1.RPCClient, fixture protest.Fixture)) {
 	if testBackend == "rr" {
 		protest.MustHaveRecordingAllowed(t)
 	}
@@ -29,9 +35,14 @@ func withTestClient1(name string, t *testing.T, fn func(c *rpc1.RPCClient)) {
 		t.Fatalf("couldn't start listener: %s\n", err)
 	}
 	defer listener.Close()
+	var buildFlags protest.BuildFlags
+	if buildMode == "pie" {
+		buildFlags = protest.BuildModePIE
+	}
+	fixture := protest.BuildFixture(name, buildFlags)
 	server := rpccommon.NewServer(&service.Config{
 		Listener:    listener,
-		ProcessArgs: []string{protest.BuildFixture(name, 0).Path},
+		ProcessArgs: []string{fixture.Path},
 		Backend:     testBackend,
 	})
 	if err := server.Run(); err != nil {
@@ -42,7 +53,7 @@ func withTestClient1(name string, t *testing.T, fn func(c *rpc1.RPCClient)) {
 		client.Detach(true)
 	}()
 
-	fn(client)
+	fn(client, fixture)
 }
 
 func Test1RunWithInvalidPath(t *testing.T) {
@@ -618,25 +629,24 @@ func Test1ClientServer_FindLocations(t *testing.T) {
 		findLocationHelper(t, c, "main.stacktraceme", false, 1, stacktracemeAddr)
 	})
 
-	withTestClient1("locationsUpperCase", t, func(c *rpc1.RPCClient) {
+	withTestClient1Extended("locationsUpperCase", t, func(c *rpc1.RPCClient, fixture protest.Fixture) {
 		// Upper case
 		findLocationHelper(t, c, "locationsUpperCase.go:6", false, 1, 0)
 
 		// Fully qualified path
-		path := protest.Fixtures[protest.FixtureKey{"locationsUpperCase", 0}].Source
-		findLocationHelper(t, c, path+":6", false, 1, 0)
-		bp, err := c.CreateBreakpoint(&api.Breakpoint{File: path, Line: 6})
+		findLocationHelper(t, c, fixture.Source+":6", false, 1, 0)
+		bp, err := c.CreateBreakpoint(&api.Breakpoint{File: fixture.Source, Line: 6})
 		if err != nil {
-			t.Fatalf("Could not set breakpoint in %s: %v\n", path, err)
+			t.Fatalf("Could not set breakpoint in %s: %v\n", fixture.Source, err)
 		}
 		c.ClearBreakpoint(bp.ID)
 
 		//  Allow `/` or `\` on Windows
 		if runtime.GOOS == "windows" {
-			findLocationHelper(t, c, filepath.FromSlash(path)+":6", false, 1, 0)
-			bp, err = c.CreateBreakpoint(&api.Breakpoint{File: filepath.FromSlash(path), Line: 6})
+			findLocationHelper(t, c, filepath.FromSlash(fixture.Source)+":6", false, 1, 0)
+			bp, err = c.CreateBreakpoint(&api.Breakpoint{File: filepath.FromSlash(fixture.Source), Line: 6})
 			if err != nil {
-				t.Fatalf("Could not set breakpoint in %s: %v\n", filepath.FromSlash(path), err)
+				t.Fatalf("Could not set breakpoint in %s: %v\n", filepath.FromSlash(fixture.Source), err)
 			}
 			c.ClearBreakpoint(bp.ID)
 		}
@@ -648,10 +658,10 @@ func Test1ClientServer_FindLocations(t *testing.T) {
 			shouldWrongCaseBeError = false
 			numExpectedMatches = 1
 		}
-		findLocationHelper(t, c, strings.ToLower(path)+":6", shouldWrongCaseBeError, numExpectedMatches, 0)
-		bp, err = c.CreateBreakpoint(&api.Breakpoint{File: strings.ToLower(path), Line: 6})
+		findLocationHelper(t, c, strings.ToLower(fixture.Source)+":6", shouldWrongCaseBeError, numExpectedMatches, 0)
+		bp, err = c.CreateBreakpoint(&api.Breakpoint{File: strings.ToLower(fixture.Source), Line: 6})
 		if (err == nil) == shouldWrongCaseBeError {
-			t.Fatalf("Could not set breakpoint in %s: %v\n", strings.ToLower(path), err)
+			t.Fatalf("Could not set breakpoint in %s: %v\n", strings.ToLower(fixture.Source), err)
 		}
 		c.ClearBreakpoint(bp.ID)
 	})

--- a/service/test/variables_test.go
+++ b/service/test/variables_test.go
@@ -107,7 +107,11 @@ func setVariable(p proc.Process, symbol, value string) error {
 }
 
 func withTestProcess(name string, t *testing.T, fn func(p proc.Process, fixture protest.Fixture)) {
-	fixture := protest.BuildFixture(name, 0)
+	var buildFlags protest.BuildFlags
+	if buildMode == "pie" {
+		buildFlags = protest.BuildModePIE
+	}
+	fixture := protest.BuildFixture(name, buildFlags)
 	var p proc.Process
 	var err error
 	var tracedir string


### PR DESCRIPTION
```
proc: support position independent executables (PIE)

Support for position independent executables (PIE) on the native linux
backend, the gdbserver backend on linux and the core backend.
Also implemented in the windows native backend, but it can't be tested
because go doesn't support PIE on windows yet.

```
