### PR TITLE
service/rpccommon: remove duplicate `listener.close()`

### DIFF
--- a/service/rpccommon/server.go
+++ b/service/rpccommon/server.go
@@ -92,7 +92,6 @@ func NewServer(config *service.Config) *ServerImpl {
 func (s *ServerImpl) Stop() error {
 	if s.config.AcceptMulti {
 		close(s.stopChan)
-		s.listener.Close()
 	}
 	kill := s.config.AttachPid == 0
 	return s.debugger.Detach(kill)
@@ -146,7 +145,6 @@ func (s *ServerImpl) Run() error {
 	suitableMethods(rpcServer, s.methodMaps[1], s.log)
 
 	go func() {
-		defer s.listener.Close()
 		for {
 			c, err := s.listener.Accept()
 			if err != nil {


### PR DESCRIPTION
`defer listener.Close()` has existed in cmd/dlv/cmds/commands.go.
[commands.go#L483](https://github.com/derekparker/delve/blob/910f90c3c8274a38bea01c73419dec22902bb5e3/cmd/dlv/cmds/commands.go#L483)

In fact, `Close()` return err about repeat closure possibly.