### PR TITLE
main_test: Fix "gopath mode" detection in projectRoot()

### DIFF
--- a/cmd/dlv/dlv_test.go
+++ b/cmd/dlv/dlv_test.go
@@ -51,8 +51,17 @@ func projectRoot() string {
 	if err != nil {
 		panic(err)
 	}
-	if strings.Contains(wd, os.Getenv("GOPATH")) {
-		return filepath.Join(os.Getenv("GOPATH"), "src", "github.com", "derekparker", "delve")
+
+	separatorGOPATH := ":"
+	if runtime.GOOS == "windows" {
+		separatorGOPATH = ";"
+	}
+	gopaths := strings.Split(os.Getenv("GOPATH"), separatorGOPATH)
+	for _, curpath := range gopaths {
+		// Detects "gopath mode" when GOPATH contains several paths ex. "d:\\dir\\gopath;f:\\dir\\gopath2"
+		if strings.Contains(wd, curpath) {
+			return filepath.Join(curpath, "src", "github.com", "derekparker", "delve")
+		}
 	}
 	val, err := exec.Command("go", "list", "-m", "-f", "{{ .Dir }}").Output()
 	if err != nil {

--- a/cmd/dlv/dlv_test.go
+++ b/cmd/dlv/dlv_test.go
@@ -52,11 +52,7 @@ func projectRoot() string {
 		panic(err)
 	}
 
-	separatorGOPATH := ":"
-	if runtime.GOOS == "windows" {
-		separatorGOPATH = ";"
-	}
-	gopaths := strings.Split(os.Getenv("GOPATH"), separatorGOPATH)
+	gopaths := strings.FieldsFunc(os.Getenv("GOPATH"), func(r rune) bool { return r == os.PathListSeparator })
 	for _, curpath := range gopaths {
 		// Detects "gopath mode" when GOPATH contains several paths ex. "d:\\dir\\gopath;f:\\dir\\gopath2"
 		if strings.Contains(wd, curpath) {


### PR DESCRIPTION
dlv_test.go:TestBuild() fails when dlv_test.go:projectRoot() fails to detect that this is a "gopath mode" when GOPATH contains several paths ex. "d:\\dir\\gopath;f:\\dir\\gopath2".

dlv version
Delve Debugger
Version: 1.1.0
Build: $Id: 1990ba12450cab9425a2ae62e6ab988725023d5c $

go version
go version go1.11 windows/amd64

go env
set GOARCH=amd64
set GOBIN=
set GOCACHE=C:\Users\z.malinovskiy\AppData\Local\go-build
set GOEXE=.exe
set GOFLAGS=
set GOHOSTARCH=amd64
set GOHOSTOS=windows
set GOOS=windows
set GOPATH=d:\za\GO\gopath;f:\Zavla_VB\GO
set GOPROXY=
set GORACE=
set GOROOT=d:\za\GO\go
set GOTMPDIR=
set GOTOOLDIR=d:\za\GO\go\pkg\tool\windows_amd64
set GCCGO=gccgo
set CC=gcc
set CXX=g++
set CGO_ENABLED=1
set GOMOD=
set CGO_CFLAGS=-O -g
set CGO_CPPFLAGS=
set CGO_CXXFLAGS=-g -O2
set CGO_FFLAGS=-g -O2
set CGO_LDFLAGS=-g -O2
set PKG_CONFIG=pkg-config
set GOGCCFLAGS=-m64 -mthreads -fmessage-length=0 -fdebug-prefix-map=C:\Users\Z25B7~1.MAL\AppData\Local\Temp\go-build296528246=/tmp/go-build -gno-record-gcc-switches