### PR TITLE
pkg/proc/test: Eval symlinks for test source

### DIFF
--- a/pkg/proc/test/support.go
+++ b/pkg/proc/test/support.go
@@ -150,6 +150,10 @@ func BuildFixture(name string, flags BuildFlags) Fixture {
 
 	source, _ := filepath.Abs(path)
 	source = filepath.ToSlash(source)
+	sympath, err := filepath.EvalSymlinks(source)
+	if err == nil {
+		source = strings.Replace(sympath, "\\", "/", -1)
+	}
 
 	fixture := Fixture{Name: name, Path: tmpfile, Source: source}
 


### PR DESCRIPTION
Some build environments (such as when building RPMs) enjoy symlinking
things. This unfortunately causes our tests to fail as we record the
path of fixtures and use that when looking up file:line information.
However, the debug info in the binary records the original file
location, not the location of the symlink.