### PR TITLE
Update install.md for go 1.17 and higher

### DIFF
--- a/Documentation/installation/linux/install.md
+++ b/Documentation/installation/linux/install.md
@@ -2,13 +2,11 @@
 
 Please use the following steps to build and install Delve on Linux.
 
-There are two ways to install on Linux. First is the standard `go get` method:
+There are two ways to install on Linux. First is the standard `go install` method:
 
 ```
-go get github.com/go-delve/delve/cmd/dlv
+go install github.com/go-delve/delve/cmd/dlv@latest
 ```
-
-Note: if you are using Go in modules mode you must execute this command outside of a module directory or Delve will be added to your project as a dependency.
 
 Alternatively make sure $GOPATH is set (e.g. as `~/.go`) and:
 


### PR DESCRIPTION
`go get github.com/go-delve/delve/cmd/dlv` gives

```
go: go.mod file not found in current directory or any parent directory.
	'go get' is no longer supported outside a module.
	To build and install a command, use 'go install' with a version,
	like 'go install example.com/cmd@latest'
	For more information, see https://golang.org/doc/go-get-install-deprecation
	or run 'go help get' or 'go help install'.
```