### PR TITLE
proc/proc: Extend GoroutinesInfo to allow specifying a range

### DIFF
--- a/pkg/proc/core/core_test.go
+++ b/pkg/proc/core/core_test.go
@@ -190,7 +190,7 @@ func TestCore(t *testing.T) {
 	}
 	p := withCoreFile(t, "panic", "")
 
-	gs, err := proc.GoroutinesInfo(p)
+	gs, _, err := proc.GoroutinesInfo(p, 0, 0)
 	if err != nil || len(gs) == 0 {
 		t.Fatalf("GoroutinesInfo() = %v, %v; wanted at least one goroutine", gs, err)
 	}
@@ -260,7 +260,7 @@ func TestCoreFpRegisters(t *testing.T) {
 
 	p := withCoreFile(t, "fputest/", "panic")
 
-	gs, err := proc.GoroutinesInfo(p)
+	gs, _, err := proc.GoroutinesInfo(p, 0, 0)
 	if err != nil || len(gs) == 0 {
 		t.Fatalf("GoroutinesInfo() = %v, %v; wanted at least one goroutine", gs, err)
 	}
@@ -337,7 +337,7 @@ func TestCoreWithEmptyString(t *testing.T) {
 	}
 	p := withCoreFile(t, "coreemptystring", "")
 
-	gs, err := proc.GoroutinesInfo(p)
+	gs, _, err := proc.GoroutinesInfo(p, 0, 0)
 	assertNoError(err, t, "GoroutinesInfo")
 
 	var mainFrame *proc.Stackframe

--- a/pkg/proc/proc_test.go
+++ b/pkg/proc/proc_test.go
@@ -920,7 +920,7 @@ func TestStacktraceGoroutine(t *testing.T) {
 
 		assertNoError(proc.Continue(p), t, "Continue()")
 
-		gs, err := proc.GoroutinesInfo(p)
+		gs, _, err := proc.GoroutinesInfo(p, 0, 0)
 		assertNoError(err, t, "GoroutinesInfo")
 
 		agoroutineCount := 0
@@ -1239,7 +1239,7 @@ func TestFrameEvaluation(t *testing.T) {
 		t.Logf("stopped on thread %d, goroutine: %#v", p.CurrentThread().ThreadID(), p.SelectedGoroutine())
 
 		// Testing evaluation on goroutines
-		gs, err := proc.GoroutinesInfo(p)
+		gs, _, err := proc.GoroutinesInfo(p, 0, 0)
 		assertNoError(err, t, "GoroutinesInfo")
 		found := make([]bool, 10)
 		for _, g := range gs {
@@ -1523,7 +1523,7 @@ func BenchmarkGoroutinesInfo(b *testing.B) {
 		assertNoError(proc.Continue(p), b, "Continue()")
 		for i := 0; i < b.N; i++ {
 			p.Common().ClearAllGCache()
-			_, err := proc.GoroutinesInfo(p)
+			_, _, err := proc.GoroutinesInfo(p, 0, 0)
 			assertNoError(err, b, "GoroutinesInfo")
 		}
 	})
@@ -1953,7 +1953,7 @@ func TestNextParked(t *testing.T) {
 			}
 			assertNoError(err, t, "Continue()")
 
-			gs, err := proc.GoroutinesInfo(p)
+			gs, _, err := proc.GoroutinesInfo(p, 0, 0)
 			assertNoError(err, t, "GoroutinesInfo()")
 
 			// Search for a parked goroutine that we know for sure will have to be
@@ -2005,7 +2005,7 @@ func TestStepParked(t *testing.T) {
 			}
 			assertNoError(err, t, "Continue()")
 
-			gs, err := proc.GoroutinesInfo(p)
+			gs, _, err := proc.GoroutinesInfo(p, 0, 0)
 			assertNoError(err, t, "GoroutinesInfo()")
 
 			for _, g := range gs {
@@ -2729,7 +2729,7 @@ func TestStacktraceWithBarriers(t *testing.T) {
 				return
 			}
 			assertNoError(err, t, "Continue()")
-			gs, err := proc.GoroutinesInfo(p)
+			gs, _, err := proc.GoroutinesInfo(p, 0, 0)
 			assertNoError(err, t, "GoroutinesInfo()")
 			for _, th := range p.ThreadList() {
 				if bp := th.Breakpoint(); bp.Breakpoint == nil {
@@ -2760,7 +2760,7 @@ func TestStacktraceWithBarriers(t *testing.T) {
 
 		assertNoError(proc.StepOut(p), t, "StepOut()")
 
-		gs, err := proc.GoroutinesInfo(p)
+		gs, _, err := proc.GoroutinesInfo(p, 0, 0)
 		assertNoError(err, t, "GoroutinesInfo()")
 
 		for _, goid := range stackBarrierGoids {

--- a/pkg/proc/variable_test.go
+++ b/pkg/proc/variable_test.go
@@ -15,7 +15,7 @@ func TestGoroutineCreationLocation(t *testing.T) {
 		assertNoError(err, t, "BreakByLocation()")
 		assertNoError(proc.Continue(p), t, "Continue()")
 
-		gs, err := proc.GoroutinesInfo(p)
+		gs, _, err := proc.GoroutinesInfo(p, 0, 0)
 		assertNoError(err, t, "GoroutinesInfo")
 
 		for _, g := range gs {

--- a/service/client.go
+++ b/service/client.go
@@ -95,7 +95,7 @@ type Client interface {
 	ListRegisters(threadID int, includeFp bool) (api.Registers, error)
 
 	// ListGoroutines lists all goroutines.
-	ListGoroutines() ([]*api.Goroutine, error)
+	ListGoroutines(start, count int) ([]*api.Goroutine, int, error)
 
 	// Returns stacktrace
 	Stacktrace(goroutineID int, depth int, readDefers bool, cfg *api.LoadConfig) ([]api.Stackframe, error)

--- a/service/debugger/debugger.go
+++ b/service/debugger/debugger.go
@@ -907,19 +907,19 @@ func (d *Debugger) SetVariableInScope(scope api.EvalScope, symbol, value string)
 }
 
 // Goroutines will return a list of goroutines in the target process.
-func (d *Debugger) Goroutines() ([]*api.Goroutine, error) {
+func (d *Debugger) Goroutines(start, count int) ([]*api.Goroutine, int, error) {
 	d.processMutex.Lock()
 	defer d.processMutex.Unlock()
 
 	goroutines := []*api.Goroutine{}
-	gs, err := proc.GoroutinesInfo(d.target)
+	gs, nextg, err := proc.GoroutinesInfo(d.target, start, count)
 	if err != nil {
-		return nil, err
+		return nil, 0, err
 	}
 	for _, g := range gs {
 		goroutines = append(goroutines, api.ConvertGoroutine(g))
 	}
-	return goroutines, err
+	return goroutines, nextg, err
 }
 
 // Stacktrace returns a list of Stackframes for the given goroutine. The

--- a/service/rpc1/server.go
+++ b/service/rpc1/server.go
@@ -283,7 +283,7 @@ func (s *RPCServer) ListTypes(filter string, types *[]string) error {
 }
 
 func (s *RPCServer) ListGoroutines(arg interface{}, goroutines *[]*api.Goroutine) error {
-	gs, err := s.debugger.Goroutines()
+	gs, _, err := s.debugger.Goroutines(0, 0)
 	if err != nil {
 		return err
 	}

--- a/service/rpc2/client.go
+++ b/service/rpc2/client.go
@@ -298,10 +298,10 @@ func (c *RPCClient) ListFunctionArgs(scope api.EvalScope, cfg api.LoadConfig) ([
 	return out.Args, err
 }
 
-func (c *RPCClient) ListGoroutines() ([]*api.Goroutine, error) {
+func (c *RPCClient) ListGoroutines(start, count int) ([]*api.Goroutine, int, error) {
 	var out ListGoroutinesOut
-	err := c.call("ListGoroutines", ListGoroutinesIn{}, &out)
-	return out.Goroutines, err
+	err := c.call("ListGoroutines", ListGoroutinesIn{start, count}, &out)
+	return out.Goroutines, out.Nextg, err
 }
 
 func (c *RPCClient) Stacktrace(goroutineId, depth int, readDefers bool, cfg *api.LoadConfig) ([]api.Stackframe, error) {

--- a/service/rpc2/server.go
+++ b/service/rpc2/server.go
@@ -508,19 +508,23 @@ func (s *RPCServer) ListTypes(arg ListTypesIn, out *ListTypesOut) error {
 }
 
 type ListGoroutinesIn struct {
+	Start int
+	Count int
 }
 
 type ListGoroutinesOut struct {
 	Goroutines []*api.Goroutine
+	Nextg      int
 }
 
 // ListGoroutines lists all goroutines.
 func (s *RPCServer) ListGoroutines(arg ListGoroutinesIn, out *ListGoroutinesOut) error {
-	gs, err := s.debugger.Goroutines()
+	gs, nextg, err := s.debugger.Goroutines(arg.Start, arg.Count)
 	if err != nil {
 		return err
 	}
 	out.Goroutines = gs
+	out.Nextg = nextg
 	return nil
 }
 

--- a/service/test/integration2_test.go
+++ b/service/test/integration2_test.go
@@ -801,7 +801,7 @@ func TestClientServer_FullStacktrace(t *testing.T) {
 			t.Fatalf("Continue(): %v\n", state.Err)
 		}
 
-		gs, err := c.ListGoroutines()
+		gs, _, err := c.ListGoroutines(0, 0)
 		assertNoError(err, t, "GoroutinesInfo()")
 		found := make([]bool, 10)
 		for _, g := range gs {
@@ -916,7 +916,7 @@ func TestIssue355(t *testing.T) {
 		assertError(err, t, "ListFunctionArgs()")
 		_, err = c.ListRegisters(0, false)
 		assertError(err, t, "ListRegisters()")
-		_, err = c.ListGoroutines()
+		_, _, err = c.ListGoroutines(0, 0)
 		assertError(err, t, "ListGoroutines()")
 		_, err = c.Stacktrace(gid, 10, false, &normalLoadConfig)
 		assertError(err, t, "Stacktrace()")


### PR DESCRIPTION
Instead of unconditionally returning all present goroutines,
GoroutinesInfo now allows specifying a range (start and count). In
addition to the array of goroutines and the error, it now also returns
the next goroutine to be processed, to be used as 'start' argument on
the next call, or 0 if all present goroutines have already been
processed.

This way clients can avoid eating large amounts of RAM while debugging
core dumps and processes with a exceptionally high amount of goroutines.

Fixes #1403