### PR TITLE
cmd: Fix trace bug when no package specified

### DIFF
--- a/cmd/dlv/cmds/commands.go
+++ b/cmd/dlv/cmds/commands.go
@@ -339,6 +339,7 @@ func traceCmd(cmd *cobra.Command, args []string) {
 			var dlvArgsLen = len(dlvArgs)
 			if dlvArgsLen == 1 {
 				regexp = args[0]
+				dlvArgs = dlvArgs[0:0]
 			} else if dlvArgsLen >= 2 {
 				regexp = dlvArgs[dlvArgsLen-1]
 				dlvArgs = dlvArgs[:dlvArgsLen-1]


### PR DESCRIPTION
Fix a bug where the regexp would be used as a package string
incorrectly. This would manifest when trying to execute the trace
subcommand as `dlv trace <regexp>` without specifying a package
identifier. The `<regexp>` would be passed to the Go build command
causing an error.