### PR TITLE
Update Windows install

### DIFF
--- a/Documentation/installation/windows/install.md
+++ b/Documentation/installation/windows/install.md
@@ -1,11 +1,9 @@
 # Installation on Windows
 
-Please use the standard `go get` command to build and install Delve on Windows.
+Please use the standard `go install` command to build and install Delve on Windows.
 
 ```
-go get github.com/go-delve/delve/cmd/dlv
+go install github.com/go-delve/delve/cmd/dlv@latest
 ```
-
-Note: if you are using Go in modules mode you must execute this command outside of a module directory or Delve will be added to your project as a dependency.
 
 Also, if not already set, you have to add the %GOPATH%\bin directory to your PATH variable.


### PR DESCRIPTION
This deals with:

> 'go get' is no longer supported outside a module.

and

> 'go install' requires a version when current directory is not in a module
