### PR TITLE
Early Go 1.12 support

### DIFF
--- a/_fixtures/cgostacktest/main.go
+++ b/_fixtures/cgostacktest/main.go
@@ -1,6 +1,6 @@
 package main
 
-// #include <hello.h>
+// #include "hello.h"
 import "C"
 
 import (

--- a/pkg/proc/breakpoints.go
+++ b/pkg/proc/breakpoints.go
@@ -425,12 +425,6 @@ func (rbpi *returnBreakpointInfo) Collect(thread Thread) []*Variable {
 		return (v.Flags & VariableReturnArgument) != 0
 	})
 
-	// Go saves the return variables in the opposite order that the user
-	// specifies them so here we reverse the slice to make it easier to
-	// understand.
-	for i := 0; i < len(vars)/2; i++ {
-		vars[i], vars[len(vars)-i-1] = vars[len(vars)-i-1], vars[i]
-	}
 	return vars
 }
 

--- a/pkg/proc/breakpoints.go
+++ b/pkg/proc/breakpoints.go
@@ -252,8 +252,13 @@ func (bpmap *BreakpointMap) Set(addr uint64, kind BreakpointKind, cond ast.Expr,
 		return nil, err
 	}
 
+	fnName := ""
+	if fn != nil {
+		fnName = fn.Name
+	}
+
 	newBreakpoint := &Breakpoint{
-		FunctionName: fn.Name,
+		FunctionName: fnName,
 		File:         f,
 		Line:         l,
 		Addr:         addr,

--- a/pkg/proc/disasm_amd64.go
+++ b/pkg/proc/disasm_amd64.go
@@ -118,7 +118,7 @@ func resolveCallArg(inst *archInst, currentGoroutine bool, regs Registers, mem M
 
 	file, line, fn := bininfo.PCToLine(pc)
 	if fn == nil {
-		return nil
+		return &Location{PC: pc}
 	}
 	return &Location{PC: pc, File: file, Line: line, Fn: fn}
 }

--- a/pkg/proc/gdbserial/gdbserver.go
+++ b/pkg/proc/gdbserial/gdbserver.go
@@ -1028,9 +1028,6 @@ func (p *Process) FindBreakpoint(pc uint64) (*proc.Breakpoint, bool) {
 
 func (p *Process) writeBreakpoint(addr uint64) (string, int, *proc.Function, []byte, error) {
 	f, l, fn := p.bi.PCToLine(uint64(addr))
-	if fn == nil {
-		return "", 0, nil, nil, proc.InvalidAddressError{Address: addr}
-	}
 
 	if err := p.conn.setBreakpoint(addr); err != nil {
 		return "", 0, nil, nil, err

--- a/pkg/proc/native/proc.go
+++ b/pkg/proc/native/proc.go
@@ -211,9 +211,6 @@ func (dbp *Process) CheckAndClearManualStopRequest() bool {
 
 func (dbp *Process) writeBreakpoint(addr uint64) (string, int, *proc.Function, []byte, error) {
 	f, l, fn := dbp.bi.PCToLine(uint64(addr))
-	if fn == nil {
-		return "", 0, nil, nil, proc.InvalidAddressError{Address: addr}
-	}
 
 	originalData := make([]byte, dbp.bi.Arch.BreakpointSize())
 	_, err := dbp.currentThread.ReadMemory(originalData, uintptr(addr))

--- a/pkg/proc/proc_test.go
+++ b/pkg/proc/proc_test.go
@@ -3920,23 +3920,39 @@ func TestStepOutReturn(t *testing.T) {
 			t.Fatalf("wrong number of return values %v", ret)
 		}
 
-		if ret[0].Name != "str" {
-			t.Fatalf("(str) bad return value name %s", ret[0].Name)
+		stridx := 0
+		numidx := 1
+
+		if !goversion.VersionAfterOrEqual(runtime.Version(), 1, 12) {
+			// in 1.11 and earlier the order of return values in DWARF is
+			// unspecified, in 1.11 and later it follows the order of definition
+			// specified by the user
+			for i := range ret {
+				if ret[i].Name == "str" {
+					stridx = i
+					numidx = 1 - i
+					break
+				}
+			}
 		}
-		if ret[0].Kind != reflect.String {
-			t.Fatalf("(str) bad return value kind %v", ret[0].Kind)
+
+		if ret[stridx].Name != "str" {
+			t.Fatalf("(str) bad return value name %s", ret[stridx].Name)
 		}
-		if s := constant.StringVal(ret[0].Value); s != "return 47" {
+		if ret[stridx].Kind != reflect.String {
+			t.Fatalf("(str) bad return value kind %v", ret[stridx].Kind)
+		}
+		if s := constant.StringVal(ret[stridx].Value); s != "return 47" {
 			t.Fatalf("(str) bad return value %q", s)
 		}
 
-		if ret[1].Name != "num" {
-			t.Fatalf("(num) bad return value name %s", ret[1].Name)
+		if ret[numidx].Name != "num" {
+			t.Fatalf("(num) bad return value name %s", ret[numidx].Name)
 		}
-		if ret[1].Kind != reflect.Int {
-			t.Fatalf("(num) bad return value kind %v", ret[1].Kind)
+		if ret[numidx].Kind != reflect.Int {
+			t.Fatalf("(num) bad return value kind %v", ret[numidx].Kind)
 		}
-		if n, _ := constant.Int64Val(ret[1].Value); n != 48 {
+		if n, _ := constant.Int64Val(ret[numidx].Value); n != 48 {
 			t.Fatalf("(num) bad return value %d", n)
 		}
 	})

--- a/pkg/proc/types.go
+++ b/pkg/proc/types.go
@@ -398,6 +398,13 @@ outer:
 				highpc = ranges[0][1] + bi.staticBase
 			}
 			name, ok2 := entry.Val(dwarf.AttrName).(string)
+			if !ok2 {
+				originOffset, hasAbstractOrigin := entry.Val(dwarf.AttrAbstractOrigin).(dwarf.Offset)
+				if hasAbstractOrigin {
+					name, ok2 = abstractOriginNameTable[originOffset]
+				}
+			}
+
 			var fn Function
 			if (ok1 == !inlined) && ok2 {
 				if inlined {

--- a/service/test/integration2_test.go
+++ b/service/test/integration2_test.go
@@ -1566,6 +1566,9 @@ func TestClientServerFunctionCall(t *testing.T) {
 
 func TestClientServerFunctionCallBadPos(t *testing.T) {
 	protest.MustSupportFunctionCalls(t, testBackend)
+	if goversion.VersionAfterOrEqual(runtime.Version(), 1, 12) {
+		t.Skip("this is a safe point for Go 1.12")
+	}
 	withTestClient2("fncall", t, func(c service.Client) {
 		mustHaveDebugCalls(t, c)
 		loc, err := c.FindLocation(api.EvalScope{-1, 0, 0}, "fmt/print.go:649")

--- a/service/test/integration2_test.go
+++ b/service/test/integration2_test.go
@@ -1450,24 +1450,40 @@ func TestClientServer_StepOutReturn(t *testing.T) {
 			t.Fatalf("wrong number of return values %v", ret)
 		}
 
-		if ret[0].Name != "str" {
-			t.Fatalf("(str) bad return value name %s", ret[0].Name)
-		}
-		if ret[0].Kind != reflect.String {
-			t.Fatalf("(str) bad return value kind %v", ret[0].Kind)
-		}
-		if ret[0].Value != "return 47" {
-			t.Fatalf("(str) bad return value %q", ret[0].Value)
+		stridx := 0
+		numidx := 1
+
+		if !goversion.VersionAfterOrEqual(runtime.Version(), 1, 12) {
+			// in 1.11 and earlier the order of return values in DWARF is
+			// unspecified, in 1.11 and later it follows the order of definition
+			// specified by the user
+			for i := range ret {
+				if ret[i].Name == "str" {
+					stridx = i
+					numidx = 1 - i
+					break
+				}
+			}
 		}
 
-		if ret[1].Name != "num" {
-			t.Fatalf("(num) bad return value name %s", ret[1].Name)
+		if ret[stridx].Name != "str" {
+			t.Fatalf("(str) bad return value name %s", ret[stridx].Name)
 		}
-		if ret[1].Kind != reflect.Int {
-			t.Fatalf("(num) bad return value kind %v", ret[1].Kind)
+		if ret[stridx].Kind != reflect.String {
+			t.Fatalf("(str) bad return value kind %v", ret[stridx].Kind)
 		}
-		if ret[1].Value != "48" {
-			t.Fatalf("(num) bad return value %s", ret[1].Value)
+		if ret[stridx].Value != "return 47" {
+			t.Fatalf("(str) bad return value %q", ret[stridx].Value)
+		}
+
+		if ret[numidx].Name != "num" {
+			t.Fatalf("(num) bad return value name %s", ret[numidx].Name)
+		}
+		if ret[numidx].Kind != reflect.Int {
+			t.Fatalf("(num) bad return value kind %v", ret[numidx].Kind)
+		}
+		if ret[numidx].Value != "48" {
+			t.Fatalf("(num) bad return value %s", ret[numidx].Value)
 		}
 	})
 }


### PR DESCRIPTION
```
proc: correctly extract name of functions that have been inlined

If a function can be inlined it will appear as two entries in
debug_info. A DW_TAG_subprogram entry with DW_AT_inlined = true (that
will be used as the abstract origin) and a second DW_TAG_subprogram
entry with an abstract origin.
To retrieve the name of this second entry we must load its abstract
origin.

proc/*: allow stepping into functions without debug_info symbols

If proc.Step encounters a CALL instruction that points to an address
that isn't associated with any function it should still follow the
CALL.

The circumstances creating this problem do not normally occur, it was
encountered in the process of fixing a bug created by Go1.12.

tests: minor fixes for Go 1.12

proc: remove inversion of return variables from returnBreakpointInfo

It was never true that return variables were in the inverse order.
Instead in Go1.11 return variables are saved in debug_info in an
arbitrary order and inverting them just happened to work for this
specific example.

This bug was fixed in Go 1.12, regardless we should attempt to
rearrange return variables anyway.

```
