### PR TITLE
Update EditorIntegration.md

### DIFF
--- a/Documentation/EditorIntegration.md
+++ b/Documentation/EditorIntegration.md
@@ -24,7 +24,7 @@ The following editor plugins for delve are available:
 * [vim-godebug](https://github.com/jodosha/vim-godebug) (only Neovim)
 
 **VisualStudio Code**
-* [Go for Visual Studio Code](https://github.com/Microsoft/vscode-go)
+* [Go for Visual Studio Code](https://github.com/golang/vscode-go)
 
 **Sublime**
 * [Go Debugger for Sublime](https://github.com/dishmaev/GoDebug)


### PR DESCRIPTION
Update link to the the vscode golang plugin per the previously linked repo

```
As of June 2020, our new home is https://github.com/golang/vscode-go.

For more on this, please see the below blog posts

    The next phase of Go experience in VS Code
    VS Code Go extension joins the Go project
```