### PR TITLE
Please consider change the module identity to github.com/derekparker/delve as this breaks the build of bee (github.com/beego/bee) 

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/go-delve/delve
+module github.com/derekparker/delve
 
 go 1.11
 


### PR DESCRIPTION
Please consider change the module identity to github.com/derekparker/delve as this breaks the build of bee (github.com/beego/bee) with the following error:

go get -u github.com/beego/bee
go: github.com/beego/bee upgrade => v1.10.0
go: finding module for package github.com/derekparker/delve/service/rpccommon
go: finding module for package github.com/fsnotify/fsnotify
go: finding module for package github.com/derekparker/delve/terminal
go: finding module for package github.com/astaxie/beego/swagger
go: finding module for package github.com/derekparker/delve/service
go: finding module for package gopkg.in/yaml.v2
go: finding module for package github.com/go-sql-driver/mysql
go: finding module for package github.com/astaxie/beego/utils
go: finding module for package github.com/derekparker/delve/service/rpc2
go: finding module for package github.com/gorilla/websocket
go: finding module for package github.com/lib/pq
go: found gopkg.in/yaml.v2 in gopkg.in/yaml.v2 v2.3.0
go: found github.com/astaxie/beego/swagger in github.com/astaxie/beego v1.12.1
go: found github.com/derekparker/delve/service in github.com/derekparker/delve v1.4.0
go: found github.com/fsnotify/fsnotify in github.com/fsnotify/fsnotify v1.4.9
go: found github.com/gorilla/websocket in github.com/gorilla/websocket v1.4.2
go: found github.com/go-sql-driver/mysql in github.com/go-sql-driver/mysql v1.5.0
go: found github.com/lib/pq in github.com/lib/pq v1.5.2
go: github.com/beego/bee imports
	github.com/beego/bee/cmd imports
	github.com/beego/bee/cmd/commands/dlv imports
	github.com/derekparker/delve/service: github.com/derekparker/delve@v1.4.0: parsing go.mod:
	module declares its path as: github.com/go-delve/delve
	        but was required as: github.com/derekparker/delve