### PR TITLE
 pkg/config: Using current directory to store config if getting user …

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -182,7 +182,6 @@ func createConfigPath() error {
 
 // GetConfigFilePath gets the full path to the given config file name.
 func GetConfigFilePath(file string) (string, error) {
-
 	userHomeDir := "."
 	usr, err := user.Current()
 	if err == nil {

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -182,9 +182,11 @@ func createConfigPath() error {
 
 // GetConfigFilePath gets the full path to the given config file name.
 func GetConfigFilePath(file string) (string, error) {
+
+	userHomeDir := "."
 	usr, err := user.Current()
-	if err != nil {
-		return "", err
+	if err == nil {
+		userHomeDir = usr.HomeDir
 	}
-	return path.Join(usr.HomeDir, configDir, file), nil
+	return path.Join(userHomeDir, configDir, file), nil
 }

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -58,12 +58,12 @@ func LoadConfig() *Config {
 	err := createConfigPath()
 	if err != nil {
 		fmt.Printf("Could not create config directory: %v.", err)
-		return nil
+		return &Config{}
 	}
 	fullConfigFile, err := GetConfigFilePath(configFile)
 	if err != nil {
 		fmt.Printf("Unable to get config file path: %v.", err)
-		return nil
+		return &Config{}
 	}
 
 	f, err := os.Open(fullConfigFile)
@@ -71,7 +71,7 @@ func LoadConfig() *Config {
 		f, err = createDefaultConfig(fullConfigFile)
 		if err != nil {
 			fmt.Printf("Error creating default config file: %v", err)
-			return nil
+			return &Config{}
 		}
 	}
 	defer func() {
@@ -84,14 +84,14 @@ func LoadConfig() *Config {
 	data, err := ioutil.ReadAll(f)
 	if err != nil {
 		fmt.Printf("Unable to read config data: %v.", err)
-		return nil
+		return &Config{}
 	}
 
 	var c Config
 	err = yaml.Unmarshal(data, &c)
 	if err != nil {
 		fmt.Printf("Unable to decode config file: %v.", err)
-		return nil
+		return &Config{}
 	}
 
 	return &c


### PR DESCRIPTION
When dlv was run inside a container, I am getting this error. Basically call to get user directory fails as it is not implemented. So I made changes to use current directory. Please let me know if it is ok.

 ./dlv attach 10
Could not create config directory: user: Current not implemented on linux/amd64.Config  <nil>
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x50 pc=0x8cf17a]

goroutine 1 [running]:
github.com/derekparker/delve/cmd/dlv/cmds.execute(0xa, 0xc420075fe0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x3, 0x0)
        /home/chandraa/share/src/github.com/derekparker/delve/cmd/dlv/cmds/commands.go:579 +0x3aa
github.com/derekparker/delve/cmd/dlv/cmds.attachCmd(0xc4200f58c0, 0xc420075fe0, 0x1, 0x1)
        /home/chandraa/share/src/github.com/derekparker/delve/cmd/dlv/cmds/commands.go:473 +0xc2
github.com/derekparker/delve/vendor/github.com/spf13/cobra.(*Command).execute(0xc4200f58c0, 0xc420075fa0, 0x1, 0x1, 0xc4200f58c0, 0xc4
        /home/chandraa/share/src/github.com/derekparker/delve/vendor/github.com/spf13/cobra/command.go:647 +0x237
github.com/derekparker/delve/vendor/github.com/spf13/cobra.(*Command).ExecuteC(0xc4200f5680, 0xa73f90, 0x913dc0, 0x0)
        /home/chandraa/share/src/github.com/derekparker/delve/vendor/github.com/spf13/cobra/command.go:733 +0x2d4
github.com/derekparker/delve/vendor/github.com/spf13/cobra.(*Command).Execute(0xc4200f5680, 0xc4200f5680, 0xa04fd6)
        /home/chandraa/share/src/github.com/derekparker/delve/vendor/github.com/spf13/cobra/command.go:692 +0x2b
main.main()
        /home/chandraa/share/src/github.com/derekparker/delve/cmd/dlv/main.go:24 +0xe4
