### PR TITLE
Miscellaneous one-line bugfixes

### DIFF
--- a/Documentation/cli/README.md
+++ b/Documentation/cli/README.md
@@ -93,7 +93,9 @@ Current limitations:
 ## check
 Creates a checkpoint at the current position.
 
-	checkpoint [where]
+	checkpoint [note]
+
+The "note" is arbitrary text that can be used to identify the checkpoint, if it is not specified it defaults to the current filename:line position.
 
 Aliases: checkpoint
 

--- a/_fixtures/issue1374.go
+++ b/_fixtures/issue1374.go
@@ -1,0 +1,12 @@
+package main
+
+import "fmt"
+
+func main() {
+	i := getNum()
+	fmt.Println(i)
+}
+
+func getNum() int {
+	return 0
+}

--- a/pkg/proc/gdbserial/gdbserver.go
+++ b/pkg/proc/gdbserial/gdbserver.go
@@ -697,6 +697,14 @@ continueLoop:
 		// process so we must stop here.
 		case 0x91, 0x92, 0x93, 0x94, 0x95, 0x96: /* TARGET_EXC_BAD_ACCESS */
 			break continueLoop
+
+		// Signal 0 is returned by rr when it reaches the start of the process
+		// in backward continue mode.
+		case 0:
+			if p.conn.direction == proc.Backward {
+				break continueLoop
+			}
+
 		default:
 			// any other signal is always propagated to inferior
 		}

--- a/pkg/proc/proc.go
+++ b/pkg/proc/proc.go
@@ -281,7 +281,7 @@ func stepInstructionOut(dbp Process, curthread Thread, fnname1, fnname2 string) 
 			if g := dbp.SelectedGoroutine(); g != nil {
 				g.CurrentLoc = *loc
 			}
-			return nil
+			return curthread.SetCurrentBreakpoint()
 		}
 	}
 }

--- a/pkg/terminal/command.go
+++ b/pkg/terminal/command.go
@@ -356,7 +356,9 @@ If locspec is omitted edit will open the current source file in the editor, othe
 			cmdFn:   checkpoint,
 			helpMsg: `Creates a checkpoint at the current position.
 
-	checkpoint [where]`,
+	checkpoint [note]
+
+The "note" is arbitrary text that can be used to identify the checkpoint, if it is not specified it defaults to the current filename:line position.`,
 		})
 		c.cmds = append(c.cmds, command{
 			aliases: []string{"checkpoints"},
@@ -1954,7 +1956,7 @@ func checkpoints(t *Term, ctx callContext, args string) error {
 	}
 	w := new(tabwriter.Writer)
 	w.Init(os.Stdout, 4, 4, 2, ' ', 0)
-	fmt.Fprintln(w, "ID\tWhen\tWhere")
+	fmt.Fprintln(w, "ID\tWhen\tNote")
 	for _, cp := range cps {
 		fmt.Fprintf(w, "c%d\t%s\t%s\n", cp.ID, cp.When, cp.Where)
 	}


### PR DESCRIPTION
```
proc/gdbserial: backward continue should stop at start of process

ContinueOnce didn't detect the way RR signals that it has reached the
start of the process and would never finish.

Fixes #1376

proc: Continue should always work after CallFunction

Continue did not resume execution after a call to CallFunction if the
point where the process was stopped, before the call CallFunction, was
a breakpoint.

Fixes #1374

Documentation: rename "where" parameter of checkpoint to "note"

The name "where" may confuse users into thinking that this parameter
actually does something where in fact it's just arbitrary text used to
identify the checkpoint.

Fixes #1373

```
