### PR TITLE
proc: do not panic if we can't satisfy a composite location

### DIFF
--- a/pkg/proc/variables.go
+++ b/pkg/proc/variables.go
@@ -908,7 +908,10 @@ func (scope *EvalScope) extractVarInfoFromEntry(varEntry *dwarf.Entry) (*Variabl
 	mem := scope.Mem
 	if pieces != nil {
 		addr = fakeAddress
-		mem = newCompositeMemory(scope.Mem, scope.Regs, pieces)
+		mem, err = newCompositeMemory(scope.Mem, scope.Regs, pieces)
+		if mem == nil {
+			mem = scope.Mem
+		}
 	}
 
 	v := scope.newVariable(n, uintptr(addr), t, mem)


### PR DESCRIPTION
```
proc: do not panic if we can't satisfy a composite location

When a location expression requests a register check that we have as
many bytes in the register as requested and if we don't report the
error.

Updates #1416

```
