### PR TITLE
proc/native: Mask MS_VC_EXCEPTION [windows]

### DIFF
--- a/pkg/proc/native/proc_windows.go
+++ b/pkg/proc/native/proc_windows.go
@@ -245,6 +245,8 @@ const (
 	waitDontHandleExceptions
 )
 
+const _MS_VC_EXCEPTION = 0x406D1388 // part of VisualC protocol to set thread names
+
 func (dbp *Process) waitForDebugEvent(flags waitForDebugEventFlags) (threadID, exitCode int, err error) {
 	var debugEvent _DEBUG_EVENT
 	shouldExit := false
@@ -346,6 +348,10 @@ func (dbp *Process) waitForDebugEvent(flags waitForDebugEventFlags) (threadID, e
 			case _EXCEPTION_SINGLE_STEP:
 				dbp.os.breakThread = tid
 				return tid, 0, nil
+			case _MS_VC_EXCEPTION:
+				// This exception is sent to set the thread name in VisualC, we should
+				// mask it or it might crash the program.
+				continueStatus = _DBG_CONTINUE
 			default:
 				continueStatus = _DBG_EXCEPTION_NOT_HANDLED
 			}


### PR DESCRIPTION
Some libraries (for example steam_api64.dll) will send this exception
code to set the thread name on Microsoft VisualC.
In theory it should be fine to send the exception back to the target,
which is responsible for setting a handler for it, in practice in some
cases (steam_api64.dll) this will crash the program. So we'll mask it
instead.

Fixes #1383
