### PR TITLE
Update dlv installation go command

### DIFF
--- a/Documentation/installation/linux/install.md
+++ b/Documentation/installation/linux/install.md
@@ -5,7 +5,7 @@ Please use the following steps to build and install Delve on Linux.
 There are two ways to install on Linux. First is the standard `go get` method:
 
 ```
-go get github.com/go-delve/delve/cmd/dlv
+go install github.com/go-delve/delve/cmd/dlv@latest
 ```
 
 Note: if you are using Go in modules mode you must execute this command outside of a module directory or Delve will be added to your project as a dependency.


### PR DESCRIPTION
Running `go get` is [not supported outside of modules](https://golang.org/doc/go-get-install-deprecation) anymore. This should be replaced with `go install` along with a version