### PR TITLE
pkg/proc: Refactor process post initialization

### DIFF
--- a/cmd/dlv/dlv_test.go
+++ b/cmd/dlv/dlv_test.go
@@ -30,6 +30,9 @@ func TestMain(m *testing.M) {
 		testBackend = os.Getenv("PROCTEST")
 		if testBackend == "" {
 			testBackend = "native"
+			if runtime.GOOS == "darwin" {
+				testBackend = "lldb"
+			}
 		}
 	}
 	os.Exit(m.Run())
@@ -83,8 +86,10 @@ func TestBuild(t *testing.T) {
 	scan := bufio.NewScanner(stderr)
 	// wait for the debugger to start
 	scan.Scan()
+	t.Log(scan.Text())
 	go func() {
 		for scan.Scan() {
+			t.Log(scan.Text())
 			// keep pipe empty
 		}
 	}()

--- a/pkg/proc/bininfo.go
+++ b/pkg/proc/bininfo.go
@@ -304,20 +304,22 @@ func NewBinaryInfo(goos, goarch string) *BinaryInfo {
 // LoadBinaryInfo will load and store the information from the binary at 'path'.
 // It is expected this will be called in parallel with other initialization steps
 // so a sync.WaitGroup must be provided.
-func (bi *BinaryInfo) LoadBinaryInfo(path string, entryPoint uint64, debugInfoDirs []string, wg *sync.WaitGroup) error {
+func (bi *BinaryInfo) LoadBinaryInfo(path string, entryPoint uint64, debugInfoDirs []string) error {
 	fi, err := os.Stat(path)
 	if err == nil {
 		bi.lastModified = fi.ModTime()
 	}
 
+	var wg sync.WaitGroup
+	defer wg.Wait()
 	bi.Path = path
 	switch bi.GOOS {
 	case "linux":
-		return bi.LoadBinaryInfoElf(path, entryPoint, debugInfoDirs, wg)
+		return bi.LoadBinaryInfoElf(path, entryPoint, debugInfoDirs, &wg)
 	case "windows":
-		return bi.LoadBinaryInfoPE(path, entryPoint, wg)
+		return bi.LoadBinaryInfoPE(path, entryPoint, &wg)
 	case "darwin":
-		return bi.LoadBinaryInfoMacho(path, entryPoint, wg)
+		return bi.LoadBinaryInfoMacho(path, entryPoint, &wg)
 	}
 	return errors.New("unsupported operating system")
 }

--- a/pkg/proc/breakpoints.go
+++ b/pkg/proc/breakpoints.go
@@ -221,13 +221,16 @@ func (bpmap *BreakpointMap) ResetBreakpointIDCounter() {
 	bpmap.breakpointIDCounter = 0
 }
 
-type writeBreakpointFn func(addr uint64) (file string, line int, fn *Function, originalData []byte, err error)
+// WriteBreakpointFn is a type that represents a function to be used for
+// writting breakpoings into the target.
+type WriteBreakpointFn func(addr uint64) (file string, line int, fn *Function, originalData []byte, err error)
+
 type clearBreakpointFn func(*Breakpoint) error
 
 // Set creates a breakpoint at addr calling writeBreakpoint. Do not call this
 // function, call proc.Process.SetBreakpoint instead, this function exists
 // to implement proc.Process.SetBreakpoint.
-func (bpmap *BreakpointMap) Set(addr uint64, kind BreakpointKind, cond ast.Expr, writeBreakpoint writeBreakpointFn) (*Breakpoint, error) {
+func (bpmap *BreakpointMap) Set(addr uint64, kind BreakpointKind, cond ast.Expr, writeBreakpoint WriteBreakpointFn) (*Breakpoint, error) {
 	if bp, ok := bpmap.M[addr]; ok {
 		// We can overlap one internal breakpoint with one user breakpoint, we
 		// need to support this otherwise a conditional breakpoint can mask a
@@ -275,7 +278,7 @@ func (bpmap *BreakpointMap) Set(addr uint64, kind BreakpointKind, cond ast.Expr,
 }
 
 // SetWithID creates a breakpoint at addr, with the specified ID.
-func (bpmap *BreakpointMap) SetWithID(id int, addr uint64, writeBreakpoint writeBreakpointFn) (*Breakpoint, error) {
+func (bpmap *BreakpointMap) SetWithID(id int, addr uint64, writeBreakpoint WriteBreakpointFn) (*Breakpoint, error) {
 	bp, err := bpmap.Set(addr, UserBreakpoint, nil, writeBreakpoint)
 	if err == nil {
 		bp.ID = id

--- a/pkg/proc/core/core_test.go
+++ b/pkg/proc/core/core_test.go
@@ -174,7 +174,7 @@ func withCoreFile(t *testing.T, name, args string) *Process {
 
 	p, err := OpenCore(corePath, fix.Path, []string{})
 	if err != nil {
-		t.Errorf("ReadCore(%q) failed: %v", corePath, err)
+		t.Errorf("OpenCore(%q) failed: %v", corePath, err)
 		pat, err := ioutil.ReadFile("/proc/sys/kernel/core_pattern")
 		t.Errorf("read core_pattern: %q, %v", pat, err)
 		apport, err := ioutil.ReadFile("/var/log/apport.log")

--- a/pkg/proc/interface.go
+++ b/pkg/proc/interface.go
@@ -68,6 +68,7 @@ type Info interface {
 	// ErrProcessExited or ProcessDetachedError).
 	Valid() (bool, error)
 	BinInfo() *BinaryInfo
+	EntryPoint() (uint64, error)
 	// Common returns a struct with fields common to all backends
 	Common() *CommonProcess
 
@@ -86,6 +87,7 @@ type ThreadInfo interface {
 // GoroutineInfo is an interface for getting information on running goroutines.
 type GoroutineInfo interface {
 	SelectedGoroutine() *G
+	SetSelectedGoroutine(*G)
 }
 
 // ProcessManipulation is an interface for changing the execution state of a process.

--- a/pkg/proc/native/nonative_darwin.go
+++ b/pkg/proc/native/nonative_darwin.go
@@ -75,7 +75,9 @@ func (dbp *Process) detach(kill bool) error {
 	panic(ErrNativeBackendDisabled)
 }
 
-func (dbp *Process) entryPoint() (uint64, error) {
+// EntryPoint returns the entry point for the process,
+// useful for PIEs.
+func (dbp *Process) EntryPoint() (uint64, error) {
 	panic(ErrNativeBackendDisabled)
 }
 
@@ -85,17 +87,17 @@ func (t *Thread) Blocked() bool {
 }
 
 // SetPC sets the value of the PC register.
-func (thread *Thread) SetPC(pc uint64) error {
+func (t *Thread) SetPC(pc uint64) error {
 	panic(ErrNativeBackendDisabled)
 }
 
 // SetSP sets the value of the SP register.
-func (thread *Thread) SetSP(sp uint64) error {
+func (t *Thread) SetSP(sp uint64) error {
 	panic(ErrNativeBackendDisabled)
 }
 
 // SetDX sets the value of the DX register.
-func (thread *Thread) SetDX(dx uint64) error {
+func (t *Thread) SetDX(dx uint64) error {
 	panic(ErrNativeBackendDisabled)
 }
 
@@ -126,3 +128,5 @@ func (t *Thread) restoreRegisters(sr proc.Registers) error {
 func (t *Thread) Stopped() bool {
 	panic(ErrNativeBackendDisabled)
 }
+
+func initialize(dbp *Process) error { return nil }

--- a/pkg/proc/native/proc_darwin.go
+++ b/pkg/proc/native/proc_darwin.go
@@ -13,7 +13,6 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
-	"sync"
 	"unsafe"
 
 	sys "golang.org/x/sys/unix"
@@ -119,7 +118,7 @@ func Launch(cmd []string, wd string, foreground bool, _ []string) (*Process, err
 	}
 
 	dbp.os.initialized = true
-	dbp, err = initializeDebugProcess(dbp, argv0Go, []string{})
+	err = dbp.initialize(argv0Go, []string{})
 	if err != nil {
 		return nil, err
 	}
@@ -155,7 +154,7 @@ func Attach(pid int, _ []string) (*Process, error) {
 		return nil, err
 	}
 
-	dbp, err = initializeDebugProcess(dbp, "", []string{})
+	err = dbp.initialize("", []string{})
 	if err != nil {
 		dbp.Detach(false)
 		return nil, err
@@ -383,10 +382,6 @@ func (dbp *Process) waitForStop() ([]int, error) {
 	}
 }
 
-func (dbp *Process) loadProcessInformation(wg *sync.WaitGroup) {
-	wg.Done()
-}
-
 func (dbp *Process) wait(pid, options int) (int, *sys.WaitStatus, error) {
 	var status sys.WaitStatus
 	wpid, err := sys.Wait4(pid, &status, options, nil)
@@ -464,7 +459,9 @@ func (dbp *Process) detach(kill bool) error {
 	return PtraceDetach(dbp.pid, 0)
 }
 
-func (dbp *Process) entryPoint() (uint64, error) {
+func (dbp *Process) EntryPoint() (uint64, error) {
 	//TODO(aarzilli): implement this
 	return 0, nil
 }
+
+func initialize(dbp *Process) error { return nil }

--- a/pkg/proc/native/proc_windows.go
+++ b/pkg/proc/native/proc_windows.go
@@ -7,7 +7,6 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
-	"sync"
 	"syscall"
 	"unsafe"
 
@@ -77,11 +76,14 @@ func Launch(cmd []string, wd string, foreground bool, _ []string) (*Process, err
 	dbp.pid = p.Pid
 	dbp.childProcess = true
 
-	return newDebugProcess(dbp, argv0Go)
+	if err = dbp.initialize(argv0Go, []string{}); err != nil {
+		dbp.Detach(true)
+		return nil, err
+	}
+	return dbp, nil
 }
 
-// newDebugProcess prepares process pid for debugging.
-func newDebugProcess(dbp *Process, exepath string) (*Process, error) {
+func initialize(dbp *Process) error {
 	// It should not actually be possible for the
 	// call to waitForDebugEvent to fail, since Windows
 	// will always fire a CREATE_PROCESS_DEBUG_EVENT event
@@ -93,29 +95,25 @@ func newDebugProcess(dbp *Process, exepath string) (*Process, error) {
 		tid, exitCode, err = dbp.waitForDebugEvent(waitBlocking)
 	})
 	if err != nil {
-		return nil, err
+		return err
 	}
 	if tid == 0 {
 		dbp.postExit()
-		return nil, proc.ErrProcessExited{Pid: dbp.pid, Status: exitCode}
+		return proc.ErrProcessExited{Pid: dbp.pid, Status: exitCode}
 	}
 	// Suspend all threads so that the call to _ContinueDebugEvent will
 	// not resume the target.
 	for _, thread := range dbp.threads {
 		_, err := _SuspendThread(thread.os.hThread)
 		if err != nil {
-			return nil, err
+			return err
 		}
 	}
 
 	dbp.execPtraceFunc(func() {
 		err = _ContinueDebugEvent(uint32(dbp.pid), uint32(dbp.os.breakThread), _DBG_CONTINUE)
 	})
-	if err != nil {
-		return nil, err
-	}
-
-	return initializeDebugProcess(dbp, exepath, []string{})
+	return err
 }
 
 // findExePath searches for process pid, and returns its executable path.
@@ -163,11 +161,9 @@ func Attach(pid int, _ []string) (*Process, error) {
 	if err != nil {
 		return nil, err
 	}
-	dbp, err := newDebugProcess(New(pid), exepath)
-	if err != nil {
-		if dbp != nil {
-			dbp.Detach(false)
-		}
+	dbp := New(pid)
+	if err = dbp.initialize(exepath, []string{}); err != nil {
+		dbp.Detach(true)
 		return nil, err
 	}
 	return dbp, nil
@@ -392,10 +388,6 @@ func (dbp *Process) trapWait(pid int) (*Thread, error) {
 	return th, nil
 }
 
-func (dbp *Process) loadProcessInformation(wg *sync.WaitGroup) {
-	wg.Done()
-}
-
 func (dbp *Process) wait(pid, options int) (int, *sys.WaitStatus, error) {
 	return 0, nil, fmt.Errorf("not implemented: wait")
 }
@@ -488,7 +480,7 @@ func (dbp *Process) detach(kill bool) error {
 	return _DebugActiveProcessStop(uint32(dbp.pid))
 }
 
-func (dbp *Process) entryPoint() (uint64, error) {
+func (dbp *Process) EntryPoint() (uint64, error) {
 	return dbp.os.entryPoint, nil
 }
 

--- a/pkg/proc/proc.go
+++ b/pkg/proc/proc.go
@@ -62,14 +62,6 @@ func PostInitializationSetup(p Process, path string, debugInfoDirs []string, wri
 
 	createUnrecoveredPanicBreakpoint(p, writeBreakpoint)
 
-	panicpc, err := FindFunctionLocation(p, "runtime.startpanic", true, 0)
-	if err == nil {
-		bp, err := p.Breakpoints().SetWithID(-1, panicpc, writeBreakpoint)
-		if err == nil {
-			bp.Name = UnrecoveredPanic
-			bp.Variables = []string{"runtime.curg._panic.arg"}
-		}
-	}
 	return nil
 }
 


### PR DESCRIPTION
This patch is a slight refactor to share more code used for generic
process initialization. There will always be OS/backend specific
initialization, but as much as can be shared should be to prevent
duplicating of any logic (setting internal breakpoints, loading bininfo,
etc).