### PR TITLE
proc: do not panic if we can't satisfy a composite location for a slice var

### DIFF
--- a/pkg/dwarf/dwarfbuilder/info.go
+++ b/pkg/dwarf/dwarfbuilder/info.go
@@ -5,6 +5,7 @@ import (
 	"debug/dwarf"
 	"encoding/binary"
 
+	"github.com/derekparker/delve/pkg/dwarf/godwarf"
 	"github.com/derekparker/delve/pkg/dwarf/util"
 )
 
@@ -279,6 +280,15 @@ func (b *Builder) AddMember(fieldname string, typ dwarf.Offset, memberLoc []byte
 	r := b.TagOpen(dwarf.TagMember, fieldname)
 	b.Attr(dwarf.AttrType, typ)
 	b.Attr(dwarf.AttrDataMemberLoc, memberLoc)
+	b.TagClose()
+	return r
+}
+
+// AddPointerType adds a new pointer type to debug_info.
+func (b *Builder) AddPointerType(typename string, typ dwarf.Offset) dwarf.Offset {
+	r := b.TagOpen(dwarf.TagPointerType, typename)
+	b.Attr(dwarf.AttrType, typ)
+	b.Attr(godwarf.AttrGoKind, uint8(22))
 	b.TagClose()
 	return r
 }

--- a/pkg/proc/variables.go
+++ b/pkg/proc/variables.go
@@ -908,9 +908,10 @@ func (scope *EvalScope) extractVarInfoFromEntry(varEntry *dwarf.Entry) (*Variabl
 	mem := scope.Mem
 	if pieces != nil {
 		addr = fakeAddress
-		mem, err = newCompositeMemory(scope.Mem, scope.Regs, pieces)
-		if mem == nil {
-			mem = scope.Mem
+		var cmem *compositeMemory
+		cmem, err = newCompositeMemory(scope.Mem, scope.Regs, pieces)
+		if cmem != nil {
+			mem = cmem
 		}
 	}
 


### PR DESCRIPTION
```
proc: do not panic if we can't satisfy a composite location for a slice var

The fix in 7f53117 for Issue #1416 had a bug, fix it and add a test.

Fixes #1419

```
