### PR TITLE
cmd: Add --exec and --test flags for trace sub cmd

### DIFF
--- a/Documentation/usage/dlv_trace.md
+++ b/Documentation/usage/dlv_trace.md
@@ -19,9 +19,11 @@ dlv trace [package] regexp
 ### Options
 
 ```
+  -e, --exec string     Binary file to exec and trace.
       --output string   Output path for the binary. (default "debug")
   -p, --pid int         Pid to attach to.
   -s, --stack int       Show stack trace with given depth.
+  -t, --test            Trace a test binary.
 ```
 
 ### Options inherited from parent commands

--- a/cmd/dlv/cmds/commands.go
+++ b/cmd/dlv/cmds/commands.go
@@ -339,6 +339,7 @@ func traceCmd(cmd *cobra.Command, args []string) {
 			var dlvArgsLen = len(dlvArgs)
 			if dlvArgsLen == 1 {
 				regexp = args[0]
+				dlvArgs = dlvArgs[0:0]
 			} else if dlvArgsLen >= 2 {
 				regexp = dlvArgs[dlvArgsLen-1]
 				dlvArgs = dlvArgs[:dlvArgsLen-1]


### PR DESCRIPTION

Adds an --exec flag for the trace subcommand allowing users to specify a
pre-compiled binary to exec and trace.

Also adds a --test flag as a convienance for compiling and tracing a
test binary.

Fixes #1073

Includes #1380 until it's merged then I will rebase.