### PR TITLE
cmd,service: remove temporary def of `Server interface` in func

### DIFF
--- a/cmd/dlv/cmds/commands.go
+++ b/cmd/dlv/cmds/commands.go
@@ -510,10 +510,7 @@ func execute(attachPid int, processArgs []string, conf *config.Config, coreFile 
 	}
 	defer listener.Close()
 
-	var server interface {
-		Run() error
-		Stop() error
-	}
+	var server service.Server
 
 	disconnectChan := make(chan struct{})
 

--- a/service/server.go
+++ b/service/server.go
@@ -4,5 +4,5 @@ package service
 // to connect to.
 type Server interface {
 	Run() error
-	Stop(bool) error
+	Stop() error
 }


### PR DESCRIPTION
Use the defination of `Server interface` in service package, instead of
temporary in func.