### PR TITLE
pkg/config, terminal/terminal.go: Add config (bool) 'source-list-line-bright'

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -43,6 +43,10 @@ type Config struct {
 	// If ShowLocationExpr is true whatis will print the DWARF location
 	// expression for its argument.
 	ShowLocationExpr bool `yaml:"show-location-expr"`
+	
+	// Source list line-number preference: dark (default, blue) or
+	// light (bright yellow)
+	SrcListLineColor bool `yaml:"source-list-line-bright"`
 }
 
 // LoadConfig attempts to populate a Config object from the config.yml file.
@@ -128,6 +132,10 @@ func writeDefaultConfig(f *os.File) error {
 
 # This is the default configuration file. Available options are provided, but disabled.
 # Delete the leading hash mark to enable an item.
+
+# Uncomment the following line to make line numbers in (list) command show bright yellow
+# rather than dark blue.. much better for old eyes in a black terminal.
+# source-list-line-bright: true
 
 # Provided aliases will be added to the default aliases for a given command.
 aliases:

--- a/pkg/terminal/terminal.go
+++ b/pkg/terminal/terminal.go
@@ -19,9 +19,15 @@ import (
 )
 
 const (
-	historyFile             string = ".dbg_history"
-	terminalBlueEscapeCode  string = "\033[34m"
-	terminalResetEscapeCode string = "\033[0m"
+	historyFile                    string = ".dbg_history"
+	terminalBlueEscapeCode         string = "\033[34m"
+	terminalBrightYellowEscapeCode string = "\033[93m"
+	terminalResetEscapeCode        string = "\033[0m"
+)
+
+var (
+	// Controlled by config 'source-list-line-bright' pref
+	terminalHighlightColor = terminalBlueEscapeCode
 )
 
 // Term represents the terminal running dlv.
@@ -158,6 +164,10 @@ func (t *Term) Run() (int, error) {
 		return
 	})
 
+	if t.conf.SrcListLineColor {
+		terminalHighlightColor = terminalBrightYellowEscapeCode
+	}
+
 	fullHistoryFile, err := config.GetConfigFilePath(historyFile)
 	if err != nil {
 		fmt.Printf("Unable to load history file: %v.", err)
@@ -217,7 +227,7 @@ func (t *Term) Run() (int, error) {
 // Println prints a line to the terminal.
 func (t *Term) Println(prefix, str string) {
 	if !t.dumb {
-		prefix = fmt.Sprintf("%s%s%s", terminalBlueEscapeCode, prefix, terminalResetEscapeCode)
+		prefix = fmt.Sprintf("%s%s%s", terminalHighlightColor, prefix, terminalResetEscapeCode)
 	}
 	fmt.Fprintf(t.stdout, "%s%s\n", prefix, str)
 }


### PR DESCRIPTION
This change adds a config flag to make the line numbers in the list command either
'dark' (false: blue) or 'bright' (true: bright yellow) as older eyes may have
difficulty with the dark blue ANSI on a Linux white-on-black xterm.
** No new unit tests were added as the feature seemed too trivial to warrant one
  (it depends just on the YAML parser's builtin capabilities)