### PR TITLE
Fix 1353

### DIFF
--- a/cmd/dlv/cmds/commands.go
+++ b/cmd/dlv/cmds/commands.go
@@ -563,15 +563,16 @@ func execute(attachPid int, processArgs []string, conf *config.Config, coreFile 
 	switch APIVersion {
 	case 1, 2:
 		server = rpccommon.NewServer(&service.Config{
-			Listener:    listener,
-			ProcessArgs: processArgs,
-			AttachPid:   attachPid,
-			AcceptMulti: AcceptMulti,
-			APIVersion:  APIVersion,
-			WorkingDir:  WorkingDir,
-			Backend:     Backend,
-			CoreFile:    coreFile,
-			Foreground:  Headless,
+			Listener:             listener,
+			ProcessArgs:          processArgs,
+			AttachPid:            attachPid,
+			AcceptMulti:          AcceptMulti,
+			APIVersion:           APIVersion,
+			WorkingDir:           WorkingDir,
+			Backend:              Backend,
+			CoreFile:             coreFile,
+			Foreground:           Headless,
+			DebugInfoDirectories: conf.DebugInfoDirectories,
 
 			DisconnectChan: disconnectChan,
 		})

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -15,7 +15,7 @@ const (
 	configFile string = "config.yml"
 )
 
-// Describes a rule for substitution of path to source code file.
+// SubstitutePathRule describes a rule for substitution of path to source code file.
 type SubstitutePathRule struct {
 	// Directory path will be substituted if it matches `From`.
 	From string
@@ -23,7 +23,7 @@ type SubstitutePathRule struct {
 	To string
 }
 
-// Slice of source code path substitution rules.
+// SubstitutePathRules is a slice of source code path substitution rules.
 type SubstitutePathRules []SubstitutePathRule
 
 // Config defines all configuration options available to be set through the config file.
@@ -93,6 +93,8 @@ func LoadConfig() *Config {
 	return &c
 }
 
+// SaveConfig will marshal and save the config struct
+// to disk.
 func SaveConfig(conf *Config) error {
 	fullConfigFile, err := GetConfigFilePath(configFile)
 	if err != nil {
@@ -117,11 +119,11 @@ func SaveConfig(conf *Config) error {
 func createDefaultConfig(path string) (*os.File, error) {
 	f, err := os.Create(path)
 	if err != nil {
-		return nil, fmt.Errorf("Unable to create config file: %v.", err)
+		return nil, fmt.Errorf("unable to create config file: %v", err)
 	}
 	err = writeDefaultConfig(f)
 	if err != nil {
-		return nil, fmt.Errorf("Unable to write default configuration: %v.", err)
+		return nil, fmt.Errorf("unable to write default configuration: %v", err)
 	}
 	return f, nil
 }

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -43,10 +43,14 @@ type Config struct {
 	// If ShowLocationExpr is true whatis will print the DWARF location
 	// expression for its argument.
 	ShowLocationExpr bool `yaml:"show-location-expr"`
-	
+
 	// Source list line-number color (3/4 bit color codes as defined
 	// here: https://en.wikipedia.org/wiki/ANSI_escape_code#Colors)
 	SourceListLineColor int `yaml:"source-list-line-color"`
+
+	// DebugFileDirectories is the list of directories Delve will use
+	// in order to resolve external debug info files.
+	DebugInfoDirectories []string `yaml:"debug-info-directories"`
 }
 
 // LoadConfig attempts to populate a Config object from the config.yml file.
@@ -160,6 +164,9 @@ substitute-path:
 
 # Uncomment the following line to make the whatis command also print the DWARF location expression of its argument.
 # show-location-expr: true
+
+# List of directories to use when searching for separate debug info files.
+debug-info-directories: ["/usr/lib/debug/.build-id"]
 `)
 	return err
 }

--- a/pkg/config/split.go
+++ b/pkg/config/split.go
@@ -5,7 +5,7 @@ import (
 	"unicode"
 )
 
-// Like strings.Fields but ignores spaces inside areas surrounded
+// SplitQuotedFields is like strings.Fields but ignores spaces inside areas surrounded
 // by the specified quote character.
 // To specify a single quote use backslash to escape it: '\''
 func SplitQuotedFields(in string, quote rune) []string {

--- a/pkg/proc/bininfo.go
+++ b/pkg/proc/bininfo.go
@@ -27,25 +27,11 @@ import (
 
 // BinaryInfo holds information on the binary being executed.
 type BinaryInfo struct {
-	lastModified time.Time // Time the executable of this process was last modified
+	// Architecture of this binary.
+	Arch Arch
 
-	GOOS           string
-	closer         io.Closer
-	sepDebugCloser io.Closer
-
-	staticBase uint64
-
-	// Maps package names to package paths, needed to lookup types inside DWARF info
-	packageMap map[string]string
-
-	Arch          Arch
-	dwarf         *dwarf.Data
-	frameEntries  frame.FrameDescriptionEntries
-	loclist       loclistReader
-	compileUnits  []*compileUnit
-	types         map[string]dwarf.Offset
-	packageVars   []packageVar // packageVars is a list of all global/package variables in debug_info, sorted by address
-	gStructOffset uint64
+	// GOOS operating system this binary is executing on.
+	GOOS string
 
 	// Functions is a list of all DW_TAG_subprogram entries in debug_info, sorted by entry point
 	Functions []Function
@@ -54,7 +40,26 @@ type BinaryInfo struct {
 	// LookupFunc maps function names to a description of the function.
 	LookupFunc map[string]*Function
 
-	typeCache map[dwarf.Offset]godwarf.Type
+	lastModified time.Time // Time the executable of this process was last modified
+
+	closer         io.Closer
+	sepDebugCloser io.Closer
+
+	staticBase uint64
+
+	// Maps package names to package paths, needed to lookup types inside DWARF info
+	packageMap map[string]string
+
+	dwarf        *dwarf.Data
+	dwarfReader  *dwarf.Reader
+	frameEntries frame.FrameDescriptionEntries
+	loclist      loclistReader
+	compileUnits []*compileUnit
+	types        map[string]dwarf.Offset
+	packageVars  []packageVar // packageVars is a list of all global/package variables in debug_info, sorted by address
+	typeCache    map[dwarf.Offset]godwarf.Type
+
+	gStructOffset uint64
 
 	loadModuleDataOnce sync.Once
 	moduleData         []moduleData
@@ -71,8 +76,6 @@ type BinaryInfo struct {
 
 	loadErrMu sync.Mutex
 	loadErr   error
-
-	dwarfReader *dwarf.Reader
 }
 
 // ErrUnsupportedLinuxArch is returned when attempting to debug a binary compiled for an unsupported architecture.

--- a/pkg/proc/core/core.go
+++ b/pkg/proc/core/core.go
@@ -185,14 +185,16 @@ var (
 )
 
 // OpenCore will open the core file and return a Process struct.
-func OpenCore(corePath, exePath string) (*Process, error) {
+// If the DWARF information cannot be found in the binary, Delve will look
+// for external debug files in the directories passed in.
+func OpenCore(corePath, exePath string, debugInfoDirs []string) (*Process, error) {
 	p, err := readLinuxAMD64Core(corePath, exePath)
 	if err != nil {
 		return nil, err
 	}
 
 	var wg sync.WaitGroup
-	err = p.bi.LoadBinaryInfo(exePath, p.entryPoint, &wg)
+	err = p.bi.LoadBinaryInfo(exePath, p.entryPoint, debugInfoDirs, &wg)
 	wg.Wait()
 	if err == nil {
 		err = p.bi.LoadError()

--- a/pkg/proc/core/core_test.go
+++ b/pkg/proc/core/core_test.go
@@ -172,7 +172,7 @@ func withCoreFile(t *testing.T, name, args string) *Process {
 	}
 	corePath := cores[0]
 
-	p, err := OpenCore(corePath, fix.Path)
+	p, err := OpenCore(corePath, fix.Path, []string{})
 	if err != nil {
 		t.Errorf("ReadCore(%q) failed: %v", corePath, err)
 		pat, err := ioutil.ReadFile("/proc/sys/kernel/core_pattern")

--- a/pkg/proc/gdbserial/rr.go
+++ b/pkg/proc/gdbserial/rr.go
@@ -53,7 +53,7 @@ func Record(cmd []string, wd string, quiet bool) (tracedir string, err error) {
 
 // Replay starts an instance of rr in replay mode, with the specified trace
 // directory, and connects to it.
-func Replay(tracedir string, quiet bool) (*Process, error) {
+func Replay(tracedir string, quiet bool, debugInfoDirs []string) (*Process, error) {
 	if err := checkRRAvailabe(); err != nil {
 		return nil, err
 	}
@@ -82,7 +82,7 @@ func Replay(tracedir string, quiet bool) (*Process, error) {
 
 	p := New(rrcmd.Process)
 	p.tracedir = tracedir
-	err = p.Dial(init.port, init.exe, 0)
+	err = p.Dial(init.port, init.exe, 0, debugInfoDirs)
 	if err != nil {
 		rrcmd.Process.Kill()
 		return nil, err
@@ -257,11 +257,11 @@ func splitQuotedFields(in string) []string {
 }
 
 // RecordAndReplay acts like calling Record and then Replay.
-func RecordAndReplay(cmd []string, wd string, quiet bool) (p *Process, tracedir string, err error) {
+func RecordAndReplay(cmd []string, wd string, quiet bool, debugInfoDirs []string) (p *Process, tracedir string, err error) {
 	tracedir, err = Record(cmd, wd, quiet)
 	if tracedir == "" {
 		return nil, "", err
 	}
-	p, err = Replay(tracedir, quiet)
+	p, err = Replay(tracedir, quiet, debugInfoDirs)
 	return p, tracedir, err
 }

--- a/pkg/proc/gdbserial/rr_test.go
+++ b/pkg/proc/gdbserial/rr_test.go
@@ -30,7 +30,7 @@ func withTestRecording(name string, t testing.TB, fn func(p *gdbserial.Process, 
 		t.Skip("test skipped, rr not found")
 	}
 	t.Log("recording")
-	p, tracedir, err := gdbserial.RecordAndReplay([]string{fixture.Path}, ".", true)
+	p, tracedir, err := gdbserial.RecordAndReplay([]string{fixture.Path}, ".", true, []string{})
 	if err != nil {
 		t.Fatal("Launch():", err)
 	}

--- a/pkg/proc/native/nonative_darwin.go
+++ b/pkg/proc/native/nonative_darwin.go
@@ -12,12 +12,12 @@ import (
 var ErrNativeBackendDisabled = errors.New("native backend disabled during compilation")
 
 // Launch returns ErrNativeBackendDisabled.
-func Launch(cmd []string, wd string, foreground bool) (*Process, error) {
+func Launch(cmd []string, wd string, foreground bool, _ []string) (*Process, error) {
 	return nil, ErrNativeBackendDisabled
 }
 
 // Attach returns ErrNativeBackendDisabled.
-func Attach(pid int) (*Process, error) {
+func Attach(pid int, _ []string) (*Process, error) {
 	return nil, ErrNativeBackendDisabled
 }
 

--- a/pkg/proc/native/proc.go
+++ b/pkg/proc/native/proc.go
@@ -189,7 +189,7 @@ func (dbp *Process) Breakpoints() *proc.BreakpointMap {
 // * Dwarf .debug_frame section
 // * Dwarf .debug_line section
 // * Go symbol table.
-func (dbp *Process) LoadInformation(path string) error {
+func (dbp *Process) LoadInformation(path string, debugInfoDirs []string) error {
 	var wg sync.WaitGroup
 
 	path = findExecutable(path, dbp.pid)
@@ -201,7 +201,7 @@ func (dbp *Process) LoadInformation(path string) error {
 
 	wg.Add(1)
 	go dbp.loadProcessInformation(&wg)
-	err = dbp.bi.LoadBinaryInfo(path, entryPoint, &wg)
+	err = dbp.bi.LoadBinaryInfo(path, entryPoint, debugInfoDirs, &wg)
 	wg.Wait()
 	if err == nil {
 		err = dbp.bi.LoadError()
@@ -380,8 +380,8 @@ func (dbp *Process) FindBreakpoint(pc uint64) (*proc.Breakpoint, bool) {
 }
 
 // Returns a new Process struct.
-func initializeDebugProcess(dbp *Process, path string) (*Process, error) {
-	err := dbp.LoadInformation(path)
+func initializeDebugProcess(dbp *Process, path string, debugInfoDirs []string) (*Process, error) {
+	err := dbp.LoadInformation(path, debugInfoDirs)
 	if err != nil {
 		return dbp, err
 	}

--- a/pkg/proc/native/proc_darwin.go
+++ b/pkg/proc/native/proc_darwin.go
@@ -38,7 +38,7 @@ type OSProcessDetails struct {
 // custom fork/exec process in order to take advantage of
 // PT_SIGEXC on Darwin which will turn Unix signals into
 // Mach exceptions.
-func Launch(cmd []string, wd string, foreground bool) (*Process, error) {
+func Launch(cmd []string, wd string, foreground bool, _ []string) (*Process, error) {
 	// check that the argument to Launch is an executable file
 	if fi, staterr := os.Stat(cmd[0]); staterr == nil && (fi.Mode()&0111) == 0 {
 		return nil, proc.ErrNotExecutable
@@ -119,7 +119,7 @@ func Launch(cmd []string, wd string, foreground bool) (*Process, error) {
 	}
 
 	dbp.os.initialized = true
-	dbp, err = initializeDebugProcess(dbp, argv0Go)
+	dbp, err = initializeDebugProcess(dbp, argv0Go, []string{})
 	if err != nil {
 		return nil, err
 	}
@@ -132,7 +132,7 @@ func Launch(cmd []string, wd string, foreground bool) (*Process, error) {
 }
 
 // Attach to an existing process with the given PID.
-func Attach(pid int) (*Process, error) {
+func Attach(pid int, _ []string) (*Process, error) {
 	dbp := New(pid)
 
 	kret := C.acquire_mach_task(C.int(pid),
@@ -155,7 +155,7 @@ func Attach(pid int) (*Process, error) {
 		return nil, err
 	}
 
-	dbp, err = initializeDebugProcess(dbp, "")
+	dbp, err = initializeDebugProcess(dbp, "", []string{})
 	if err != nil {
 		dbp.Detach(false)
 		return nil, err

--- a/pkg/proc/native/proc_windows.go
+++ b/pkg/proc/native/proc_windows.go
@@ -37,7 +37,7 @@ func openExecutablePathPE(path string) (*pe.File, io.Closer, error) {
 }
 
 // Launch creates and begins debugging a new process.
-func Launch(cmd []string, wd string, foreground bool) (*Process, error) {
+func Launch(cmd []string, wd string, foreground bool, _ []string) (*Process, error) {
 	argv0Go, err := filepath.Abs(cmd[0])
 	if err != nil {
 		return nil, err
@@ -115,7 +115,7 @@ func newDebugProcess(dbp *Process, exepath string) (*Process, error) {
 		return nil, err
 	}
 
-	return initializeDebugProcess(dbp, exepath)
+	return initializeDebugProcess(dbp, exepath, []string{})
 }
 
 // findExePath searches for process pid, and returns its executable path.
@@ -153,7 +153,7 @@ func findExePath(pid int) (string, error) {
 }
 
 // Attach to an existing process with the given PID.
-func Attach(pid int) (*Process, error) {
+func Attach(pid int, _ []string) (*Process, error) {
 	// TODO: Probably should have SeDebugPrivilege before starting here.
 	err := _DebugActiveProcess(uint32(pid))
 	if err != nil {

--- a/pkg/proc/proc_linux_test.go
+++ b/pkg/proc/proc_linux_test.go
@@ -1,0 +1,39 @@
+package proc_test
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"testing"
+
+	"github.com/derekparker/delve/pkg/proc/native"
+	protest "github.com/derekparker/delve/pkg/proc/test"
+)
+
+func TestLoadingExternalDebugInfo(t *testing.T) {
+	fixture := protest.BuildFixture("locationsprog", 0)
+	defer os.Remove(fixture.Path)
+	stripAndCopyDebugInfo(fixture, t)
+	p, err := native.Launch(append([]string{fixture.Path}, ""), "", false, []string{filepath.Dir(fixture.Path)})
+	if err != nil {
+		t.Fatal(err)
+	}
+	p.Detach(true)
+}
+
+func stripAndCopyDebugInfo(f protest.Fixture, t *testing.T) {
+	name := filepath.Base(f.Path)
+	// Copy the debug information to an external file.
+	copyCmd := exec.Command("objcopy", "--only-keep-debug", name, name+".debug")
+	copyCmd.Dir = filepath.Dir(f.Path)
+	if err := copyCmd.Run(); err != nil {
+		t.Fatal(err)
+	}
+
+	// Strip the original binary of the debug information.
+	stripCmd := exec.Command("strip", "--strip-debug", "--strip-unneeded", name)
+	stripCmd.Dir = filepath.Dir(f.Path)
+	if err := stripCmd.Run(); err != nil {
+		t.Fatal(err)
+	}
+}

--- a/pkg/proc/proc_test.go
+++ b/pkg/proc/proc_test.go
@@ -66,13 +66,13 @@ func withTestProcessArgs(name string, t testing.TB, wd string, args []string, bu
 
 	switch testBackend {
 	case "native":
-		p, err = native.Launch(append([]string{fixture.Path}, args...), wd, false)
+		p, err = native.Launch(append([]string{fixture.Path}, args...), wd, false, []string{})
 	case "lldb":
-		p, err = gdbserial.LLDBLaunch(append([]string{fixture.Path}, args...), wd, false)
+		p, err = gdbserial.LLDBLaunch(append([]string{fixture.Path}, args...), wd, false, []string{})
 	case "rr":
 		protest.MustHaveRecordingAllowed(t)
 		t.Log("recording")
-		p, tracedir, err = gdbserial.RecordAndReplay(append([]string{fixture.Path}, args...), wd, true)
+		p, tracedir, err = gdbserial.RecordAndReplay(append([]string{fixture.Path}, args...), wd, true, []string{})
 		t.Logf("replaying %q", tracedir)
 	default:
 		t.Fatal("unknown backend")
@@ -2048,9 +2048,9 @@ func TestIssue509(t *testing.T) {
 
 	switch testBackend {
 	case "native":
-		_, err = native.Launch([]string{exepath}, ".", false)
+		_, err = native.Launch([]string{exepath}, ".", false, []string{})
 	case "lldb":
-		_, err = gdbserial.LLDBLaunch([]string{exepath}, ".", false)
+		_, err = gdbserial.LLDBLaunch([]string{exepath}, ".", false, []string{})
 	default:
 		t.Skip("test not valid for this backend")
 	}
@@ -2090,9 +2090,9 @@ func TestUnsupportedArch(t *testing.T) {
 
 	switch testBackend {
 	case "native":
-		p, err = native.Launch([]string{outfile}, ".", false)
+		p, err = native.Launch([]string{outfile}, ".", false, []string{})
 	case "lldb":
-		p, err = gdbserial.LLDBLaunch([]string{outfile}, ".", false)
+		p, err = gdbserial.LLDBLaunch([]string{outfile}, ".", false, []string{})
 	default:
 		t.Skip("test not valid for this backend")
 	}
@@ -2839,13 +2839,13 @@ func TestAttachDetach(t *testing.T) {
 
 	switch testBackend {
 	case "native":
-		p, err = native.Attach(cmd.Process.Pid)
+		p, err = native.Attach(cmd.Process.Pid, []string{})
 	case "lldb":
 		path := ""
 		if runtime.GOOS == "darwin" {
 			path = fixture.Path
 		}
-		p, err = gdbserial.LLDBAttach(cmd.Process.Pid, path)
+		p, err = gdbserial.LLDBAttach(cmd.Process.Pid, path, []string{})
 	default:
 		err = fmt.Errorf("unknown backend %q", testBackend)
 	}
@@ -3141,13 +3141,13 @@ func TestAttachStripped(t *testing.T) {
 
 	switch testBackend {
 	case "native":
-		p, err = native.Attach(cmd.Process.Pid)
+		p, err = native.Attach(cmd.Process.Pid, []string{})
 	case "lldb":
 		path := ""
 		if runtime.GOOS == "darwin" {
 			path = fixture.Path
 		}
-		p, err = gdbserial.LLDBAttach(cmd.Process.Pid, path)
+		p, err = gdbserial.LLDBAttach(cmd.Process.Pid, path, []string{})
 	default:
 		t.Fatalf("unknown backend %q", testBackend)
 	}

--- a/pkg/proc/types.go
+++ b/pkg/proc/types.go
@@ -180,7 +180,7 @@ func (v functionsDebugInfoByEntry) Swap(i, j int)      { v[i], v[j] = v[j], v[i]
 type compileUnitsByLowpc []*compileUnit
 
 func (v compileUnitsByLowpc) Len() int               { return len(v) }
-func (v compileUnitsByLowpc) Less(i int, j int) bool { return v[i].LowPC < v[j].LowPC }
+func (v compileUnitsByLowpc) Less(i int, j int) bool { return v[i].lowPC < v[j].lowPC }
 func (v compileUnitsByLowpc) Swap(i int, j int)      { v[i], v[j] = v[j], v[i] }
 
 type packageVarsByAddr []packageVar
@@ -230,18 +230,18 @@ outer:
 			if lang, _ := entry.Val(dwarf.AttrLanguage).(int64); lang == dwarfGoLanguage {
 				cu.isgo = true
 			}
-			cu.Name, _ = entry.Val(dwarf.AttrName).(string)
+			cu.name, _ = entry.Val(dwarf.AttrName).(string)
 			compdir, _ := entry.Val(dwarf.AttrCompDir).(string)
 			if compdir != "" {
-				cu.Name = filepath.Join(compdir, cu.Name)
+				cu.name = filepath.Join(compdir, cu.name)
 			}
-			cu.Ranges, _ = bi.dwarf.Ranges(entry)
-			for i := range cu.Ranges {
-				cu.Ranges[i][0] += bi.staticBase
-				cu.Ranges[i][1] += bi.staticBase
+			cu.ranges, _ = bi.dwarf.Ranges(entry)
+			for i := range cu.ranges {
+				cu.ranges[i][0] += bi.staticBase
+				cu.ranges[i][1] += bi.staticBase
 			}
-			if len(cu.Ranges) >= 1 {
-				cu.LowPC = cu.Ranges[0][0]
+			if len(cu.ranges) >= 1 {
+				cu.lowPC = cu.ranges[0][0]
 			}
 			lineInfoOffset, _ := entry.Val(dwarf.AttrStmtList).(int64)
 			if lineInfoOffset >= 0 && lineInfoOffset < int64(len(debugLineBytes)) {

--- a/service/config.go
+++ b/service/config.go
@@ -29,6 +29,10 @@ type Config struct {
 	// CoreFile specifies the path to the core dump to open.
 	CoreFile string
 
+	// DebugInfoDirectories is the list of directories to look for
+	// when resolving external debug info files.
+	DebugInfoDirectories []string
+
 	// Selects server backend.
 	Backend string
 

--- a/service/rpccommon/server.go
+++ b/service/rpccommon/server.go
@@ -121,11 +121,12 @@ func (s *ServerImpl) Run() error {
 
 	// Create and start the debugger
 	if s.debugger, err = debugger.New(&debugger.Config{
-		AttachPid:  s.config.AttachPid,
-		WorkingDir: s.config.WorkingDir,
-		CoreFile:   s.config.CoreFile,
-		Backend:    s.config.Backend,
-		Foreground: s.config.Foreground,
+		AttachPid:            s.config.AttachPid,
+		WorkingDir:           s.config.WorkingDir,
+		CoreFile:             s.config.CoreFile,
+		Backend:              s.config.Backend,
+		Foreground:           s.config.Foreground,
+		DebugInfoDirectories: s.config.DebugInfoDirectories,
 	},
 		s.config.ProcessArgs); err != nil {
 		return err

--- a/service/test/variables_test.go
+++ b/service/test/variables_test.go
@@ -117,13 +117,13 @@ func withTestProcess(name string, t *testing.T, fn func(p proc.Process, fixture 
 	var tracedir string
 	switch testBackend {
 	case "native":
-		p, err = native.Launch([]string{fixture.Path}, ".", false)
+		p, err = native.Launch([]string{fixture.Path}, ".", false, []string{})
 	case "lldb":
-		p, err = gdbserial.LLDBLaunch([]string{fixture.Path}, ".", false)
+		p, err = gdbserial.LLDBLaunch([]string{fixture.Path}, ".", false, []string{})
 	case "rr":
 		protest.MustHaveRecordingAllowed(t)
 		t.Log("recording")
-		p, tracedir, err = gdbserial.RecordAndReplay([]string{fixture.Path}, ".", true)
+		p, tracedir, err = gdbserial.RecordAndReplay([]string{fixture.Path}, ".", true, []string{})
 		t.Logf("replaying %q", tracedir)
 	default:
 		t.Fatalf("unknown backend %q", testBackend)


### PR DESCRIPTION
Adds a config file option to allow specifying a list of directories to
search in when looking for seperate external debug info files.

Fixes #1353