### PR TITLE
Update to reflect -gcflags changes in go 1.10

### DIFF
--- a/Documentation/usage/dlv_exec.md
+++ b/Documentation/usage/dlv_exec.md
@@ -10,7 +10,7 @@ Execute a precompiled binary and begin a debug session.
 This command will cause Delve to exec the binary and immediately attach to it to
 begin a new debug session. Please note that if the binary was not compiled with
 optimizations disabled, it may be difficult to properly debug it. Please
-consider compiling debugging binaries with -gcflags="-N -l".
+consider compiling debugging binaries with ```-gcflags="-N -l"``` if you are using a go version below 1.10 or use```-gcflags="all=-N -l"``` for go 1.10 or above.
 
 ```
 dlv exec <path/to/binary>


### PR DESCRIPTION
Starting from golang 1.10 the -cflags changed in order to build all the files with debug flags you need to use ```-gcflags="all=-N -l"```
see:
https://golang.org/doc/go1.10#build