### PR TITLE
Automate binary creation and changelog management with goreleaser.

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,0 +1,51 @@
+---
+project_name: delve
+
+release:
+  github:
+    owner: derekparker
+    name: delve
+
+builds:
+- binary: delve
+  goos:
+  - darwin
+  - windows
+  - linux
+  goarch:
+  - amd64
+  - 386
+  env:
+  - CGO_ENABLED=1
+  main: ./cmd/dlv/
+
+archive:
+  format: tar.gz
+  wrap_in_directory: true
+  format_overrides:
+  - goos: windows
+    format: zip
+  name_template: '{{ .Binary }}-{{ .Version }}-{{ .Os }}-{{ .Arch }}{{ if .Arm }}v{{ .Arm }}{{ end }}'
+  files:
+  - LICENSE
+  - README.md
+
+snapshot:
+  name_template: SNAPSHOT-{{ .Commit }}
+
+checksum:
+  name_template: '{{ .ProjectName }}-{{ .Version }}-checksums.txt'
+
+changelog:
+  sort: asc
+  filters:
+    exclude:
+    - '^docs:'
+    - '^test:'
+    - '^dev:'
+    - 'README'
+    - Merge pull request
+    - Merge branch
+
+git:
+  short_hash: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,3 +17,10 @@ matrix:
 
 before_install:
   - if [ $TRAVIS_OS_NAME = "linux" ]; then sudo apt-get -qq update; sudo apt-get install -y dwz; fi
+
+deploy:
+- provider: script
+  skip_cleanup: true
+  script: curl -sL https://git.io/goreleaser | bash
+  on:
+    tags: true


### PR DESCRIPTION
- Fixes #494 


Have configured the generation of binaries for following configurations

```yaml
  goos:
  - darwin
  - windows
  - linux
  goarch:
  - amd64
  - 386
```
Kindly let me know if i need to add more

Also i observed that you maintain a manual change log [here](https://github.com/derekparker/delve/blob/master/CHANGELOG.md). Have taken the liberty of automating that as well using [goreleaser](https://goreleaser.com/) config. Currently the change log excludes the following patterns

```
    - '^docs:'
    - '^test:'
    - '^dev:'
    - 'README'
    - Merge pull request
    - Merge branch
```

Do let me know if more tweaking is necessary to resemble the one you have created.
