### PR TITLE
pkg/proc: align memory size of tls arena to pointer-sized boundary (fix for #1428)

### DIFF
--- a/pkg/proc/bininfo.go
+++ b/pkg/proc/bininfo.go
@@ -753,9 +753,12 @@ func (bi *BinaryInfo) setGStructOffsetElf(exe *elf.File, wg *sync.WaitGroup) {
 			break
 		}
 	}
+	memsz := tls.Memsz
+
+	memsz = (memsz + uint64(bi.Arch.PtrSize()) - 1) & ^uint64(bi.Arch.PtrSize()-1) // align to pointer-sized-boundary
 	// The TLS register points to the end of the TLS block, which is
 	// tls.Memsz long. runtime.tlsg is an offset from the beginning of that block.
-	bi.gStructOffset = ^(tls.Memsz) + 1 + tlsg.Value // -tls.Memsz + tlsg.Value
+	bi.gStructOffset = ^(memsz) + 1 + tlsg.Value // -tls.Memsz + tlsg.Value
 }
 
 // PE ////////////////////////////////////////////////////////////////


### PR DESCRIPTION
```
pkg/proc: align memory size of tls arena to pointer sized boundary

The size of the TLS memory arena needs to be aligned to pointer sized
boundaries on 86x64 architectures, otherwise some programs using cgo
will not have the correct offset for the g struct.

No tests because reproducing this problem depends on behavior of the
GNU ld linker caused by unclear influences.

Fixes #1428.

proc: handle gid == 0 in FindGoroutine

Goroutine id == 0 is special (there can be many goroutines with id 0).
If the caller of FindGoroutine asks for gid==0 and current thread is
running a goroutine 0 (i.e. either no goroutine or a special
goroutine) return whatever goroutine is running on the current thread.

Updates #1428

```
